### PR TITLE
Refname fix

### DIFF
--- a/gcsfs/_version.py
+++ b/gcsfs/_version.py
@@ -22,7 +22,7 @@ def get_keywords():
     # setup.py/versioneer.py will grep for the variable names, so they must
     # each be defined on a line of their own. _version.py will just call
     # get_keywords().
-    git_refnames = "$Format:%d$"
+    git_refnames = "$Format:%(describe:exclude=HEAD|main:tags=true)$"
     git_full = "$Format:%H$"
     git_date = "$Format:%ci$"
     keywords = {"refnames": git_refnames, "full": git_full, "date": git_date}


### PR DESCRIPTION
closes: https://github.com/fsspec/gcsfs/issues/441

Until upstream gets a better general solution, just filter out problematic references.

On untagged commits, it will look like:

```
[11:11:36] jon@nixos ~/projects/gcsfs (fix-refnames)
$ git archive HEAD | tar -Oxf - gcsfs/_version.py | grep refnames
    git_refnames = "2021.11.1-1-g18960ad"
```

For tagged commits:
```
[11:08:58] jon@nixos ~/projects/gcsfs (fix-refnames)
$ git tag 2022.01.8 --annotate
[11:09:22] jon@nixos ~/projects/gcsfs (fix-refnames)
$ git archive HEAD | tar -Oxf - gcsfs/_version.py | grep refnames
    git_refnames = "2022.01.8"
```