### PR TITLE
gcsfs: drop python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -31,6 +30,6 @@ setup(
         open("README.rst").read() if os.path.exists("README.rst") else ""
     ),
     extras_require={"gcsfuse": ["fusepy"], "crc": ["crcmod"]},
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     zip_safe=False,
 )


### PR DESCRIPTION
Following https://github.com/fsspec/filesystem_spec/pull/889

3.6 wasn't even tested in CI.