### PR TITLE
Change pin of fsspec to 2022.2.0 (no leading zeros)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ google-auth-oauthlib
 google-cloud-storage
 requests
 decorator>4.1.2
-fsspec==2022.02.0
+fsspec==2022.2.0
 aiohttp<4


### PR DESCRIPTION
To do some nitpicking, there is no version of `fsspec=2022.02.0` on [pypi](https://pypi.org/project/fsspec/). 

In general, this does not do any harm and is normalized to `2022.2.0` in most cases.

Coming across from https://github.com/peterdemin/pip-compile-multi/issues/304 I predict some ping-pong who is in charge of this, I would propose to use the "correct" version.

Or is there anything I have overseen?

**Edit:** Seems like this is used in other fsspec repos as well.