### PR TITLE
Close auth session

### DIFF
--- a/gcsfs/credentials.py
+++ b/gcsfs/credentials.py
@@ -156,13 +156,14 @@ class GoogleCredentials:
             return  # anon
         if self.credentials.valid:
             return  # still good
-        req = Request(requests.Session())
-        with self.lock:
-            if self.credentials.valid:
-                return  # repeat to avoid race (but don't want lock in common case)
-            logger.debug("GCS refresh")
-            self.credentials.refresh(req)
-            self.apply(self.heads)
+        with requests.Session() as session:
+            req = Request(session)
+            with self.lock:
+                if self.credentials.valid:
+                    return  # repeat to avoid race (but don't want lock in common case)
+                logger.debug("GCS refresh")
+                self.credentials.refresh(req)
+                self.apply(self.heads)
 
     def apply(self, out):
         """Insert credential headers in-place to a dictionary"""


### PR DESCRIPTION
I noticed that this `requests.Session()` wasn't being closed when running in (py)tests with `filterwarnings = ["error"]` and getting this warning (raised as an error):
```
ResourceWarning: unclosed <ssl.SSLSocket fd=24, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0,
```

After this change and reinstalling the package locally, the issue was fixed. Easier to see when [ignoring whitespace only changes](https://github.com/fsspec/gcsfs/pull/452/files?w=1)