### PR TITLE
Add **kwargs parameters to _mkdir, _cat_file, adhere to fsspec API

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -609,6 +609,7 @@ class GCSFileSystem(AsyncFileSystem):
         acl="projectPrivate",
         default_acl="bucketOwnerFullControl",
         location=None,
+        **kwargs,
     ):
         """
         New bucket
@@ -758,7 +759,7 @@ class GCSFileSystem(AsyncFileSystem):
         object = quote_plus(object)
         return u.format(self._location, bucket, object)
 
-    async def _cat_file(self, path, start=None, end=None):
+    async def _cat_file(self, path, start=None, end=None, **kwargs):
         """Simple one-shot get of file data"""
         u2 = self.url(path)
         if start or end:

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -1035,3 +1035,15 @@ def test_dir_marker(gcs):
     out3 = gcs.info(f"{TEST_BUCKET}/placeholder/")
     assert out2 == out3
     assert out2["type"] == "directory"
+
+
+def test_mkdir_with_path(gcs):
+    with pytest.raises(FileNotFoundError):
+        gcs.mkdir("new/path", create_parents=False)
+    assert not gcs.exists("new")
+    gcs.mkdir("new/path", create_parents=True)
+    assert gcs.exists("new")
+
+    # these lines do nothing, but should not fail
+    gcs.mkdir("new/path", create_parents=False)
+    gcs.mkdir("new/path", create_parents=True)


### PR DESCRIPTION
These two methods don't accept `**kwargs` parameters, which makes them incompatible with libraries utilizing the abstract API. For example, pyarrow 6.0.1 fails for create dir:

```
import fsspec
import pyarrow.fs

fs = fsspec.filesystem("gs")
wrapped = pyarrow.fs.PyFileSystem(pyarrow.fs.FSSpecHandler(fs))
wrapped.create_dir("bucket/test", recursive=True)
```

with 

```
  File "pyarrow/_fs.pyx", line 461, in pyarrow._fs.FileSystem.create_dir
  File "pyarrow/_fs.pyx", line 1129, in pyarrow._fs._cb_create_dir
  File "/Users/kai/.pyenv/versions/3.7.7/lib/python3.7/site-packages/pyarrow/fs.py", line 341, in create_dir
    self.fs.mkdir(path, create_parents=recursive)
  File "/Users/kai/.pyenv/versions/3.7.7/lib/python3.7/site-packages/fsspec/asyn.py", line 85, in wrapper
    return sync(self.loop, func, *args, **kwargs)
  File "/Users/kai/.pyenv/versions/3.7.7/lib/python3.7/site-packages/fsspec/asyn.py", line 47, in sync
    coro = func(*args, **kwargs)
TypeError: _mkdir() got an unexpected keyword argument 'create_parents'
```

Closes #404 