### PR TITLE
Fix failed tests `test_attrs()` and `test_mkdir_with_path()`

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -843,7 +843,6 @@ class GCSFileSystem(AsyncFileSystem):
             json=i_json,
             json_out=True,
         )
-        (await self._info(path))["metadata"] = o_json.get("metadata", {})
         return o_json.get("metadata", {})
 
     setxattrs = sync_wrapper(_setxattrs)

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -835,7 +835,7 @@ class GCSFileSystem(AsyncFileSystem):
 
         bucket, key = self.split_path(path)
         o_json = await self._call(
-            "PATCH",
+            "PUT",
             "b/{}/o/{}",
             bucket,
             key,

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -835,7 +835,7 @@ class GCSFileSystem(AsyncFileSystem):
 
         bucket, key = self.split_path(path)
         o_json = await self._call(
-            "PUT",
+            "PATCH",
             "b/{}/o/{}",
             bucket,
             key,

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -642,7 +642,9 @@ class GCSFileSystem(AsyncFileSystem):
         if "/" in path and create_parents and await self._exists(bucket):
             # nothing to do
             return
-        if "/" in path and not create_parents and not await self._exists(bucket):
+        if "/" in path and not create_parents:
+            if await self._exists(bucket):
+                return
             raise FileNotFoundError(bucket)
 
         json_data = {"name": bucket}

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -798,6 +798,9 @@ class GCSFileSystem(AsyncFileSystem):
     ):
         """Set/delete/add writable metadata attributes
 
+        Note: uses PATCH method (update), leaving unedited keys alone.
+        fake-gcs-server:latest does not seem to support this.
+
         Parameters
         ---------
         content_type: str

--- a/gcsfs/tests/conftest.py
+++ b/gcsfs/tests/conftest.py
@@ -10,6 +10,7 @@ import requests
 from gcsfs import GCSFileSystem
 from gcsfs.tests.settings import TEST_BUCKET
 
+IS_FAKE_GCSFS = False
 files = {
     "test/accounts.1.json": (
         b'{"amount": 100, "name": "Alice"}\n'
@@ -60,6 +61,8 @@ def docker_gcs():
         # assume using real API or otherwise have a server already set up
         yield os.environ["STORAGE_EMULATOR_HOST"]
         return
+    global IS_FAKE_GCSFS
+    IS_FAKE_GCSFS = True
     container = "gcsfs_test"
     cmd = (
         "docker run -d -p 4443:4443 --name gcsfs_test fsouza/fake-gcs-server:latest -scheme "

--- a/gcsfs/tests/conftest.py
+++ b/gcsfs/tests/conftest.py
@@ -10,7 +10,6 @@ import requests
 from gcsfs import GCSFileSystem
 from gcsfs.tests.settings import TEST_BUCKET
 
-IS_FAKE_GCSFS = False
 files = {
     "test/accounts.1.json": (
         b'{"amount": 100, "name": "Alice"}\n'
@@ -61,8 +60,6 @@ def docker_gcs():
         # assume using real API or otherwise have a server already set up
         yield os.environ["STORAGE_EMULATOR_HOST"]
         return
-    global IS_FAKE_GCSFS
-    IS_FAKE_GCSFS = True
     container = "gcsfs_test"
     cmd = (
         "docker run -d -p 4443:4443 --name gcsfs_test fsouza/fake-gcs-server:latest -scheme "

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -789,6 +789,8 @@ def test_array(gcs):
         assert out == b"A" * 1000
 
 
+# https://github.com/fsspec/gcsfs/pull/479
+@pytest.mark.xfail("fake-gcs-server:latest only supports PUT for metadata, not PATCH")
 def test_attrs(gcs):
     gcs.touch(a)
     assert "metadata" not in gcs.info(a)
@@ -1070,12 +1072,15 @@ def test_dir_marker(gcs):
 
 
 def test_mkdir_with_path(gcs):
+
     with pytest.raises(FileNotFoundError):
-        gcs.mkdir("gcsfs-test-dir/path", create_parents=False)
-    assert not gcs.exists("gcsfs-test-dir")
-    gcs.mkdir("gcsfs-test-dir/path", create_parents=True)
-    assert gcs.exists("gcsfs-test-dir")
+        gcs.mkdir(f"{TEST_BUCKET + 'new'}/path", create_parents=False)
+    assert not gcs.exists(f"{TEST_BUCKET + 'new'}")
+    gcs.mkdir(f"{TEST_BUCKET + 'new'}/path", create_parents=True)
+    assert gcs.exists(f"{TEST_BUCKET + 'new'}")
 
     # these lines do nothing, but should not fail
-    gcs.mkdir("gcsfs-test-dir/path", create_parents=False)
-    gcs.mkdir("gcsfs-test-dir/path", create_parents=True)
+    gcs.mkdir(f"{TEST_BUCKET + 'new'}/path", create_parents=False)
+    gcs.mkdir(f"{TEST_BUCKET + 'new'}/path", create_parents=True)
+
+    gcs.rm(f"{TEST_BUCKET + 'new'}", recursive=True)

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -1071,11 +1071,11 @@ def test_dir_marker(gcs):
 
 def test_mkdir_with_path(gcs):
     with pytest.raises(FileNotFoundError):
-        gcs.mkdir("new/path", create_parents=False)
-    assert not gcs.exists("new")
-    gcs.mkdir("new/path", create_parents=True)
-    assert gcs.exists("new")
+        gcs.mkdir("gcsfs-test-dir/path", create_parents=False)
+    assert not gcs.exists("gcsfs-test-dir")
+    gcs.mkdir("gcsfs-test-dir/path", create_parents=True)
+    assert gcs.exists("gcsfs-test-dir")
 
     # these lines do nothing, but should not fail
-    gcs.mkdir("new/path", create_parents=False)
-    gcs.mkdir("new/path", create_parents=True)
+    gcs.mkdir("gcsfs-test-dir/path", create_parents=False)
+    gcs.mkdir("gcsfs-test-dir/path", create_parents=True)

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -15,7 +15,6 @@ from fsspec.asyn import sync
 
 from gcsfs.tests.settings import TEST_BUCKET, TEST_PROJECT, TEST_REQUESTER_PAYS_BUCKET
 from gcsfs.tests.conftest import (
-    IS_FAKE_GCSFS,
     files,
     csv_files,
     text_files,
@@ -790,12 +789,10 @@ def test_array(gcs):
         assert out == b"A" * 1000
 
 
-# https://github.com/fsspec/gcsfs/pull/479
-@pytest.mark.xfail(
-    IS_FAKE_GCSFS,
-    reason="fake-gcs-server:latest only supports PUT for metadata, not PATCH",
-)
 def test_attrs(gcs):
+    if not gcs.on_google:
+        # https://github.com/fsspec/gcsfs/pull/479
+        pytest.skip("fake-gcs-server:latest only supports PUT for metadata, not PATCH")
     gcs.touch(a)
     assert "metadata" not in gcs.info(a)
     with pytest.raises(KeyError):

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -15,6 +15,7 @@ from fsspec.asyn import sync
 
 from gcsfs.tests.settings import TEST_BUCKET, TEST_PROJECT, TEST_REQUESTER_PAYS_BUCKET
 from gcsfs.tests.conftest import (
+    IS_FAKE_GCSFS,
     files,
     csv_files,
     text_files,
@@ -790,7 +791,10 @@ def test_array(gcs):
 
 
 # https://github.com/fsspec/gcsfs/pull/479
-@pytest.mark.xfail("fake-gcs-server:latest only supports PUT for metadata, not PATCH")
+@pytest.mark.xfail(
+    IS_FAKE_GCSFS,
+    reason="fake-gcs-server:latest only supports PUT for metadata, not PATCH",
+)
 def test_attrs(gcs):
     gcs.touch(a)
     assert "metadata" not in gcs.info(a)


### PR DESCRIPTION
Hello, this PR is a trial to fix `test_attrs()`, one of the current pytest failures.

I noticed this PATCH call didn't actually update the `metadata` field but PUT did:
https://github.com/fsspec/gcsfs/blob/c2d2d89b540fc289794c69d2741d20e5934a18fa/gcsfs/core.py#L837-L845

I'm not sure this is the best way to fix it since the official documentation recommends us to use a PATCH request for the update of user-defined metadata: [Objects: update  |  Cloud Storage  |  Google Cloud](https://cloud.google.com/storage/docs/json_api/v1/objects/update). Maybe this is an issue of fsouza/fake-gcs-server.

I also delete the following line as the assigned values seem not used anywhere:
https://github.com/fsspec/gcsfs/blob/c2d2d89b540fc289794c69d2741d20e5934a18fa/gcsfs/core.py#L846

Here is a test GitHub Actions run on my fork branch: shuuji3/gcsfs/pull/1