### PR TITLE
Fix to also try `cloud` authentication method when `method=None`

### DIFF
--- a/gcsfs/credentials.py
+++ b/gcsfs/credentials.py
@@ -94,6 +94,10 @@ class GoogleCredentials:
         self.credentials = gauth.compute_engine.Credentials()
 
     def _connect_cache(self):
+
+        if len(self.tokens) == 0:
+            raise ValueError("No cached tokens")
+
         project, access = self.project, self.access
         if (project, access) in self.tokens:
             credentials = self.tokens[(project, access)]
@@ -220,7 +224,7 @@ class GoogleCredentials:
                     self.connect(method=meth)
                     logger.debug("Connected with method %s", meth)
                     break
-                except google.auth.exceptions.GoogleAuthError as e:
+                except (google.auth.exceptions.GoogleAuthError, ValueError) as e:
                     # GoogleAuthError is the base class for all authentication
                     # errors
                     logger.debug(

--- a/gcsfs/credentials.py
+++ b/gcsfs/credentials.py
@@ -93,6 +93,9 @@ class GoogleCredentials:
     def _connect_cloud(self):
         self.credentials = gauth.compute_engine.Credentials()
 
+        if not self.credentials.valid:
+            raise ValueError("Invalid gcloud credentials")
+
     def _connect_cache(self):
 
         if len(self.tokens) == 0:
@@ -230,6 +233,9 @@ class GoogleCredentials:
                     logger.debug(
                         'Connection with method "%s" failed' % meth, exc_info=e
                     )
+                    # Reset credentials if they were set but the authentication failed
+                    # (reverts to 'anon' behavior)
+                    self.credentials = None
             else:
                 # Since the 'anon' connection method should always succeed,
                 # getting here means something has gone terribly wrong.


### PR DESCRIPTION
This PR addresses #480 by raising an exception if we attempt to connect through the cache if the cache is empty. The cache is only available for the browser token-based access. It also modifies the `method=None` loop behavior to skip past the `cache` method and try the `cloud` method if the cache is empty, so the `gauth` IAM service account will also be checked with the compute engine API. Without this, the empty cache connection would result in `self.credentials=None`, which is equivalent to the `anon` connection method. So it would never try the `cloud` method  unless explicitly specified through `GCSFileSystem(token='cloud')`.