### PR TITLE
Fix `pip install --pre gcsfs`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ google-cloud-storage
 requests
 decorator>4.1.2
 fsspec==2022.7.1
-aiohttp
+aiohttp!=4.0.0a0, !=4.0.0a1


### PR DESCRIPTION
It is not possible to run `pip install --pre gcsfs` right now because the two latest pre-releases of `aiohttp` are broken (v4.0.0a0 and v4.0.0a1).

This PR proposes excluding these two versions from the requirements.

More details: https://github.com/fsspec/filesystem_spec/pull/1018