### PR TITLE
For `_rm`, raise multiple exceptions instead of the first.

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -984,7 +984,7 @@ class GCSFileSystem(AsyncFileSystem):
             and not isinstance(ex, FileNotFoundError)
         ]
         if exs:
-            raise exs[0]
+            raise Exception(exs)
         await asyncio.gather(*[self._rmdir(d) for d in dirs])
 
     rm = sync_wrapper(_rm)


### PR DESCRIPTION
I'm following this example to raise multiple exceptions, with the intention that this will help me better debug a GCS error: https://stackoverflow.com/a/50414672.