### PR TITLE
Extend Retry logic to address OSErrors. 

### DIFF
--- a/gcsfs/retry.py
+++ b/gcsfs/retry.py
@@ -63,8 +63,8 @@ def is_retriable(exception):
     if isinstance(exception, HttpError):
         return exception.code in errs
 
-    if isinstance(exception, OSError):
-        return 'internal error' in str(exception)
+    if 'internal error' in str(exception):
+        return True
 
     return isinstance(exception, RETRIABLE_EXCEPTIONS)
 
@@ -122,7 +122,6 @@ async def retry_request(func, retries=6, *args, **kwargs):
             google.auth.exceptions.GoogleAuthError,
             ChecksumError,
             aiohttp.client_exceptions.ClientError,
-            OSError,
         ) as e:
             if (
                 isinstance(e, HttpError)

--- a/gcsfs/retry.py
+++ b/gcsfs/retry.py
@@ -48,7 +48,6 @@ RETRIABLE_EXCEPTIONS = (
     google.auth.exceptions.RefreshError,
     aiohttp.client_exceptions.ClientError,
     ChecksumError,
-    OSError,
 )
 
 
@@ -63,6 +62,9 @@ def is_retriable(exception):
     errs += [str(e) for e in errs]
     if isinstance(exception, HttpError):
         return exception.code in errs
+
+    if isinstance(exception, OSError):
+        return 'internal error' in str(exception)
 
     return isinstance(exception, RETRIABLE_EXCEPTIONS)
 

--- a/gcsfs/retry.py
+++ b/gcsfs/retry.py
@@ -48,6 +48,7 @@ RETRIABLE_EXCEPTIONS = (
     google.auth.exceptions.RefreshError,
     aiohttp.client_exceptions.ClientError,
     ChecksumError,
+    OSError,
 )
 
 
@@ -119,6 +120,7 @@ async def retry_request(func, retries=6, *args, **kwargs):
             google.auth.exceptions.GoogleAuthError,
             ChecksumError,
             aiohttp.client_exceptions.ClientError,
+            OSError,
         ) as e:
             if (
                 isinstance(e, HttpError)

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -204,6 +204,17 @@ def test_rm_recursive(gcs):
     assert not gcs.exists(TEST_BUCKET + files[-1])
 
 
+@pytest.mark.slow
+def test_rm_batch_large(gcs):
+    files = [f'{TEST_BUCKET}/t{i}' for i in range(24 * 365 * 40)]
+    for fn in files:
+        gcs.touch(fn)
+        assert fn in gcs.find(TEST_BUCKET)
+    gcs.rm(files)
+    for fn in files:
+        assert fn not in gcs.find(TEST_BUCKET)
+
+
 def test_file_access(gcs):
     fn = TEST_BUCKET + "/nested/file1"
     data = b"hello\n"

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -205,6 +205,7 @@ def test_rm_recursive(gcs):
 
 
 @pytest.mark.slow
+@pytest.mark.skip(reason="integration tests: it is really slow.")
 def test_rm_batch_large(gcs):
     files = [f'{TEST_BUCKET}/t{i}' for i in range(24 * 365 * 40)]
     for fn in files:

--- a/gcsfs/tests/test_retry.py
+++ b/gcsfs/tests/test_retry.py
@@ -37,6 +37,9 @@ def test_retriable_exception():
     e = ProxyError()
     assert is_retriable(e)
 
+    e = OSError('An internal error occurred.')
+    assert is_retriable(e)
+
 
 def test_validate_response():
     validate_response(200, None, "/path")

--- a/gcsfs/tests/test_retry.py
+++ b/gcsfs/tests/test_retry.py
@@ -40,6 +40,9 @@ def test_retriable_exception():
     e = OSError('An internal error occurred.')
     assert is_retriable(e)
 
+    e = OSError('Network error')
+    assert not is_retriable(e)
+
 
 def test_validate_response():
     validate_response(200, None, "/path")


### PR DESCRIPTION
I've encountered a case where large bulk deletions throws an `OSError`. The GCS documentation points out that this is a general problem (https://cloud.google.com/storage/docs/deleting-objects#delete-objects-in-bulk). I did not expect, however, that this would throw an OSError instead of a 500 error.

In any case, this PR extends `gcsfs`'s retry logic to include internal errors that throw `OSError`s. My hope is that this fixes an associated issue in Pangeo Forge Recipes (pangeo-forge/pangeo-forge-recipes#406).