### PR TITLE
core: support object versioning

### DIFF
--- a/gcsfs/tests/conftest.py
+++ b/gcsfs/tests/conftest.py
@@ -116,5 +116,30 @@ def gcs(gcs_factory, populate=True):
     finally:
         try:
             gcs.rm(gcs.find(TEST_BUCKET))
+            gcs.rm(TEST_BUCKET)
+        except:  # noqa: E722
+            pass
+
+
+@pytest.fixture
+def gcs_versioned(gcs_factory):
+    gcs = gcs_factory()
+    gcs.version_aware = True
+    try:
+        try:
+            gcs.rm(gcs.find(TEST_BUCKET, versions=True))
+        except FileNotFoundError:
+            pass
+
+        try:
+            gcs.mkdir(TEST_BUCKET, enable_versioning=True)
+        except Exception:
+            pass
+        gcs.invalidate_cache()
+        yield gcs
+    finally:
+        try:
+            gcs.rm(gcs.find(TEST_BUCKET, versions=True))
+            gcs.rm(TEST_BUCKET)
         except:  # noqa: E722
             pass

--- a/gcsfs/tests/conftest.py
+++ b/gcsfs/tests/conftest.py
@@ -63,7 +63,8 @@ def docker_gcs():
     container = "gcsfs_test"
     cmd = (
         "docker run -d -p 4443:4443 --name gcsfs_test fsouza/fake-gcs-server:latest -scheme "
-        "http -public-host http://localhost:4443 -external-url http://localhost:4443"
+        "http -public-host http://localhost:4443 -external-url http://localhost:4443 "
+        "-backend memory"
     )
     stop_docker(container)
     subprocess.check_output(shlex.split(cmd))


### PR DESCRIPTION
Enables support for Cloud Storage [object versioning](https://cloud.google.com/storage/docs/object-versioning).

- Provides a consistent implementation with existing cloud versioning support in s3fs and adlfs
    - `generation` used instead of `version_id` to match the GCS terminology
    - `version_aware` filesystem attribute should be set when using cloud versioning functionality
- Supports specifying object generation in either path `bucket/key?generation=1234` querystring or `bucket/key#1234` fragment to remain consistent with GCS.
    - GCS CLI utilities (`gcloud`) accept and return versioned paths using the `#...` fragment
    - GCS rest API calls (and python SDK calls) use the `?generation=...` querystring (either provided through python SDK kwargs or directly in the URL)
- object `metageneration` is returned in `fs.info` & file`details`, but this implementation only supports returning the latest `metageneration` for a given object version.
- `find(..., versions=True)` will return versioned object names (in `path#generation` form) for all object versions in the specified path/prefix

~~TODO:~~
- [x] add tests (this PR has been tested manually on a real world GCS bucket, I'm still working out how to get versioning working with the fake-gcs-server docker container)