### PR TITLE
Added support for the # character in filenames

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ requests
 decorator>4.1.2
 fsspec==2022.11.0
 aiohttp!=4.0.0a0, !=4.0.0a1
+yarl>=1.7.0


### PR DESCRIPTION
Google requires `#` to remain unescaped in the URL, but `aiohttp` considers it the start of the fragment and strips it out. 