### PR TITLE
ls: Only append the generation to the entry's name if it exists

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -835,15 +835,10 @@ class GCSFileSystem(AsyncFileSystem):
             for entry in await self._list_objects(
                 path, prefix=prefix, versions=versions
             ):
-                if versions:
-                    out.append(
-                        {
-                            **entry,
-                            "name": f"{entry['name']}#{entry['generation']}",
-                        }
-                    )
-                else:
-                    out.append(entry)
+                if versions and "generation" in entry:
+                    entry = entry.copy()
+                    entry["name"] = f"{entry['name']}#{entry['generation']}"
+                out.append(entry)
 
         if detail:
             return out

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -1205,6 +1205,7 @@ def test_ls_versioned(gcs_versioned):
     assert versions == {
         entry["name"] for entry in gcs_versioned.ls(dpath, detail=True, versions=True)
     }
+    assert gcs_versioned.ls(TEST_BUCKET, versions=True) == ["gcsfs_test/tmp"]
 
 
 def test_find_versioned(gcs_versioned):


### PR DESCRIPTION
Fixes #522