### PR TITLE
Add python 3.11, drop 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - name: Checkout source

--- a/setup.py
+++ b/setup.py
@@ -20,10 +20,10 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     keywords=["google-cloud-storage", "gcloud", "file-system"],
     packages=["gcsfs", "gcsfs.cli"],
@@ -32,6 +32,6 @@ setup(
         open("README.rst").read() if os.path.exists("README.rst") else ""
     ),
     extras_require={"gcsfuse": ["fusepy"], "crc": ["crcmod"]},
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     zip_safe=False,
 )


### PR DESCRIPTION
Change minimum python version from 3.7 to 3.8, in line with https://github.com/fsspec/filesystem_spec/pull/1184 and https://github.com/fsspec/filesystem_spec/pull/1185. Also added 3.11 to classifiers and CI.