### PR TITLE
GCSFileSystem can accept a raw token

### DIFF
--- a/gcsfs/credentials.py
+++ b/gcsfs/credentials.py
@@ -132,12 +132,6 @@ class GoogleCredentials:
             )
         return token
 
-    def _raw_token_to_credentials(self, token: str):
-        try:
-            return Credentials(token)
-        except Exception:
-            raise ValueError(f"Unable to create Credentials from token: {token}")
-
     def _connect_token(self, token):
         """
         Connect using a concrete token
@@ -162,7 +156,7 @@ class GoogleCredentials:
                     with open(token) as data:
                         token = json.load(data)
             else:
-                token = self._raw_token_to_credentials(token)
+                token = Credentials(token)
         if isinstance(token, dict):
             credentials = self._dict_to_credentials(token)
         elif isinstance(token, google.auth.credentials.Credentials):

--- a/gcsfs/credentials.py
+++ b/gcsfs/credentials.py
@@ -146,7 +146,7 @@ class GoogleCredentials:
         ----------
         token: str, dict or Credentials
             If a str and a valid file name, try to load as a Service file, or next as a JSON;
-            if not a valid file name, assume it's a valid raw token, and pass to Credentials. If
+            if not a valid file name, assume it's a valid raw (non-renewable/session) token, and pass to Credentials. If
             dict, try to interpret as credentials; if Credentials, use directly.
         """
         if isinstance(token, str):

--- a/gcsfs/tests/test_credentials.py
+++ b/gcsfs/tests/test_credentials.py
@@ -1,7 +1,7 @@
 import pytest
 
-from gcsfs.credentials import GoogleCredentials
 from gcsfs import GCSFileSystem
+from gcsfs.credentials import GoogleCredentials
 from gcsfs.retry import HttpError
 
 

--- a/gcsfs/tests/test_credentials.py
+++ b/gcsfs/tests/test_credentials.py
@@ -1,7 +1,18 @@
+import pytest
+
 from gcsfs.credentials import GoogleCredentials
+from gcsfs import GCSFileSystem
+from gcsfs.retry import HttpError
 
 
 def test_googlecredentials_none():
     credentials = GoogleCredentials(project="myproject", token=None, access="read_only")
     headers = {}
     credentials.apply(headers)
+
+
+@pytest.mark.parametrize("token", ["", "incorrect.token", "x" * 100])
+def test_credentials_from_raw_token(token):
+    with pytest.raises(HttpError, match="Invalid Credentials"):
+        fs = GCSFileSystem(project="myproject", token=token)
+        fs.ls("/")


### PR DESCRIPTION
Related to https://github.com/fsspec/gcsfs/issues/553.

`Credentials` will happily be created from an invalid token - google library doesn't seem to do any checks when the object is instantiated. However, when using such an instance of `Credentials`, an `HttpError` will be raised.
