### PR TITLE
Added refresh flag to _ls

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -835,10 +835,12 @@ class GCSFileSystem(AsyncFileSystem):
             prefix = path[:ind].split("/")[-1]
         return await super()._glob(path, prefix=prefix, **kwargs)
 
-    async def _ls(self, path, detail=False, prefix="", versions=False, **kwargs):
+    async def _ls(self, path, detail=False, refresh=False, prefix="", versions=False, **kwargs):
         """List objects under the given '/{bucket}/{prefix} path."""
         path = self._strip_protocol(path).rstrip("/")
 
+        if refresh:
+            self.invalidate_cache()
         if path in ["/", ""]:
             out = await self._list_buckets()
         else:

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -266,6 +266,11 @@ def test_ls_detail(gcs):
     L = gcs.ls(TEST_BUCKET + "/nested", detail=True)
     assert all(isinstance(item, dict) for item in L)
 
+@pytest.mark.parametrize("refresh", (False, True))
+def test_ls_refresh(gcs, refresh):
+    with mock.patch.object(gcs, "invalidate_cache") as mock_invalidate_cache:
+        gcs.ls(TEST_BUCKET, refresh=refresh)
+    assert mock_invalidate_cache.called is refresh
 
 def test_gcs_glob(gcs):
     fn = TEST_BUCKET + "/nested/file1"


### PR DESCRIPTION
This change is intended to implement the refresh functionality defined on AbstractFileSystem for GCSFileSystem (https://github.com/fsspec/filesystem_spec/blob/master/fsspec/spec.py#L331). 

GCSFileSystem inherits from AsyncFileSystem, which inherits from AbstractFileSystem.

I believe this works as my understanding is "_list_objects" will generate the cache for a path, should one not be found. "_list_objects" will be called after "invalidate_cache". 