### PR TITLE
Faster cache in `find`

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1254,9 +1254,10 @@ class GCSFileSystem(AsyncFileSystem):
                     "size": 0,
                 }
 
-                listing = cache_entries.setdefault(parent, [])
-                if previous not in listing:
-                    listing.append(previous)
+                listing = cache_entries.setdefault(parent, {})
+                name = previous["name"]
+                if name not in listing:
+                    listing[name] = previous
 
                 previous = dirs[parent]
                 parent = self._parent(parent)

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1263,7 +1263,8 @@ class GCSFileSystem(AsyncFileSystem):
                 parent = self._parent(parent)
 
         if not prefix:
-            self.dircache.update(cache_entries)
+            cache_entries_list = {k: list(v.values()) for k, v in cache_entries.items()}
+            self.dircache.update(cache_entries_list)
 
         if withdirs:
             objects = sorted(objects + list(dirs.values()), key=lambda x: x["name"])


### PR DESCRIPTION
Fixes #560.

`set` didn't immediately work because `previous` is a dict and not hashable. Converting to a `frozenset` is also not straightforward because these are nested dicts.

Couple questions (haven't even run tests yet so these may be answered by CI): 

1. ~~do we need to convert this back to a `list` in `self.dircache.update(cache_entries)`?~~ yes, done
2. should we hash using `previous["id"]` or some other/better attribute to handle versioned objects? I see `id` has this information for files, but `DIRECTORY` doesn't have an `id` attr so we would need a conditional there to use `name`.