### PR TITLE
Translate time metadata from GCS names to fsspec standard names.

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -462,9 +462,9 @@ class GCSFileSystem(AsyncFileSystem):
         # Translate time metadata from GCS names to fsspec standard names.
         # TODO(issues/559): Remove legacy names `updated` and `timeCreated`?
         if "updated" in object_metadata:
-            result["mtime"] = object_metadata["updated"]
+            result["mtime"] = self._parse_timestamp(object_metadata["updated"])
         if "timeCreated" in object_metadata:
-            result["ctime"] = object_metadata["timeCreated"]
+            result["ctime"] = self._parse_timestamp(object_metadata["timeCreated"])
         if "generation" in object_metadata or "metageneration" in object_metadata:
             result["generation"] = object_metadata.get("generation")
             result["metageneration"] = object_metadata.get("metageneration")
@@ -756,10 +756,10 @@ class GCSFileSystem(AsyncFileSystem):
     rmdir = sync_wrapper(_rmdir)
 
     def modified(self, path):
-        return self._parse_timestamp(self.info(path)["mtime"])
+        return self.info(path)["mtime"]
 
     def created(self, path):
-        return self._parse_timestamp(self.info(path)["ctime"])
+        return self.info(path)["ctime"]
 
     def _parse_timestamp(self, timestamp):
         assert timestamp.endswith("Z")

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -128,6 +128,9 @@ def test_info(gcs):
     today = datetime.date.today().isoformat()
     assert gcs.created(a).isoformat().startswith(today)
     assert gcs.modified(a).isoformat().startswith(today)
+    # Check conformance with expected info attribute names.
+    assert gcs.info(a)["ctime"] == gcs.created(a)
+    assert gcs.info(a)["mtime"] == gcs.modified(a)
 
 
 def test_ls2(gcs):


### PR DESCRIPTION
To fix issue #559.