### PR TITLE
Invalidate dircache on copy

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1006,6 +1006,7 @@ class GCSFileSystem(AsyncFileSystem):
                 json_out=True,
                 sourceGeneration=g1,
             )
+        self.invalidate_cache(self._parent(path2))
 
     async def _rm_file(self, path, **kwargs):
         bucket, key, generation = self.split_path(path)


### PR DESCRIPTION
Fixes #562.

`_cp_file()` wasn't invalidating the dircache for the target path, leading to stale cache information causing a erroneous `isfile()` test. Similar functions `_put_file()` and `_rm_file()` do have the cache invalidation.

Solution here is to add
```python
self.invalidate_cache(self._parent(path2))
```
at the end of `_cp_file()`.