### PR TITLE
Add pickling support to `HttpError` class

### DIFF
--- a/gcsfs/retry.py
+++ b/gcsfs/retry.py
@@ -15,6 +15,8 @@ class HttpError(Exception):
     """Holds the message and code from cloud errors."""
 
     def __init__(self, error_response=None):
+        # Save error_response for potential pickle.
+        self._error_response = error_response
         if error_response:
             self.code = error_response.get("code", None)
             self.message = error_response.get("message", "")
@@ -28,6 +30,12 @@ class HttpError(Exception):
             self.code = None
         # Call the base class constructor with the parameters it needs
         super().__init__(self.message)
+
+    def __reduce__(self):
+        """This makes the Exception pickleable."""
+
+        # This is basically deconstructing the HttpError when pickled.
+        return HttpError, (self._error_response,)
 
 
 class ChecksumError(Exception):

--- a/gcsfs/tests/test_retry.py
+++ b/gcsfs/tests/test_retry.py
@@ -1,3 +1,4 @@
+import multiprocessing
 import os
 import pickle
 from concurrent.futures import ProcessPoolExecutor
@@ -61,7 +62,7 @@ def test_multiprocessing_error_handling():
             raise HttpError({"message": "", "code": 400})
 
     # Ensure spawn context to avoid forking issues
-    ctx = mp.get_context("spawn")
+    ctx = multiprocessing.get_context("spawn")
 
     # Run on two processes
     with ProcessPoolExecutor(2, mp_context=ctx) as p:

--- a/gcsfs/tests/test_retry.py
+++ b/gcsfs/tests/test_retry.py
@@ -55,12 +55,13 @@ def test_pickle_serialization():
     assert is_same_type and is_same_args
 
 
-def test_multiprocessing_error_handling():
-    def conditional_exception(process_id):
-        # Raise only on second process (id=1)
-        if process_id == 1:
-            raise HttpError({"message": "", "code": 400})
+def conditional_exception(process_id):
+    # Raise only on second process (id=1)
+    if process_id == 1:
+        raise HttpError({"message": "", "code": 400})
 
+
+def test_multiprocessing_error_handling():
     # Ensure spawn context to avoid forking issues
     ctx = multiprocessing.get_context("spawn")
 


### PR DESCRIPTION
The `HttpError` class was updated to include support for pickling. A new private attribute `_error_response` was added for potential pickle use, and the `__reduce__` method was added to deconstruct the HttpError when pickled. This update allows HttpErrors to be serialized and deserialized, i.e. in the case of multiprocessing use.

Closes #570.