### PR TITLE
Better double asterisk support

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1241,6 +1241,7 @@ class GCSFileSystem(AsyncFileSystem):
         **kwargs,
     ):
         path = self._strip_protocol(path)
+        path = path.rstrip("/")
         bucket, key, generation = self.split_path(path)
 
         if maxdepth is not None and maxdepth < 1:

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1241,7 +1241,6 @@ class GCSFileSystem(AsyncFileSystem):
         **kwargs,
     ):
         path = self._strip_protocol(path)
-        path = path.rstrip("/")
         bucket, key, generation = self.split_path(path)
 
         if maxdepth is not None and maxdepth < 1:
@@ -1295,7 +1294,7 @@ class GCSFileSystem(AsyncFileSystem):
 
         if maxdepth:
             # Filter returned objects based on requested maxdepth
-            depth = path.count("/") + maxdepth
+            depth = path.rstrip("/").count("/") + maxdepth
             objects = list(filter(lambda o: o["name"].count("/") <= depth, objects))
 
         if detail:

--- a/gcsfs/tests/derived/gcsfs_fixtures.py
+++ b/gcsfs/tests/derived/gcsfs_fixtures.py
@@ -1,19 +1,17 @@
-import pytest
 import fsspec
-from gcsfs.tests.settings import TEST_BUCKET
-from gcsfs.tests.conftest import allfiles
+import pytest
 from fsspec.tests.abstract import AbstractFixtures
+
 from gcsfs.core import GCSFileSystem
+from gcsfs.tests.conftest import allfiles
+from gcsfs.tests.settings import TEST_BUCKET
 
 
 class GcsfsFixtures(AbstractFixtures):
-
     @pytest.fixture(scope="class")
     def fs(self, docker_gcs):
         GCSFileSystem.clear_instance_cache()
-        gcs = fsspec.filesystem(
-            "gcs", endpoint_url=docker_gcs
-        )
+        gcs = fsspec.filesystem("gcs", endpoint_url=docker_gcs)
         try:
             # ensure we're empty.
             try:

--- a/gcsfs/tests/derived/gcsfs_fixtures.py
+++ b/gcsfs/tests/derived/gcsfs_fixtures.py
@@ -37,5 +37,6 @@ class GcsfsFixtures(AbstractFixtures):
     def fs_path(self):
         return TEST_BUCKET
 
+    @pytest.fixture
     def supports_empty_directories(self):
         return False

--- a/gcsfs/tests/derived/gcsfs_fixtures.py
+++ b/gcsfs/tests/derived/gcsfs_fixtures.py
@@ -1,0 +1,43 @@
+import pytest
+import fsspec
+from gcsfs.tests.settings import TEST_BUCKET
+from gcsfs.tests.conftest import allfiles
+from fsspec.tests.abstract import AbstractFixtures
+from gcsfs.core import GCSFileSystem
+
+
+class GcsfsFixtures(AbstractFixtures):
+
+    @pytest.fixture(scope="class")
+    def fs(self, docker_gcs):
+        GCSFileSystem.clear_instance_cache()
+        gcs = fsspec.filesystem(
+            "gcs", endpoint_url=docker_gcs
+        )
+        try:
+            # ensure we're empty.
+            try:
+                gcs.rm(TEST_BUCKET, recursive=True)
+            except FileNotFoundError:
+                pass
+            try:
+                gcs.mkdir(TEST_BUCKET)
+            except Exception:
+                pass
+
+            gcs.pipe({TEST_BUCKET + "/" + k: v for k, v in allfiles.items()})
+            gcs.invalidate_cache()
+            yield gcs
+        finally:
+            try:
+                gcs.rm(gcs.find(TEST_BUCKET))
+                gcs.rm(TEST_BUCKET)
+            except:  # noqa: E722
+                pass
+
+    @pytest.fixture
+    def fs_path(self):
+        return TEST_BUCKET
+
+    def supports_empty_directories(self):
+        return False

--- a/gcsfs/tests/derived/gcsfs_test.py
+++ b/gcsfs/tests/derived/gcsfs_test.py
@@ -1,4 +1,5 @@
 import fsspec.tests.abstract as abstract
+
 from gcsfs.tests.derived.gcsfs_fixtures import GcsfsFixtures
 
 

--- a/gcsfs/tests/derived/gcsfs_test.py
+++ b/gcsfs/tests/derived/gcsfs_test.py
@@ -1,0 +1,14 @@
+import fsspec.tests.abstract as abstract
+from gcsfs.tests.derived.gcsfs_fixtures import GcsfsFixtures
+
+
+class TestGcsfsCopy(abstract.AbstractCopyTests, GcsfsFixtures):
+    pass
+
+
+class TestGcsfsGet(abstract.AbstractGetTests, GcsfsFixtures):
+    pass
+
+
+class TestGcsfsPut(abstract.AbstractPutTests, GcsfsFixtures):
+    pass

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -274,7 +274,7 @@ def test_gcs_glob(gcs):
     fn = TEST_BUCKET + "/nested/file1"
     assert fn not in gcs.glob(TEST_BUCKET + "/")
     assert fn not in gcs.glob(TEST_BUCKET + "/*")
-    assert fn in gcs.glob(TEST_BUCKET + "/nested/")
+    assert fn not in gcs.glob(TEST_BUCKET + "/nested/")
     assert fn in gcs.glob(TEST_BUCKET + "/nested/*")
     assert fn in gcs.glob(TEST_BUCKET + "/nested/file*")
     assert fn in gcs.glob(TEST_BUCKET + "/*/*")


### PR DESCRIPTION
This PR updates the `gcsfs` implementation to support updates made in the [Better double asterisks ** support](https://github.com/fsspec/filesystem_spec/pull/1329) pull request in the `filesystem_spec` repo.

Successful run: https://github.com/fsspec/filesystem_spec/actions/runs/5847462518/job/15915309794

@ianthomas23 Let me know if you prefer to merge your PR with `derived test` and I'll remove my updates regarding this.