### PR TITLE
Add test_move_recursive

### DIFF
--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -399,6 +399,19 @@ def test_move(gcs):
     assert not gcs.exists(fn)
 
 
+@pytest.mark.parametrize("slash_from", ([False, True]))
+def test_move_recursive(gcs, slash_from):
+    # See issue #489
+    dir_from = TEST_BUCKET + "/nested"
+    if slash_from:
+        dir_from += "/"
+    dir_to = TEST_BUCKET + "/new_name"
+
+    gcs.mv(dir_from, dir_to, recursive=True)
+    assert not gcs.exists(dir_from)
+    assert gcs.ls(dir_to) == [dir_to + "/file1", dir_to + "/file2", dir_to + "/nested2"]
+
+
 def test_cat_file(gcs):
     fn = TEST_BUCKET + "/test/accounts.1.json"
     data = gcs.cat_file(fn)


### PR DESCRIPTION
Closes #489.

Issue #489 has been fixed by the recent improvements to recursive path expansions. This PR adds an explicit test to confirm this and ensure that any future regressions are caught.