### PR TITLE
Use utcnow time to test ctime info

### DIFF
--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -125,7 +125,7 @@ def test_info(gcs):
     gcs.touch(a)
     assert gcs.info(a) == gcs.ls(a, detail=True)[0]
 
-    today = datetime.date.today().isoformat()
+    today = datetime.datetime.utcnow().date().isoformat()
     assert gcs.created(a).isoformat().startswith(today)
     assert gcs.modified(a).isoformat().startswith(today)
     # Check conformance with expected info attribute names.


### PR DESCRIPTION
When running tests from the future (in a zone at day+1 compared to UTC time), the `test_info` test fails with:
```
>       assert gcs.created(a).isoformat().startswith(today)
E       AssertionError: assert False
```

This fix uses the UTC date with `datetime.datetime.utcnow().date()` instead of `datetime.date.today()` since it has to be compared with `ctime` info that seems to be UTC as well.