### PR TITLE
Fix small transaction

### DIFF
--- a/gcsfs/retry.py
+++ b/gcsfs/retry.py
@@ -82,7 +82,8 @@ def validate_response(status, content, path, args=None):
     r: requests response object
     path: associated URL path, for error messages
     """
-    if status >= 400:
+    if status >= 400 and status != 499:
+        # 499 is special "upload was cancelled" status
         if args:
             from .core import quote
 


### PR DESCRIPTION
Fixes #389 

It seems return core 499 is new behaviour on GCS upon upload cancel, and not supported on the emulator - so the test does not actually run in CI, but works against real GCS.