### PR TITLE
Fix double asterisk glob in tests

### DIFF
--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -286,7 +286,7 @@ def test_gcs_glob(gcs):
     assert fn in gcs.glob(TEST_BUCKET + "/nested/file*")
     assert fn in gcs.glob(TEST_BUCKET + "/*/*")
     assert fn in gcs.glob(TEST_BUCKET + "/**")
-    assert fn in gcs.glob(TEST_BUCKET + "/**1")
+    assert fn in gcs.glob(TEST_BUCKET + "/**/*1")
     assert all(
         f in gcs.find(TEST_BUCKET)
         for f in gcs.glob(TEST_BUCKET + "/nested/*")


### PR DESCRIPTION
To avoid an error after https://github.com/fsspec/filesystem_spec/pull/1382