### PR TITLE
close_session: clean up loop handling

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -342,7 +342,7 @@ class GCSFileSystem(AsyncFileSystem):
         if loop is not None and session is not None:
             if loop.is_running():
                 try:
-                    current_loop = asyncio.get_event_loop()
+                    current_loop = asyncio.get_running_loop()
                     current_loop.create_task(session.close())
                     return
                 except RuntimeError:


### PR DESCRIPTION
Previously we were potentially running cleanup on a different
event loop, even if the session's associated event loop was
active. This manifested in RuntimeError instances being raised
when synchronous cleanup was attempted. Change cleanup to
always use the session's associated event loop and add some
logging when things have gone wrong.