### PR TITLE
Ensure dircache on ls

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -583,7 +583,6 @@ class GCSFileSystem(AsyncFileSystem):
             }
             for prefix in prefixes
         ]
-        breakpoint()
         if not (items + pseudodirs):
             if key:
                 return [await self._get_object(path)]

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -583,6 +583,7 @@ class GCSFileSystem(AsyncFileSystem):
             }
             for prefix in prefixes
         ]
+        breakpoint()
         if not (items + pseudodirs):
             if key:
                 return [await self._get_object(path)]
@@ -596,7 +597,7 @@ class GCSFileSystem(AsyncFileSystem):
 
         # Don't cache prefixed/partial listings, in addition to
         # not using the inventory report service to do listing directly.
-        if not prefix and use_snapshot_listing is False:
+        if not prefix and not use_snapshot_listing:
             self.dircache[path] = out
         return out
 

--- a/gcsfs/retry.py
+++ b/gcsfs/retry.py
@@ -58,15 +58,17 @@ RETRIABLE_EXCEPTIONS = (
 )
 
 
+errs = list(range(500, 505)) + [
+    # Request Timeout
+    408,
+    # Too Many Requests
+    429,
+]
+errs = set(errs + [str(e) for e in errs])
+
+
 def is_retriable(exception):
     """Returns True if this exception is retriable."""
-    errs = list(range(500, 505)) + [
-        # Request Timeout
-        408,
-        # Too Many Requests
-        429,
-    ]
-    errs += [str(e) for e in errs]
     if isinstance(exception, HttpError):
         return exception.code in errs
 

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -32,7 +32,7 @@ def test_simple(gcs, monkeypatch):
     gcs.ls("/" + TEST_BUCKET)  # OK to lead with '/'
 
 
-def test_dircache_filled(gcs, mocker):
+def test_dircache_filled(gcs):
     assert not dict(gcs.dircache)
     gcs.ls(TEST_BUCKET)
     assert len(gcs.dircache) == 1


### PR DESCRIPTION
Fixes #611 

I would still like to add a test to make sure this doesn't happen again, and also to double check what happens within find()