### PR TITLE
_get_file: fix makedirs call when the lpath is relative and in the working directory

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1534,7 +1534,8 @@ class GCSFileSystem(asyn.AsyncFileSystem):
             callback.set_size(size)
 
             checker = get_consistency_checker(consistency)
-            os.makedirs(os.path.dirname(lpath), exist_ok=True)
+            lparent = os.path.dirname(lpath) or os.curdir
+            os.makedirs(lparent, exist_ok=True)
             with open(lpath, "wb") as f2:
                 while True:
                     data = await r.content.read(4096 * 32)

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -515,6 +515,19 @@ def test_get_put_file_in_dir(protocol, gcs):
         assert gcs.cat(protocol + TEST_BUCKET + "/temp_dir/accounts.1.json") == data1
 
 
+@pytest.mark.parametrize("protocol", ["", "gs://", "gcs://"])
+def test_get_file_to_current_working_directory(monkeypatch, protocol, gcs):
+    fn = protocol + TEST_BUCKET + "/temp"
+    gcs.pipe(fn, b"hello world")
+
+    with tempdir() as dn:
+        os.makedirs(dn)
+        monkeypatch.chdir(dn)
+        gcs.get_file(fn, "temp")
+        with open("temp", mode="rb") as f:
+            assert f.read() == b"hello world"
+
+
 def test_special_characters_filename(gcs: GCSFileSystem):
     special_filename = """'!"`#$%&'()+,-.<=>?@[]^_{}~/'"""
     full_path = TEST_BUCKET + "/" + special_filename


### PR DESCRIPTION
Let's say if `lpath` is `file` literal, a relative path and to be downloaded to
the current working directory, `_get_file` currently fails with `FileNotFoundError`
during `os.makedirs` call.
```python
await fs._get_file('gs://bucket/file', 'file')
```
    
This happens because `os.path.dirname()` returns an empty string, which when passed to `os.makedirs()`,
it raises a `FileNotFoundError`.

```py
>>> os.path.dirname('file')
''
>>> os.makedirs('')
FileNotFoundError: [Errno 2] No such file or directory: ''
```

The following is a part of a traceback that I get.

```pytb
File "/Users/user/dev/solutions/checkpoints-gcp/.venv/lib/python3.11/site-packages/fsspec/asyn.py", line 118, in wrapper
    return sync(self.loop, func, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/Users/user/dev/solutions/checkpoints-gcp/.venv/lib/python3.11/site-packages/fsspec/asyn.py", line 103, in sync
    raise return_result
File "/Users/user/dev/solutions/checkpoints-gcp/.venv/lib/python3.11/site-packages/fsspec/asyn.py", line 56, in _runner
    result[0] = await coro
                ^^^^^^^^^^
File "/Users/user/dev/solutions/checkpoints-gcp/.venv/lib/python3.11/site-packages/gcsfs/core.py", line 1491, in _get_file
    await self._get_file_request(u2, lpath, callback=callback, **kwargs)
File "/Users/user/dev/solutions/checkpoints-gcp/.venv/lib/python3.11/site-packages/decorator.py", line 221, in fun
    return await caller(func, *(extras + args), **kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/Users/user/dev/solutions/checkpoints-gcp/.venv/lib/python3.11/site-packages/gcsfs/retry.py", line 123, in retry_request
    return await func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/Users/user/dev/solutions/checkpoints-gcp/.venv/lib/python3.11/site-packages/gcsfs/core.py", line 1472, in _get_file_request
    os.makedirs(os.path.dirname(lpath), exist_ok=True)
File "<frozen os>", line 225, in makedirs

FileNotFoundError: [Errno 2] No such file or directory: ''
```

The fix here is to fallback to `os.curdir` on an empty string.
