### PR TITLE
Swap order of protocols to favor "gs" when unstripping protocol from URI

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -261,7 +261,7 @@ class GCSFileSystem(asyn.AsyncFileSystem):
     scopes = {"read_only", "read_write", "full_control"}
     retries = 6  # number of retries on http failure
     default_block_size = DEFAULT_BLOCK_SIZE
-    protocol = "gcs", "gs"
+    protocol = "gs", "gcs"
     async_impl = True
 
     def __init__(


### PR DESCRIPTION
Fixes issue #619.

When `unstrip_protocol` is called, it currently produces invalid GCS URIs (not recognized by `gsutil` or other tools). This PR swaps the order of protocols to favor `gs://` over the non-standard `gcs://` when unstripping.