### PR TITLE
Add seek(0) to request data to prevent issues on retries

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -421,6 +421,8 @@ class GCSFileSystem(asyn.AsyncFileSystem):
         self, method, path, *args, headers=None, json=None, data=None, **kwargs
     ):
         await self._set_session()
+        if hasattr(data, "seek"):
+            data.seek(0)
         async with self.session.request(
             method=method,
             url=self._format_path(path, args),


### PR DESCRIPTION
Closes #621 

Credits go to @martindurant for the code.

When a simple_upload request fails but the `data` BytesIO stream was fully consumed, the retry attempt may fail because it does not send any data in the retried request. This PR attempt to fix that by always performing a `seek(0)` before starting the request.