### PR TITLE
Handle case when error message is a string.

### DIFF
--- a/gcsfs/retry.py
+++ b/gcsfs/retry.py
@@ -99,7 +99,11 @@ def validate_response(status, content, path, args=None):
             content = content.decode()
         try:
             error = json.loads(content)["error"]
-            msg = error["message"]
+            # Sometimes the error message is a string.
+            if isinstance(error, str):
+                msg = error
+            else:
+                msg = error["message"]
         except json.decoder.JSONDecodeError:
             msg = content
 
@@ -109,7 +113,7 @@ def validate_response(status, content, path, args=None):
             raise requests.exceptions.ProxyError()
         elif "invalid" in str(msg):
             raise ValueError(f"Bad Request: {path}\n{msg}")
-        elif error:
+        elif error and not isinstance(error, str):
             raise HttpError(error)
         elif status:
             raise HttpError({"code": status, "message": msg})  # text-like

--- a/gcsfs/tests/test_retry.py
+++ b/gcsfs/tests/test_retry.py
@@ -103,6 +103,15 @@ def test_validate_response():
         validate_response(502, b"", "/path")
 
 
+def test_validate_response_error_is_string():
+    # HttpError with JSON body
+    j = '{"error": "Too Many Requests"}'
+    with pytest.raises(HttpError) as e:
+        validate_response(429, j, "/path")
+    assert e.value.code == 429
+    assert e.value.message == "Too Many Requests, 429"
+
+
 @pytest.mark.parametrize(
     ["file_path", "validate_get_error", "validate_list_error", "expected_error"],
     [


### PR DESCRIPTION
Fixes https://github.com/fsspec/gcsfs/issues/630.