### PR TITLE
Improvements for credentials refresh under high load

### DIFF
--- a/gcsfs/retry.py
+++ b/gcsfs/retry.py
@@ -71,6 +71,9 @@ def is_retriable(exception):
     """Returns True if this exception is retriable."""
 
     if isinstance(exception, HttpError):
+        # Add 401 to retriable errors when it's an auth expiration issue
+        if exception.code == 401 and "Invalid Credentials" in str(exception.message):
+            return True
         return exception.code in errs
 
     return isinstance(exception, RETRIABLE_EXCEPTIONS)


### PR DESCRIPTION
This PR contains some improvements aimed at avoiding errors when gcsfs is under heavy load and performing credential refreshes.

These changes were made in response to observing errors of the following form in our logs from a long-running process with many GCS file system operations happening:

```
gcsfs.retry.HttpError: Invalid Credentials, 401
```