### PR TITLE
Yet another fix for isdir

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -627,9 +627,11 @@ class GCSFileSystem(asyn.AsyncFileSystem):
             "use_snapshot_listing"
         )
 
+        max_results = kwargs.get("max_results")
+
         # Don't cache prefixed/partial listings, in addition to
         # not using the inventory report service to do listing directly.
-        if not prefix and not use_snapshot_listing:
+        if not prefix and not use_snapshot_listing and not max_results:
             self.dircache[path] = out
         return out
 
@@ -683,7 +685,7 @@ class GCSFileSystem(asyn.AsyncFileSystem):
                 end_offset=None,
                 prefix=prefix,
                 versions=versions,
-                page_size=max_results,
+                max_results=max_results,
             )
 
     async def _concurrent_list_objects_helper(
@@ -736,7 +738,7 @@ class GCSFileSystem(asyn.AsyncFileSystem):
                     end_offset=end_offsets[i],
                     prefix=prefix,
                     versions=versions,
-                    page_size=page_size,
+                    max_results=page_size,
                 )
                 for i in range(0, len(start_offsets))
             ]
@@ -761,7 +763,7 @@ class GCSFileSystem(asyn.AsyncFileSystem):
         end_offset,
         prefix,
         versions,
-        page_size,
+        max_results,
     ):
         """
         Sequential list objects within the start and end offset range.
@@ -778,7 +780,7 @@ class GCSFileSystem(asyn.AsyncFileSystem):
             prefix=prefix,
             startOffset=start_offset,
             endOffset=end_offset,
-            maxResults=page_size,
+            maxResults=max_results,
             json_out=True,
             versions="true" if versions else None,
         )
@@ -796,7 +798,7 @@ class GCSFileSystem(asyn.AsyncFileSystem):
                 prefix=prefix,
                 startOffset=start_offset,
                 endOffset=end_offset,
-                maxResults=page_size,
+                maxResults=max_results,
                 pageToken=next_page_token,
                 json_out=True,
                 versions="true" if versions else None,

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -1223,6 +1223,47 @@ def test_dir_marker(gcs):
     assert out2["type"] == "directory"
 
 
+def test_dir_marker_directory_not_listed(gcs):
+    gcs.touch(f"{TEST_BUCKET}/psudodir/")
+    gcs.touch(f"{TEST_BUCKET}/psudodir/innerfolder/innerfile")
+    gcs.invalidate_cache()
+    info = gcs.info(f"{TEST_BUCKET}/psudodir")
+    assert info["type"] == "directory"
+
+
+def test_dir_marker_directory_listed(gcs):
+    gcs.touch(f"{TEST_BUCKET}/psudodir/")
+    gcs.touch(f"{TEST_BUCKET}/psudodir/innerfolder/innerfile")
+    gcs.invalidate_cache()
+    gcs.ls(f"{TEST_BUCKET}/psudodir")
+    info = gcs.info(f"{TEST_BUCKET}/psudodir")
+    assert info["type"] == "directory"
+
+
+def test_dir_marker_parent_directory_listed(gcs):
+    gcs.touch(f"{TEST_BUCKET}/parent_psudodir/psudodir/")
+    gcs.touch(f"{TEST_BUCKET}/parent_psudodir/psudodir/innerfolder/innerfile")
+    gcs.invalidate_cache()
+    gcs.ls(f"{TEST_BUCKET}/parent_psudodir")
+    info = gcs.info(f"{TEST_BUCKET}/parent_psudodir/psudodir")
+    assert info["type"] == "directory"
+
+
+def test_dir_marker_info_eq_ls(gcs):
+    gcs.touch(f"{TEST_BUCKET}/psudodir/")
+    gcs.invalidate_cache()
+    out1 = gcs.info(f"{TEST_BUCKET}/psudodir")
+    out2 = gcs.ls(f"{TEST_BUCKET}/psudodir", detail=True)[0]
+    assert out1["type"] == "directory"
+    assert out1 == out2
+
+    gcs.invalidate_cache()
+    out3 = gcs.ls(f"{TEST_BUCKET}/psudodir", detail=True)[0]
+    out4 = gcs.info(f"{TEST_BUCKET}/psudodir")
+    assert out3["type"] == "directory"
+    assert out3 == out4
+
+
 def test_mkdir_with_path(gcs):
     with pytest.raises(FileNotFoundError):
         gcs.mkdir(f"{TEST_BUCKET + 'new'}/path", create_parents=False)


### PR DESCRIPTION
This is yet another stab at a fix for #312. 
Empty files that ends with "/" are treated as empty directories in "ls" and "info".
Test requsted in #313 is added.