### PR TITLE
Add support for specifying Cloud KMS keys when creating files

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1834,6 +1834,8 @@ class GCSFile(fsspec.spec.AbstractBufferedFile):
         kms_key_name: str
             Resource name of the Cloud KMS key that will be used to encrypt
             the object.
+            More info:
+            https://cloud.google.com/storage/docs/encryption/customer-managed-keys
         timeout: int
             Timeout seconds for the asynchronous callback.
         generation: str

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -2086,7 +2086,7 @@ async def initiate_upload(
     metadata=None,
     fixed_key_metadata=None,
     kms_key_name=None,
-    mode="overwrie",
+    mode="overwrite",
 ):
     j = {"name": key}
     if metadata:

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1791,8 +1791,8 @@ class GCSFile(fsspec.spec.AbstractBufferedFile):
         content_type=None,
         timeout=None,
         fixed_key_metadata=None,
-        kms_key_name=None,
         generation=None,
+        kms_key_name=None,
         **kwargs,
     ):
         """
@@ -1978,8 +1978,8 @@ class GCSFile(fsspec.spec.AbstractBufferedFile):
             self.content_type,
             self.metadata,
             self.fixed_key_metadata,
-            self.kms_key_name,
             mode="create" if "x" in self.mode else "overwrite",
+            kms_key_name=self.kms_key_name,
             timeout=self.timeout,
         )
 
@@ -2012,8 +2012,8 @@ class GCSFile(fsspec.spec.AbstractBufferedFile):
             self.consistency,
             self.content_type,
             self.fixed_key_metadata,
-            self.kms_key_name,
             mode="create" if "x" in self.mode else "overwrite",
+            kms_key_name=self.kms_key_name,
             timeout=self.timeout,
         )
 
@@ -2085,8 +2085,8 @@ async def initiate_upload(
     content_type="application/octet-stream",
     metadata=None,
     fixed_key_metadata=None,
-    kms_key_name=None,
     mode="overwrite",
+    kms_key_name=None,
 ):
     j = {"name": key}
     if metadata:
@@ -2119,8 +2119,8 @@ async def simple_upload(
     consistency=None,
     content_type="application/octet-stream",
     fixed_key_metadata=None,
-    kms_key_name=None,
     mode="overwrite",
+    kms_key_name=None,
 ):
     checker = get_consistency_checker(consistency)
     path = f"{fs._location}/upload/storage/v1/b/{quote(bucket)}/o"

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -2093,7 +2093,7 @@ async def initiate_upload(
         j["metadata"] = metadata
     kw = {"ifGenerationMatch": "0"} if mode == "create" else {}
     if kms_key_name:
-        kw['kmsKeyName'] = kms_key_name
+        kw["kmsKeyName"] = kms_key_name
     j.update(_convert_fixed_key_metadata(fixed_key_metadata))
     headers, _ = await fs._call(
         method="POST",
@@ -2129,7 +2129,7 @@ async def simple_upload(
         metadata["metadata"] = metadatain
     kw = {"ifGenerationMatch": "0"} if mode == "create" else {}
     if kms_key_name:
-        kw['kmsKeyName'] = kms_key_name
+        kw["kmsKeyName"] = kms_key_name
     metadata.update(_convert_fixed_key_metadata(fixed_key_metadata))
     metadata = json.dumps(metadata)
     template = (

--- a/gcsfs/tests/settings.py
+++ b/gcsfs/tests/settings.py
@@ -3,4 +3,7 @@ import os
 TEST_BUCKET = os.getenv("GCSFS_TEST_BUCKET", "gcsfs_test")
 TEST_PROJECT = os.getenv("GCSFS_TEST_PROJECT", "project")
 TEST_REQUESTER_PAYS_BUCKET = "gcsfs_test_req_pay"
-TEST_KMS_KEY = os.getenv("GCSFS_TEST_KMS_KEY", f"projects/{TEST_PROJECT}/locations/us/keyRings/gcsfs_test/cryptKeys/gcsfs_test_key")
+TEST_KMS_KEY = os.getenv(
+    "GCSFS_TEST_KMS_KEY",
+    f"projects/{TEST_PROJECT}/locations/us/keyRings/gcsfs_test/cryptKeys/gcsfs_test_key",
+)

--- a/gcsfs/tests/settings.py
+++ b/gcsfs/tests/settings.py
@@ -3,3 +3,4 @@ import os
 TEST_BUCKET = os.getenv("GCSFS_TEST_BUCKET", "gcsfs_test")
 TEST_PROJECT = os.getenv("GCSFS_TEST_PROJECT", "project")
 TEST_REQUESTER_PAYS_BUCKET = "gcsfs_test_req_pay"
+TEST_KMS_KEY = os.getenv("GCSFS_TEST_KMS_KEY", f"projects/{TEST_PROJECT}/locations/us/keyRings/gcsfs_test/cryptKeys/gcsfs_test_key")

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -26,6 +26,7 @@ TEST_PROJECT = gcsfs.tests.settings.TEST_PROJECT
 TEST_REQUESTER_PAYS_BUCKET = gcsfs.tests.settings.TEST_REQUESTER_PAYS_BUCKET
 TEST_KMS_KEY = gcsfs.tests.settings.TEST_KMS_KEY
 
+
 def test_simple(gcs, monkeypatch):
     monkeypatch.setattr(GoogleCredentials, "tokens", None)
     gcs.ls(TEST_BUCKET)  # no error
@@ -94,7 +95,7 @@ def test_simple_upload_with_kms(gcs):
     with gcs.open(fn, "wb", content_type="text/plain", kms_key_name=TEST_KMS_KEY) as f:
         f.write(b"zz")
     assert gcs.cat(fn) == b"zz"
-    assert TEST_KMS_KEY in gcs.info(fn)['kmsKeyName']
+    assert TEST_KMS_KEY in gcs.info(fn)["kmsKeyName"]
 
 
 def test_large_upload(gcs):
@@ -118,10 +119,12 @@ def test_large_upload_with_kms(gcs):
     try:
         fn = TEST_BUCKET + "/test"
         d = b"7123" * 262144
-        with gcs.open(fn, "wb", content_type="application/octet-stream", kms_key_name=TEST_KMS_KEY) as f:
+        with gcs.open(
+            fn, "wb", content_type="application/octet-stream", kms_key_name=TEST_KMS_KEY
+        ) as f:
             f.write(d)
         assert gcs.cat(fn) == d
-        assert TEST_KMS_KEY in gcs.info(fn)['kmsKeyName']
+        assert TEST_KMS_KEY in gcs.info(fn)["kmsKeyName"]
     finally:
         gcsfs.core.GCS_MAX_BLOCK_SIZE = orig
 
@@ -176,13 +179,15 @@ def test_multi_upload_with_kms(gcs):
     assert gcs.cat(fn) == d + b"xx"
     assert gcs.info(fn)["contentType"] == "text/plain"
     # empty buffer on close
-    with gcs.open(fn, "wb", content_type="text/plain", block_size=2**19, kms_key_name=TEST_KMS_KEY) as f:
+    with gcs.open(
+        fn, "wb", content_type="text/plain", block_size=2**19, kms_key_name=TEST_KMS_KEY
+    ) as f:
         f.write(d)
         f.write(b"xx")
         f.write(d)
     assert gcs.cat(fn) == d + b"xx" + d
     assert gcs.info(fn)["contentType"] == "text/plain"
-    assert TEST_KMS_KEY in gcs.info(fn)['kmsKeyName']
+    assert TEST_KMS_KEY in gcs.info(fn)["kmsKeyName"]
 
     fn = TEST_BUCKET + "/test"
     d = b"01234567" * 2**15
@@ -193,7 +198,7 @@ def test_multi_upload_with_kms(gcs):
         f.write(b"xx")
     assert gcs.cat(fn) == d + b"xx"
     assert gcs.info(fn)["contentType"] == "application/octet-stream"
-    assert 'kmsKeyName' not in gcs.info(fn)
+    assert "kmsKeyName" not in gcs.info(fn)
     # empty buffer on close
     with gcs.open(fn, "wb", block_size=2**19) as f:
         f.write(d)

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -24,7 +24,7 @@ from gcsfs.tests.utils import tempdir, tmpfile
 TEST_BUCKET = gcsfs.tests.settings.TEST_BUCKET
 TEST_PROJECT = gcsfs.tests.settings.TEST_PROJECT
 TEST_REQUESTER_PAYS_BUCKET = gcsfs.tests.settings.TEST_REQUESTER_PAYS_BUCKET
-
+TEST_KMS_KEY = gcsfs.tests.settings.TEST_KMS_KEY
 
 def test_simple(gcs, monkeypatch):
     monkeypatch.setattr(GoogleCredentials, "tokens", None)
@@ -87,6 +87,16 @@ def test_simple_upload(gcs):
     assert gcs.cat(fn) == b"zz"
 
 
+def test_simple_upload_with_kms(gcs):
+    if not gcs.on_google:
+        pytest.skip("emulator does not support kmsKeyName")
+    fn = TEST_BUCKET + "/test"
+    with gcs.open(fn, "wb", content_type="text/plain", kms_key_name=TEST_KMS_KEY) as f:
+        f.write(b"zz")
+    assert gcs.cat(fn) == b"zz"
+    assert TEST_KMS_KEY in gcs.info(fn)['kmsKeyName']
+
+
 def test_large_upload(gcs):
     orig = gcsfs.core.GCS_MAX_BLOCK_SIZE
     gcsfs.core.GCS_MAX_BLOCK_SIZE = 262144  # minimum block size
@@ -96,6 +106,22 @@ def test_large_upload(gcs):
         with gcs.open(fn, "wb", content_type="application/octet-stream") as f:
             f.write(d)
         assert gcs.cat(fn) == d
+    finally:
+        gcsfs.core.GCS_MAX_BLOCK_SIZE = orig
+
+
+def test_large_upload_with_kms(gcs):
+    if not gcs.on_google:
+        pytest.skip("emulator does not support kmsKeyName")
+    orig = gcsfs.core.GCS_MAX_BLOCK_SIZE
+    gcsfs.core.GCS_MAX_BLOCK_SIZE = 262144  # minimum block size
+    try:
+        fn = TEST_BUCKET + "/test"
+        d = b"7123" * 262144
+        with gcs.open(fn, "wb", content_type="application/octet-stream", kms_key_name=TEST_KMS_KEY) as f:
+            f.write(d)
+        assert gcs.cat(fn) == d
+        assert TEST_KMS_KEY in gcs.info(fn)['kmsKeyName']
     finally:
         gcsfs.core.GCS_MAX_BLOCK_SIZE = orig
 
@@ -127,6 +153,47 @@ def test_multi_upload(gcs):
         f.write(b"xx")
     assert gcs.cat(fn) == d + b"xx"
     assert gcs.info(fn)["contentType"] == "application/octet-stream"
+    # empty buffer on close
+    with gcs.open(fn, "wb", block_size=2**19) as f:
+        f.write(d)
+        f.write(b"xx")
+        f.write(d)
+    assert gcs.cat(fn) == d + b"xx" + d
+    assert gcs.info(fn)["contentType"] == "application/octet-stream"
+
+
+def test_multi_upload_with_kms(gcs):
+    if not gcs.on_google:
+        pytest.skip("emulator does not support kmsKeyName")
+
+    fn = TEST_BUCKET + "/test"
+    d = b"01234567" * 2**15
+
+    # something to write on close
+    with gcs.open(fn, "wb", content_type="text/plain", block_size=2**18) as f:
+        f.write(d)
+        f.write(b"xx")
+    assert gcs.cat(fn) == d + b"xx"
+    assert gcs.info(fn)["contentType"] == "text/plain"
+    # empty buffer on close
+    with gcs.open(fn, "wb", content_type="text/plain", block_size=2**19, kms_key_name=TEST_KMS_KEY) as f:
+        f.write(d)
+        f.write(b"xx")
+        f.write(d)
+    assert gcs.cat(fn) == d + b"xx" + d
+    assert gcs.info(fn)["contentType"] == "text/plain"
+    assert TEST_KMS_KEY in gcs.info(fn)['kmsKeyName']
+
+    fn = TEST_BUCKET + "/test"
+    d = b"01234567" * 2**15
+
+    # something to write on close
+    with gcs.open(fn, "wb", block_size=2**18) as f:
+        f.write(d)
+        f.write(b"xx")
+    assert gcs.cat(fn) == d + b"xx"
+    assert gcs.info(fn)["contentType"] == "application/octet-stream"
+    assert 'kmsKeyName' not in gcs.info(fn)
     # empty buffer on close
     with gcs.open(fn, "wb", block_size=2**19) as f:
         f.write(d)

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -180,7 +180,11 @@ def test_multi_upload_with_kms(gcs):
     assert gcs.info(fn)["contentType"] == "text/plain"
     # empty buffer on close
     with gcs.open(
-        fn, "wb", content_type="text/plain", block_size=2**19, kms_key_name=TEST_KMS_KEY
+        fn,
+        "wb",
+        content_type="text/plain",
+        block_size=2**19,
+        kms_key_name=TEST_KMS_KEY,
     ) as f:
         f.write(d)
         f.write(b"xx")


### PR DESCRIPTION
Allows for creating files with a specific Cloud KMS key by passing a fully qualified resource path to the `kms_key_name` keyword argument.

I've attempted to add some basic tests for this functionality. `fake-gcs-server` does not seem to support KMS, so they're skipped unless running against the live API.

This is my first contribution to this project and I'm happy to address any concerns :)