### PR TITLE
Add multi-threaded fixed-duration read microbenchmarks

### DIFF
--- a/gcsfs/tests/perf/microbenchmarks/read/configs.yaml
+++ b/gcsfs/tests/perf/microbenchmarks/read/configs.yaml
@@ -22,3 +22,11 @@ scenarios:
     pattern: "rand"
     processes: [1, 16, 48]
     files: 1
+
+  - name: "read_seq_fixed_duration_multi_thread"
+    pattern: "seq"
+    threads: [32]
+
+  - name: "read_rand_fixed_duration_multi_thread"
+    pattern: "rand"
+    threads: [32]

--- a/gcsfs/tests/perf/microbenchmarks/read/test_read.py
+++ b/gcsfs/tests/perf/microbenchmarks/read/test_read.py
@@ -9,6 +9,7 @@ from gcsfs.tests.perf.microbenchmarks.read.configs import get_read_benchmark_cas
 from gcsfs.tests.perf.microbenchmarks.runner import (
     filter_test_cases,
     run_multi_process,
+    run_multi_threaded_fixed_duration,
     run_single_threaded_fixed_duration,
 )
 
@@ -58,7 +59,9 @@ def _random_read_worker(gcs, file_paths, chunk_size, offsets, runtime, block_siz
 
 
 all_benchmark_cases = get_read_benchmark_cases()
-single_threaded_cases, _, multi_process_cases = filter_test_cases(all_benchmark_cases)
+single_threaded_cases, multi_threaded_cases, multi_process_cases = filter_test_cases(
+    all_benchmark_cases
+)
 
 
 @pytest.mark.parametrize(
@@ -70,6 +73,37 @@ single_threaded_cases, _, multi_process_cases = filter_test_cases(all_benchmark_
 def test_read_single_threaded(benchmark, gcsfs_benchmark_read, monitor):
     gcs, file_paths, params = gcsfs_benchmark_read
 
+    op, op_args = _build_read_worker(params, gcs, file_paths)
+
+    run_single_threaded_fixed_duration(
+        benchmark, monitor, params, op, op_args, BENCHMARK_GROUP
+    )
+
+
+@pytest.mark.parametrize(
+    "gcsfs_benchmark_read",
+    multi_threaded_cases,
+    indirect=True,
+    ids=lambda p: p.name,
+)
+def test_read_multi_threaded(benchmark, gcsfs_benchmark_read, monitor):
+    gcs, file_paths, params = gcsfs_benchmark_read
+
+    args_list = []
+    for _ in range(params.threads):
+        thread_file_paths = list(file_paths)
+        random.shuffle(thread_file_paths)
+        _, op_args = _build_read_worker(params, gcs, thread_file_paths)
+        args_list.append(op_args)
+
+    op, _ = _build_read_worker(params, gcs, file_paths)
+
+    run_multi_threaded_fixed_duration(
+        benchmark, monitor, params, op, args_list, BENCHMARK_GROUP
+    )
+
+
+def _build_read_worker(params, gcs, file_paths):
     op = None
     block_size = params.block_size_bytes
     op_args = (gcs, file_paths, params.chunk_size_bytes, params.runtime, block_size)
@@ -87,10 +121,10 @@ def test_read_single_threaded(benchmark, gcsfs_benchmark_read, monitor):
             params.runtime,
             block_size,
         )
+    else:
+        raise ValueError(f"Unsupported read pattern: {params.pattern}")
 
-    run_single_threaded_fixed_duration(
-        benchmark, monitor, params, op, op_args, BENCHMARK_GROUP
-    )
+    return op, op_args
 
 
 def _process_worker_fixed_duration(

--- a/gcsfs/tests/perf/microbenchmarks/runner.py
+++ b/gcsfs/tests/perf/microbenchmarks/runner.py
@@ -82,6 +82,42 @@ def run_multi_threaded(
     publish_resource_metrics(benchmark, m)
 
 
+def run_multi_threaded_fixed_duration(
+    benchmark, monitor_cls, params, worker_func, args_list, benchmark_group
+):
+    """
+    Runs a multi-threaded benchmark for a fixed duration and records bytes per round.
+
+    Note: In gcsfs, while the workload submission is multi-threaded (using a ThreadPoolExecutor),
+    the actual execution of underlying requests in gcsfs is handled using multi-coroutines
+    running in a single background event loop thread.
+
+    Args:
+        worker_func: The function to run in each thread. It must return bytes processed.
+        args_list: A list of tuples, where each tuple contains arguments for one thread.
+    """
+    publish_benchmark_extra_info(benchmark, params, benchmark_group)
+
+    total_bytes_per_round = []
+    with monitor_cls() as m:
+        for round_num in range(params.rounds):
+            logging.info(
+                f"Multi-threaded fixed-duration {benchmark_group} benchmark: "
+                f"Starting round {round_num + 1}/{params.rounds}."
+            )
+            with ThreadPoolExecutor(max_workers=params.threads) as executor:
+                futures = [executor.submit(worker_func, *args) for args in args_list]
+                total_bytes_per_round.append(sum(f.result() for f in futures))
+
+    publish_fixed_duration_benchmark_extra_info(
+        benchmark, total_bytes_per_round, params
+    )
+    publish_resource_metrics(benchmark, m)
+
+    # This is to ensure the JSON report is generated correctly by pytest-benchmark
+    benchmark.pedantic(lambda: None, rounds=1, iterations=1, warmup_rounds=0)
+
+
 def run_multi_process(
     benchmark,
     monitor_cls,

--- a/gcsfs/tests/perf/microbenchmarks/test_configs.py
+++ b/gcsfs/tests/perf/microbenchmarks/test_configs.py
@@ -17,6 +17,7 @@ from gcsfs.tests.perf.microbenchmarks.read.configs import (
     get_read_benchmark_cases,
 )
 from gcsfs.tests.perf.microbenchmarks.rename.configs import get_rename_benchmark_cases
+from gcsfs.tests.perf.microbenchmarks.runner import filter_test_cases
 from gcsfs.tests.perf.microbenchmarks.write.configs import (
     WriteConfigurator,
     get_write_benchmark_cases,
@@ -100,6 +101,30 @@ def test_read_configurator(mock_config_dependencies):
     assert case.chunk_size_bytes == 16 * MB
     assert case.pattern == "seq"
     assert case.bucket_name == "test-bucket"
+
+
+def test_read_fixed_duration_multi_thread_config(mock_config_dependencies):
+    """Test that read fixed-duration multi-thread cases are generated and classified."""
+    with mock.patch("gcsfs.tests.perf.microbenchmarks.configs.BENCHMARK_FILTER", ""):
+        cases = get_read_benchmark_cases()
+
+    _, multi_thread_cases, _ = filter_test_cases(cases)
+    multi_thread_cases = [
+        case
+        for case in multi_thread_cases
+        if case.name.startswith("read_seq_fixed_duration_multi_thread")
+        or case.name.startswith("read_rand_fixed_duration_multi_thread")
+    ]
+
+    names = {case.name for case in multi_thread_cases}
+    assert any(
+        name.startswith("read_seq_fixed_duration_multi_thread") for name in names
+    )
+    assert any(
+        name.startswith("read_rand_fixed_duration_multi_thread") for name in names
+    )
+    assert {case.threads for case in multi_thread_cases} == {16}
+    assert {case.files for case in multi_thread_cases} == {16}
 
 
 def test_write_configurator(mock_config_dependencies):

--- a/gcsfs/tests/perf/microbenchmarks/test_configs.py
+++ b/gcsfs/tests/perf/microbenchmarks/test_configs.py
@@ -123,8 +123,8 @@ def test_read_fixed_duration_multi_thread_config(mock_config_dependencies):
     assert any(
         name.startswith("read_rand_fixed_duration_multi_thread") for name in names
     )
-    assert {case.threads for case in multi_thread_cases} == {16}
-    assert {case.files for case in multi_thread_cases} == {16}
+    assert {case.threads for case in multi_thread_cases} == {32}
+    assert {case.files for case in multi_thread_cases} == {32}
 
 
 def test_write_configurator(mock_config_dependencies):

--- a/gcsfs/tests/perf/microbenchmarks/test_runner.py
+++ b/gcsfs/tests/perf/microbenchmarks/test_runner.py
@@ -93,6 +93,35 @@ def test_run_multi_threaded(mock_benchmark, mock_monitor):
     assert worker_func.call_count == 2
 
 
+def test_run_multi_threaded_fixed_duration(mock_benchmark, mock_monitor):
+    params = MockParams(threads=2, rounds=3)
+    params.runtime = 30
+    # 2 threads and 3 rounds means worker_func is called 6 times in total (2 calls per round).
+    # Since worker_func returns sequential values:
+    # - Round 1: calls return 10 and 20 (Sum = 30)
+    # - Round 2: calls return 30 and 40 (Sum = 70)
+    # - Round 3: calls return 50 and 60 (Sum = 110)
+    worker_func = mock.Mock(side_effect=[10, 20, 30, 40, 50, 60])
+    args_list = [(1,), (2,)]
+
+    runner.run_multi_threaded_fixed_duration(
+        mock_benchmark, mock_monitor, params, worker_func, args_list, "read"
+    )
+
+    assert mock_benchmark.extra_info["threads"] == 2
+    assert mock_benchmark.group == "read"
+    # Verify that the sum of returns matches the expected values for each of the 3 rounds
+    assert mock_benchmark.extra_info["runs"] == [30, 70, 110]
+    assert mock_benchmark.extra_info["min_run"] == 30
+    assert mock_benchmark.extra_info["max_run"] == 110
+
+    mock_monitor.assert_called_once()
+    assert worker_func.call_count == 6
+    mock_benchmark.pedantic.assert_called_once_with(
+        mock.ANY, rounds=1, iterations=1, warmup_rounds=0
+    )
+
+
 @mock.patch("gcsfs.tests.perf.microbenchmarks.runner.multiprocessing")
 def test_run_multi_process(mock_mp, mock_benchmark, mock_monitor):
     params = MockParams(processes=2, rounds=2)


### PR DESCRIPTION
This PR introduces multi-threaded fixed-duration read microbenchmarks to evaluate the performance of read operations under concurrent workloads.

**Key changes:**
- Implemented multi-threaded fixed-duration reads in `runner.py`.
- Added support and test cases in `test_read.py`.
- Configured multi-threaded read cases to use 32 threads and 32 files in `test_configs.py`.

These benchmarks will provide better visibility into throughput and latency under high-concurrency settings.