### PR TITLE
Pass trailing / to createFolder as per documentation

### DIFF
--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -846,7 +846,7 @@ class ExtendedGcsFileSystem(GCSFileSystem):
     async def _create_hns_folder(self, path, bucket, key, create_parents):
         logger.debug(f"Using HNS-aware mkdir for '{path}'.")
         parent = f"projects/_/buckets/{bucket}"
-        folder_id = key.rstrip("/")
+        folder_id = key.rstrip("/") + "/"
         request = storage_control_v2.CreateFolderRequest(
             parent=parent,
             folder_id=folder_id,

--- a/gcsfs/tests/test_extended_hns_gcsfs.py
+++ b/gcsfs/tests/test_extended_hns_gcsfs.py
@@ -677,7 +677,7 @@ class TestExtendedGcsFileSystemMkdir:
         bucket, folder_path = dir_path.split("/", 1)
         return storage_control_v2.CreateFolderRequest(
             parent=f"projects/_/buckets/{bucket}",
-            folder_id=folder_path.rstrip("/"),
+            folder_id=folder_path.rstrip("/") + "/",
             recursive=recursive,
             request_id=FIXED_REQUEST_ID,
         )


### PR DESCRIPTION
The [documentation](https://github.com/googleapis/google-cloud-python/blob/main/packages/google-cloud-storage-control/google/cloud/storage_control_v2/types/storage_control.py#L203) for `createFolderRequest` specifies that a trailing prefix should be included. Although the functionality appears identical regardless of whether a trailing slash is present, I have updated the code to include it to ensure compliance with the documentation.