### PR TITLE
feat: Allow running E2E tests against fsspec HEAD

### DIFF
--- a/cloudbuild/e2e-tests-cloudbuild.yaml
+++ b/cloudbuild/e2e-tests-cloudbuild.yaml
@@ -18,6 +18,8 @@ substitutions:
   _SHORT_BUILD_ID: ${BUILD_ID:0:8}
   _SKIP_IF_FAILED: '[[ -f /workspace/FAILED ]] && echo "⚠️ Skipping: Previous failure" && exit 0'
   _TEST_ENV_VARS: "SHORT_BUILD_ID='${_SHORT_BUILD_ID}' PROJECT_ID='${PROJECT_ID}' REGION='${_REGION}' KEY_RING='${_GCSFS_KEY_RING_NAME}' KEY_NAME='${_GCSFS_KEY_NAME}'"
+  _INSTALL_FSSPEC_HEAD: "false"
+  _INSTALL_GCSFS_FROM_PYPI: "false"
 
 steps:
   # Generate a persistent SSH key for this build run.
@@ -78,7 +80,7 @@ steps:
           --zone=${_ZONE} \
           --internal-ip \
           --ssh-key-file=/workspace/.ssh/google_compute_engine \
-          --command="bash cloudbuild/setup_vm.sh" || { echo "setup-vm (setup script)" >> /workspace/FAILED; exit 1; }
+          --command="export INSTALL_FSSPEC_HEAD='${_INSTALL_FSSPEC_HEAD}' INSTALL_GCSFS_FROM_PYPI='${_INSTALL_GCSFS_FROM_PYPI}' && bash cloudbuild/setup_vm.sh" || { echo "setup-vm (setup script)" >> /workspace/FAILED; exit 1; }
     waitFor: ["create-resources", "generate-ssh-key"]
     allowFailure: true
 

--- a/cloudbuild/setup_vm.sh
+++ b/cloudbuild/setup_vm.sh
@@ -11,4 +11,15 @@ source env/bin/activate
 
 pip install --upgrade pip > /dev/null
 pip install pytest pytest-timeout pytest-subtests pytest-asyncio build hatchling hatch-vcs fusepy google-cloud-storage > /dev/null
-pip install -e . > /dev/null
+if [ "$INSTALL_GCSFS_FROM_PYPI" = "true" ]; then
+    echo '--- Installing gcsfs from PyPI ---'
+    pip install gcsfs > /dev/null
+else
+    echo '--- Installing gcsfs from local source ---'
+    pip install -e . > /dev/null
+fi
+
+if [ "$INSTALL_FSSPEC_HEAD" = "true" ]; then
+    echo '--- Installing fsspec HEAD ---'
+    pip install --force-reinstall git+https://github.com/fsspec/filesystem_spec.git > /dev/null
+fi


### PR DESCRIPTION
This PR adds the capability to run GCSFS end-to-end integration tests against the latest development head of fsspec. This enables setting up a nightly or scheduled pipeline to catch breaking changes in fsspec before they are released.

Added _INSTALL_FSSPEC_HEAD substitution variable (defaults to "false") and passed it to the remote VM setup script. This variable would be set to True from the nightly run trigger. If set to "true", it installs fsspec directly from its git repository using --force-reinstall to ensure the latest head is fetched. Also added a substitution variable to give flexibility to run against GCSFS latest released version or HEAD.

Currently, GCSFS tests run in every fsspec PR but are limited to the emulator and do not cover end-to-end testing against real GCS. Implementing this setup for nightly runs would help detect any fsspec changes that might break GCSFS.



