### PR TITLE
Fix Storage Control endpoint resolution for TPC

### DIFF
--- a/cloudbuild/setup_vm.sh
+++ b/cloudbuild/setup_vm.sh
@@ -22,4 +22,5 @@ fi
 if [ "$INSTALL_FSSPEC_HEAD" = "true" ]; then
     echo '--- Installing fsspec HEAD ---'
     pip install --force-reinstall git+https://github.com/fsspec/filesystem_spec.git > /dev/null
+    echo "fsspec version: $(python3 -c 'import fsspec; print(fsspec.__version__)')"
 fi

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -8,6 +8,7 @@ from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 from glob import has_magic
 
+import grpc
 from fsspec import asyn
 from fsspec.callbacks import NoOpCallback
 from google.api_core import exceptions as api_exceptions
@@ -188,7 +189,14 @@ class ExtendedGcsFileSystem(GCSFileSystem):
                 endpoint = self._location.split("://")[-1]
                 channel_kwargs["host"] = endpoint
 
-            channel = transport_cls.create_channel(**channel_kwargs)
+            if self._location and self._location.startswith("http://"):
+                host = channel_kwargs["host"]
+                channel = grpc.aio.insecure_channel(
+                    host, options=channel_kwargs.get("options")
+                )
+            else:
+                channel = transport_cls.create_channel(**channel_kwargs)
+
             transport = transport_cls(channel=channel)
             self._storage_control_client = storage_control_v2.StorageControlAsyncClient(
                 transport=transport

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -160,8 +160,8 @@ class ExtendedGcsFileSystem(GCSFileSystem):
         if self._grpc_client is None:
             client_options = ClientOptions(quota_project_id=self._user_project)
             if self._location:
-                # client_options expects only the host:port, without the protocol.
-                endpoint = self._location.split("://")[-1]
+                # client_options expects only the host:port, without any protocol or path components.
+                endpoint = self._location.split("://")[-1].split("/")[0]
                 client_options.api_endpoint = endpoint
             self._grpc_client = AsyncGrpcClient(
                 credentials=self.credential,
@@ -186,7 +186,8 @@ class ExtendedGcsFileSystem(GCSFileSystem):
                 "quota_project_id": self._user_project,
             }
             if self._location:
-                endpoint = self._location.split("://")[-1]
+                # Extract host:port safely (strips protocol and trailing URL paths if any).
+                endpoint = self._location.split("://")[-1].split("/")[0]
                 channel_kwargs["host"] = endpoint
 
             if self._location and self._location.startswith("http://"):

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -179,11 +179,16 @@ class ExtendedGcsFileSystem(GCSFileSystem):
                     "grpc_asyncio"
                 )
             )
-            channel = transport_cls.create_channel(
-                credentials=self.credential,
-                options=[("grpc.primary_user_agent", f"{USER_AGENT}/{version}")],
-                quota_project_id=self._user_project,
-            )
+            channel_kwargs = {
+                "credentials": self.credential,
+                "options": [("grpc.primary_user_agent", f"{USER_AGENT}/{version}")],
+                "quota_project_id": self._user_project,
+            }
+            if self._location:
+                endpoint = self._location.split("://")[-1]
+                channel_kwargs["host"] = endpoint
+
+            channel = transport_cls.create_channel(**channel_kwargs)
             transport = transport_cls(channel=channel)
             self._storage_control_client = storage_control_v2.StorageControlAsyncClient(
                 transport=transport

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -8,7 +8,6 @@ from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 from glob import has_magic
 
-import grpc
 from fsspec import asyn
 from fsspec.callbacks import NoOpCallback
 from google.api_core import exceptions as api_exceptions
@@ -190,13 +189,7 @@ class ExtendedGcsFileSystem(GCSFileSystem):
                 endpoint = self._location.split("://")[-1].split("/")[0]
                 channel_kwargs["host"] = endpoint
 
-            if self._location and self._location.startswith("http://"):
-                host = channel_kwargs["host"]
-                channel = grpc.aio.insecure_channel(
-                    host, options=channel_kwargs.get("options")
-                )
-            else:
-                channel = transport_cls.create_channel(**channel_kwargs)
+            channel = transport_cls.create_channel(**channel_kwargs)
 
             transport = transport_cls(channel=channel)
             self._storage_control_client = storage_control_v2.StorageControlAsyncClient(

--- a/gcsfs/tests/conftest.py
+++ b/gcsfs/tests/conftest.py
@@ -116,13 +116,13 @@ def stop_docker(container):
 
 @pytest.fixture(scope="session")
 def docker_gcs():
-    if "STORAGE_EMULATOR_HOST" in os.environ:
-        if not is_real_gcs():
-            params["token"] = "anon"
-        # assume using real API or otherwise have a server already set up
-        yield os.getenv("STORAGE_EMULATOR_HOST")
+    if not is_real_gcs():
+        params["token"] = "anon"
+
+    if "STORAGE_EMULATOR_HOST" in os.environ or is_real_gcs():
+        from gcsfs.core import _location
+        yield _location()
         return
-    params["token"] = "anon"
     container = "gcsfs_test"
     cmd = (
         "docker run -d -p 4443:4443 --name gcsfs_test fsouza/fake-gcs-server:latest -scheme "

--- a/gcsfs/tests/conftest.py
+++ b/gcsfs/tests/conftest.py
@@ -21,6 +21,8 @@ from gcsfs.tests.settings import (
     TEST_BUCKET,
     TEST_HNS_BUCKET,
     TEST_HNS_REQUESTER_PAYS_BUCKET,
+    TEST_PROJECT,
+    TEST_REGION,
     TEST_REQUESTER_PAYS_BUCKET,
     TEST_VERSIONED_BUCKET,
     TEST_ZONAL_BUCKET,
@@ -121,6 +123,7 @@ def docker_gcs():
 
     if "STORAGE_EMULATOR_HOST" in os.environ or is_real_gcs():
         from gcsfs.core import _location
+
         yield _location()
         return
     container = "gcsfs_test"
@@ -150,6 +153,10 @@ def docker_gcs():
 @pytest.fixture(scope="session")
 def gcs_factory(docker_gcs):
     params["endpoint_url"] = docker_gcs
+    if is_real_gcs():
+        params["default_location"] = TEST_REGION
+        params["project"] = TEST_PROJECT
+
 
     def factory(**kwargs):
         GCSFileSystem.clear_instance_cache()

--- a/gcsfs/tests/conftest.py
+++ b/gcsfs/tests/conftest.py
@@ -94,7 +94,7 @@ def _avoid_adc_timeout(monkeypatch):
     yield
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(scope="session", autouse=True)
 def _mock_get_bucket_type_on_emulator():
     """Mock _get_bucket_type to return UNKNOWN instantly on emulator."""
     if not is_real_gcs():

--- a/gcsfs/tests/conftest.py
+++ b/gcsfs/tests/conftest.py
@@ -157,7 +157,6 @@ def gcs_factory(docker_gcs):
         params["default_location"] = TEST_REGION
         params["project"] = TEST_PROJECT
 
-
     def factory(**kwargs):
         GCSFileSystem.clear_instance_cache()
         return fsspec.filesystem("gcs", **params, **kwargs)

--- a/gcsfs/tests/conftest.py
+++ b/gcsfs/tests/conftest.py
@@ -159,7 +159,9 @@ def gcs_factory(docker_gcs):
 
     def factory(**kwargs):
         GCSFileSystem.clear_instance_cache()
-        return fsspec.filesystem("gcs", **params, **kwargs)
+        combined_params = params.copy()
+        combined_params.update(kwargs)
+        return fsspec.filesystem("gcs", **combined_params)
 
     return factory
 

--- a/gcsfs/tests/integration/test_extended_hns.py
+++ b/gcsfs/tests/integration/test_extended_hns.py
@@ -17,8 +17,8 @@ import uuid
 
 import pytest
 
-from gcsfs.extended_gcsfs import BucketType, ExtendedGcsFileSystem
-from gcsfs.tests.settings import TEST_HNS_BUCKET, TEST_PROJECT
+from gcsfs.extended_gcsfs import BucketType
+from gcsfs.tests.settings import TEST_HNS_BUCKET
 from gcsfs.tests.utils import is_real_gcs
 
 should_run_hns = os.getenv("GCSFS_EXPERIMENTAL_ZB_HNS_SUPPORT", "false").lower() in (
@@ -1624,13 +1624,15 @@ class TestHNSFolderStatus:
 class TestExtendedGcsFileSystemHnsRequesterPays:
     """Integration tests for HNS operations on requester pays buckets."""
 
-    def test_hns_mkdir_fails_without_quota_project(self, hns_requester_pays_bucket):
+    def test_hns_mkdir_fails_without_quota_project(
+        self, hns_requester_pays_bucket, gcs_factory
+    ):
         """Test that HNS mkdir fails if quota project is not provided on a req pays bucket."""
 
         bucket = hns_requester_pays_bucket
         dir_path = f"{bucket}/new_dir_{uuid.uuid4().hex}"
 
-        fs = ExtendedGcsFileSystem(requester_pays=False)
+        fs = gcs_factory(requester_pays=False)
 
         # It raises ValueError with custom message if it detects requester pays
         with pytest.raises(ValueError) as excinfo:
@@ -1638,24 +1640,28 @@ class TestExtendedGcsFileSystemHnsRequesterPays:
 
         assert "Bucket is requester pays" in str(excinfo.value)
 
-    def test_hns_mkdir_succeeds_with_quota_project(self, hns_requester_pays_bucket):
+    def test_hns_mkdir_succeeds_with_quota_project(
+        self, hns_requester_pays_bucket, gcs_factory
+    ):
         """Test that HNS mkdir succeeds if quota project is provided on a req pays bucket."""
 
         bucket = hns_requester_pays_bucket
         dir_path = f"{bucket}/new_dir_{uuid.uuid4().hex}"
 
         # Pass project explicitly to ensure it's used as quota_project_id
-        fs = ExtendedGcsFileSystem(project=TEST_PROJECT, requester_pays=True)
+        fs = gcs_factory(requester_pays=True)
 
         fs.mkdir(dir_path)
         # Invalidate cache to force reading from backend
         fs.invalidate_cache()
         assert fs.isdir(dir_path)
 
-    def test_hns_bucket_type_detection_with_req_pays(self, hns_requester_pays_bucket):
+    def test_hns_bucket_type_detection_with_req_pays(
+        self, hns_requester_pays_bucket, gcs_factory
+    ):
         """Test that hns apis are invoked and return HNS when req pays is enabled."""
 
-        fs = ExtendedGcsFileSystem(project=TEST_PROJECT, requester_pays=True)
+        fs = gcs_factory(requester_pays=True)
 
         # Clear cache to force lookup
         fs._storage_layout_cache.clear()

--- a/gcsfs/tests/settings.py
+++ b/gcsfs/tests/settings.py
@@ -14,6 +14,7 @@ TEST_VERSIONED_BUCKET = _get_bucket_name(
 TEST_HNS_BUCKET = _get_bucket_name("GCSFS_HNS_TEST_BUCKET", "gcsfs_hns_test")
 TEST_ZONAL_BUCKET = _get_bucket_name("GCSFS_ZONAL_TEST_BUCKET", "gcsfs_zonal_test")
 TEST_PROJECT = os.getenv("GCSFS_TEST_PROJECT", "project")
+TEST_REGION = os.getenv("GCSFS_TEST_REGION", "us-central1")
 TEST_REQUESTER_PAYS_BUCKET = _get_bucket_name(
     "GCSFS_TEST_REQ_PAYS_BUCKET", "gcsfs_test_req_pays"
 )

--- a/gcsfs/tests/settings.py
+++ b/gcsfs/tests/settings.py
@@ -23,7 +23,7 @@ TEST_HNS_REQUESTER_PAYS_BUCKET = _get_bucket_name(
 )
 TEST_KMS_KEY = os.getenv(
     "GCSFS_TEST_KMS_KEY",
-    f"projects/{TEST_PROJECT}/locations/us/keyRings/gcsfs_test/cryptKeys/gcsfs_test_key",
+    f"projects/{TEST_PROJECT}/locations/{TEST_REGION}/keyRings/gcsfs_test/cryptoKeys/gcsfs_test_key",
 )
 
 # =============================================================================

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -1841,8 +1841,8 @@ def test_user_project_fallback_google_default(monkeypatch):
 
 
 @pytest.mark.parametrize("requester_pays", [True, TEST_PROJECT])
-def test_requester_pays_cat(requester_pays_bucket, requester_pays):
-    gcs = GCSFileSystem(requester_pays=requester_pays)
+def test_requester_pays_cat(gcs_factory, requester_pays_bucket, requester_pays):
+    gcs = gcs_factory(requester_pays=requester_pays)
     file_path = f"{requester_pays_bucket}/test_file.txt"
     data = b"test data requester pays"
 
@@ -1850,14 +1850,14 @@ def test_requester_pays_cat(requester_pays_bucket, requester_pays):
     assert gcs.cat(file_path) == data
 
 
-def test_requester_pays_fails_without_user_project(requester_pays_bucket):
+def test_requester_pays_fails_without_user_project(requester_pays_bucket, gcs_factory):
     """Test that operations on a requester-pays bucket fail if the flag is not set."""
-    fs = GCSFileSystem(requester_pays=False)
+    fs = gcs_factory(requester_pays=False)
     with pytest.raises(ValueError, match="Bucket is requester pays"):
         fs.ls(requester_pays_bucket)
 
 
-def test_fs_requester_pays_on_bucket_without_requester_pays(gcs, gcs_factory):
+def test_fs_requester_pays_on_bucket_without_requester_pays(gcs_factory):
     """Test that metadata and data operations work when fs has requester_pays=True
     but the bucket does not have requester-pays enabled."""
     fs = gcs_factory(requester_pays=True)

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -2486,6 +2486,7 @@ def test_default_gcp_universe(monkeypatch):
     # Make sure we simulate a mock less connection
     monkeypatch.delenv("STORAGE_EMULATOR_HOST", raising=False)
     monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+    monkeypatch.delenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN", raising=False)
 
     fs = fsspec.filesystem("gcs", token="anon")
     assert fs.base == "https://storage.googleapis.com/storage/v1/"

--- a/gcsfs/tests/test_extended_hns_gcsfs.py
+++ b/gcsfs/tests/test_extended_hns_gcsfs.py
@@ -2182,6 +2182,7 @@ async def test_get_control_plane_client_quota_project_id(
     "endpoint_url, env_updates, expected_host, expected_insecure",
     [
         ("https://my-endpoint.com", {}, "my-endpoint.com", False),
+        ("https://my-endpoint.com/storage/v1/", {}, "my-endpoint.com", False),
         (
             None,
             {
@@ -2196,6 +2197,15 @@ async def test_get_control_plane_client_quota_project_id(
             {
                 "GOOGLE_CLOUD_UNIVERSE_DOMAIN": "apis-tpczero.goog",
                 "STORAGE_EMULATOR_HOST": "http://my-emulator.com",
+            },
+            "my-emulator.com",
+            True,
+        ),
+        (
+            None,
+            {
+                "GOOGLE_CLOUD_UNIVERSE_DOMAIN": "apis-tpczero.goog",
+                "STORAGE_EMULATOR_HOST": "http://my-emulator.com/storage/v1/",
             },
             "my-emulator.com",
             True,

--- a/gcsfs/tests/test_extended_hns_gcsfs.py
+++ b/gcsfs/tests/test_extended_hns_gcsfs.py
@@ -2173,6 +2173,54 @@ async def test_get_control_plane_client_quota_project_id(
         assert kwargs["quota_project_id"] == expected_quota_project
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "endpoint_url, env_updates, expected_host",
+    [
+        ("https://my-endpoint.com", {}, "my-endpoint.com"),
+        (
+            None,
+            {"GOOGLE_CLOUD_UNIVERSE_DOMAIN": "apis-tpczero.goog"},
+            "storage.apis-tpczero.goog",
+        ),
+        (None, {"STORAGE_EMULATOR_HOST": "my-emulator.com"}, "my-emulator.com"),
+        (None, {"STORAGE_EMULATOR_HOST": "http://my-emulator.com"}, "my-emulator.com"),
+        (None, {}, "storage.googleapis.com"),
+    ],
+)
+async def test_get_control_plane_client_endpoint(
+    endpoint_url, env_updates, expected_host
+):
+    fs_kwargs = {"token": "anon"}
+    if endpoint_url:
+        fs_kwargs["endpoint_url"] = endpoint_url
+
+    fs = ExtendedGcsFileSystem(**fs_kwargs)
+
+    mock_transport_cls = mock.Mock()
+    mock_channel = mock.Mock()
+    mock_transport_cls.create_channel.return_value = mock_channel
+
+    import os
+
+    with (
+        mock.patch.object(
+            storage_control_v2.StorageControlAsyncClient,
+            "get_transport_class",
+            return_value=mock_transport_cls,
+        ),
+        mock.patch.dict(os.environ, env_updates),
+    ):
+        # Clear cached client to force re-initialization
+        fs._storage_control_client = None
+
+        await fs._get_control_plane_client()
+
+        mock_transport_cls.create_channel.assert_called_once()
+        kwargs = mock_transport_cls.create_channel.call_args.kwargs
+        assert kwargs.get("host") == expected_host
+
+
 def test_extended_gcsfs_retry_init():
     fs = ExtendedGcsFileSystem(token="anon", retry_timeout=20.0, retry_initial=4.0)
     assert fs.retry_config["timeout"] == 20.0

--- a/gcsfs/tests/test_extended_hns_gcsfs.py
+++ b/gcsfs/tests/test_extended_hns_gcsfs.py
@@ -2175,9 +2175,9 @@ async def test_get_control_plane_client_quota_project_id(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "endpoint_url, env_updates, expected_host",
+    "endpoint_url, env_updates, expected_host, expected_insecure",
     [
-        ("https://my-endpoint.com", {}, "my-endpoint.com"),
+        ("https://my-endpoint.com", {}, "my-endpoint.com", False),
         (
             None,
             {
@@ -2185,28 +2185,38 @@ async def test_get_control_plane_client_quota_project_id(
                 "STORAGE_EMULATOR_HOST": "",
             },
             "storage.apis-tpczero.goog",
+            False,
         ),
         (
             None,
             {
                 "GOOGLE_CLOUD_UNIVERSE_DOMAIN": "apis-tpczero.goog",
-                "STORAGE_EMULATOR_HOST": "my-emulator.com",
+                "STORAGE_EMULATOR_HOST": "http://my-emulator.com",
             },
             "my-emulator.com",
+            True,
         ),
-        (None, {"STORAGE_EMULATOR_HOST": "my-emulator.com"}, "my-emulator.com"),
-        (None, {"STORAGE_EMULATOR_HOST": "http://my-emulator.com"}, "my-emulator.com"),
-        (None, {"STORAGE_EMULATOR_HOST": ""}, "storage.googleapis.com"),
+        (
+            None,
+            {"STORAGE_EMULATOR_HOST": "http://my-emulator.com"},
+            "my-emulator.com",
+            True,
+        ),
+        (
+            None,
+            {"STORAGE_EMULATOR_HOST": "https://my-emulator.com"},
+            "my-emulator.com",
+            False,
+        ),
+        (None, {"STORAGE_EMULATOR_HOST": ""}, "storage.googleapis.com", False),
     ],
 )
 async def test_get_control_plane_client_endpoint(
-    endpoint_url, env_updates, expected_host
+    endpoint_url, env_updates, expected_host, expected_insecure
 ):
     fs_kwargs = {"token": "anon"}
     if endpoint_url:
         fs_kwargs["endpoint_url"] = endpoint_url
-
-    fs = ExtendedGcsFileSystem(**fs_kwargs)
 
     mock_transport_cls = mock.Mock()
     mock_channel = mock.Mock()
@@ -2220,16 +2230,22 @@ async def test_get_control_plane_client_endpoint(
             "get_transport_class",
             return_value=mock_transport_cls,
         ),
+        mock.patch("grpc.aio.insecure_channel") as mock_insecure_channel,
         mock.patch.dict(os.environ, env_updates),
     ):
-        # Clear cached client to force re-initialization
-        fs._storage_control_client = None
+        ExtendedGcsFileSystem.clear_instance_cache()
+        fs = ExtendedGcsFileSystem(**fs_kwargs)
 
         await fs._get_control_plane_client()
 
-        mock_transport_cls.create_channel.assert_called_once()
-        kwargs = mock_transport_cls.create_channel.call_args.kwargs
-        assert kwargs.get("host") == expected_host
+        if expected_insecure:
+            mock_insecure_channel.assert_called_once_with(
+                expected_host, options=mock.ANY
+            )
+        else:
+            mock_transport_cls.create_channel.assert_called_once()
+            kwargs = mock_transport_cls.create_channel.call_args.kwargs
+            assert kwargs.get("host") == expected_host
 
 
 def test_extended_gcsfs_retry_init():

--- a/gcsfs/tests/test_extended_hns_gcsfs.py
+++ b/gcsfs/tests/test_extended_hns_gcsfs.py
@@ -2153,25 +2153,26 @@ async def test_get_control_plane_client_quota_project_id(
     requester_pays, expected_quota_project
 ):
 
-    ExtendedGcsFileSystem.clear_instance_cache()
-    fs = ExtendedGcsFileSystem(project="my-project", requester_pays=requester_pays)
+    with mock.patch.dict(os.environ, {"STORAGE_EMULATOR_HOST": ""}):
+        ExtendedGcsFileSystem.clear_instance_cache()
+        fs = ExtendedGcsFileSystem(project="my-project", requester_pays=requester_pays)
 
-    mock_transport_cls = mock.Mock()
-    mock_channel = mock.Mock()
-    mock_transport_cls.create_channel.return_value = mock_channel
+        mock_transport_cls = mock.Mock()
+        mock_channel = mock.Mock()
+        mock_transport_cls.create_channel.return_value = mock_channel
 
-    with mock.patch.object(
-        storage_control_v2.StorageControlAsyncClient,
-        "get_transport_class",
-        return_value=mock_transport_cls,
-    ) as mock_get_transport:
+        with mock.patch.object(
+            storage_control_v2.StorageControlAsyncClient,
+            "get_transport_class",
+            return_value=mock_transport_cls,
+        ) as mock_get_transport:
 
-        await fs._get_control_plane_client()
+            await fs._get_control_plane_client()
 
-        mock_get_transport.assert_called_once_with("grpc_asyncio")
-        mock_transport_cls.create_channel.assert_called_once()
-        kwargs = mock_transport_cls.create_channel.call_args.kwargs
-        assert kwargs["quota_project_id"] == expected_quota_project
+            mock_get_transport.assert_called_once_with("grpc_asyncio")
+            mock_transport_cls.create_channel.assert_called_once()
+            kwargs = mock_transport_cls.create_channel.call_args.kwargs
+            assert kwargs["quota_project_id"] == expected_quota_project
 
 
 @pytest.mark.asyncio

--- a/gcsfs/tests/test_extended_hns_gcsfs.py
+++ b/gcsfs/tests/test_extended_hns_gcsfs.py
@@ -2180,12 +2180,23 @@ async def test_get_control_plane_client_quota_project_id(
         ("https://my-endpoint.com", {}, "my-endpoint.com"),
         (
             None,
-            {"GOOGLE_CLOUD_UNIVERSE_DOMAIN": "apis-tpczero.goog"},
+            {
+                "GOOGLE_CLOUD_UNIVERSE_DOMAIN": "apis-tpczero.goog",
+                "STORAGE_EMULATOR_HOST": "",
+            },
             "storage.apis-tpczero.goog",
+        ),
+        (
+            None,
+            {
+                "GOOGLE_CLOUD_UNIVERSE_DOMAIN": "apis-tpczero.goog",
+                "STORAGE_EMULATOR_HOST": "my-emulator.com",
+            },
+            "my-emulator.com",
         ),
         (None, {"STORAGE_EMULATOR_HOST": "my-emulator.com"}, "my-emulator.com"),
         (None, {"STORAGE_EMULATOR_HOST": "http://my-emulator.com"}, "my-emulator.com"),
-        (None, {}, "storage.googleapis.com"),
+        (None, {"STORAGE_EMULATOR_HOST": ""}, "storage.googleapis.com"),
     ],
 )
 async def test_get_control_plane_client_endpoint(

--- a/gcsfs/tests/test_extended_hns_gcsfs.py
+++ b/gcsfs/tests/test_extended_hns_gcsfs.py
@@ -31,6 +31,8 @@ pytestmark = pytest.mark.skipif(
     not should_run, reason=f"Skipping tests: {REQUIRED_ENV_VAR} env variable is not set"
 )
 
+ORIGINAL_GET_BUCKET_TYPE = ExtendedGcsFileSystem._get_bucket_type
+
 FIXED_UUID = uuid.UUID("00000000-0000-0000-0000-000000000000")
 FIXED_REQUEST_ID = str(FIXED_UUID)
 
@@ -2336,7 +2338,7 @@ class TestExtendedGcsFileSystemBucketType:
         """Override the global session mock to allow testing the real _get_bucket_type."""
         with mock.patch(
             "gcsfs.extended_gcsfs.ExtendedGcsFileSystem._get_bucket_type",
-            new=ExtendedGcsFileSystem._get_bucket_type,
+            new=ORIGINAL_GET_BUCKET_TYPE,
         ):
             yield
 

--- a/gcsfs/tests/test_extended_hns_gcsfs.py
+++ b/gcsfs/tests/test_extended_hns_gcsfs.py
@@ -2153,6 +2153,7 @@ async def test_get_control_plane_client_quota_project_id(
     requester_pays, expected_quota_project
 ):
 
+    ExtendedGcsFileSystem.clear_instance_cache()
     fs = ExtendedGcsFileSystem(project="my-project", requester_pays=requester_pays)
 
     mock_transport_cls = mock.Mock()

--- a/gcsfs/tests/test_extended_hns_gcsfs.py
+++ b/gcsfs/tests/test_extended_hns_gcsfs.py
@@ -2326,3 +2326,93 @@ class TestStorageControlRetryExecution:
             mock_create.assert_called_once()
             kwargs = mock_create.call_args.kwargs
             assert kwargs["timeout"] == 30.0  # STORAGE_CONTROL_RPC_TIMEOUT
+
+
+class TestExtendedGcsFileSystemBucketType:
+    """Unit tests for ExtendedGcsFileSystem _get_bucket_type and grpc_client."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_get_bucket_type_on_emulator(self):
+        """Override the global session mock to allow testing the real _get_bucket_type."""
+        with mock.patch(
+            "gcsfs.extended_gcsfs.ExtendedGcsFileSystem._get_bucket_type",
+            new=ExtendedGcsFileSystem._get_bucket_type,
+        ):
+            yield
+
+    @pytest.fixture
+    def extended_gcsfs(self):
+        ExtendedGcsFileSystem.clear_instance_cache()
+        return ExtendedGcsFileSystem(token="anon")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "location_type, hns_enabled, expected_bucket_type",
+        [
+            ("zone", None, BucketType.ZONAL_HIERARCHICAL),
+            ("region", True, BucketType.HIERARCHICAL),
+            ("region", False, BucketType.NON_HIERARCHICAL),
+        ],
+    )
+    async def test_get_bucket_type_detection(
+        self, extended_gcsfs, location_type, hns_enabled, expected_bucket_type
+    ):
+        fs = extended_gcsfs
+        mock_response = mock.Mock()
+        mock_response.location_type = location_type
+        if hns_enabled is not None:
+            mock_response.hierarchical_namespace = mock.Mock(enabled=hns_enabled)
+
+        with mock.patch.object(
+            fs, "_get_control_plane_client", new_callable=mock.AsyncMock
+        ) as mock_client_getter:
+            mock_client = mock_client_getter.return_value
+            mock_client.get_storage_layout = mock.AsyncMock(return_value=mock_response)
+
+            bucket_type = await fs._get_bucket_type("test-bucket")
+            assert bucket_type == expected_bucket_type
+
+            if location_type == "zone":
+                mock_client.get_storage_layout.assert_awaited_once_with(
+                    name="projects/_/buckets/test-bucket/storageLayout",
+                    retry=mock.ANY,
+                    timeout=mock.ANY,
+                )
+
+    @pytest.mark.asyncio
+    async def test_get_bucket_type_not_found(self, extended_gcsfs, caplog):
+        import logging
+
+        fs = extended_gcsfs
+
+        with mock.patch.object(
+            fs, "_get_control_plane_client", new_callable=mock.AsyncMock
+        ) as mock_client_getter:
+            mock_client = mock_client_getter.return_value
+            mock_client.get_storage_layout = mock.AsyncMock(
+                side_effect=api_exceptions.NotFound("Not Found")
+            )
+
+            with caplog.at_level(logging.WARNING, logger="gcsfs"):
+                bucket_type = await fs._get_bucket_type("missing-bucket")
+                assert bucket_type == BucketType.UNKNOWN
+                assert "not found or you lack permissions" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_get_bucket_type_general_exception(self, extended_gcsfs, caplog):
+        import logging
+
+        fs = extended_gcsfs
+
+        with mock.patch.object(
+            fs, "_get_control_plane_client", new_callable=mock.AsyncMock
+        ) as mock_client_getter:
+            mock_client = mock_client_getter.return_value
+            mock_client.get_storage_layout = mock.AsyncMock(
+                side_effect=Exception("Error")
+            )
+
+            with caplog.at_level(logging.WARNING, logger="gcsfs"):
+                bucket_type = await fs._get_bucket_type("error-bucket")
+                assert bucket_type == BucketType.UNKNOWN
+                assert "Could not determine bucket type" in caplog.text

--- a/gcsfs/tests/test_extended_hns_gcsfs.py
+++ b/gcsfs/tests/test_extended_hns_gcsfs.py
@@ -2179,10 +2179,10 @@ async def test_get_control_plane_client_quota_project_id(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "endpoint_url, env_updates, expected_host, expected_insecure",
+    "endpoint_url, env_updates, expected_host",
     [
-        ("https://my-endpoint.com", {}, "my-endpoint.com", False),
-        ("https://my-endpoint.com/storage/v1/", {}, "my-endpoint.com", False),
+        ("https://my-endpoint.com", {}, "my-endpoint.com"),
+        ("https://my-endpoint.com/storage/v1/", {}, "my-endpoint.com"),
         (
             None,
             {
@@ -2190,7 +2190,6 @@ async def test_get_control_plane_client_quota_project_id(
                 "STORAGE_EMULATOR_HOST": "",
             },
             "storage.apis-tpczero.goog",
-            False,
         ),
         (
             None,
@@ -2199,7 +2198,6 @@ async def test_get_control_plane_client_quota_project_id(
                 "STORAGE_EMULATOR_HOST": "http://my-emulator.com",
             },
             "my-emulator.com",
-            True,
         ),
         (
             None,
@@ -2208,25 +2206,22 @@ async def test_get_control_plane_client_quota_project_id(
                 "STORAGE_EMULATOR_HOST": "http://my-emulator.com/storage/v1/",
             },
             "my-emulator.com",
-            True,
         ),
         (
             None,
             {"STORAGE_EMULATOR_HOST": "http://my-emulator.com"},
             "my-emulator.com",
-            True,
         ),
         (
             None,
             {"STORAGE_EMULATOR_HOST": "https://my-emulator.com"},
             "my-emulator.com",
-            False,
         ),
-        (None, {"STORAGE_EMULATOR_HOST": ""}, "storage.googleapis.com", False),
+        (None, {"STORAGE_EMULATOR_HOST": ""}, "storage.googleapis.com"),
     ],
 )
 async def test_get_control_plane_client_endpoint(
-    endpoint_url, env_updates, expected_host, expected_insecure
+    endpoint_url, env_updates, expected_host
 ):
     fs_kwargs = {"token": "anon"}
     if endpoint_url:
@@ -2244,7 +2239,6 @@ async def test_get_control_plane_client_endpoint(
             "get_transport_class",
             return_value=mock_transport_cls,
         ),
-        mock.patch("grpc.aio.insecure_channel") as mock_insecure_channel,
         mock.patch.dict(os.environ, env_updates),
     ):
         ExtendedGcsFileSystem.clear_instance_cache()
@@ -2252,14 +2246,9 @@ async def test_get_control_plane_client_endpoint(
 
         await fs._get_control_plane_client()
 
-        if expected_insecure:
-            mock_insecure_channel.assert_called_once_with(
-                expected_host, options=mock.ANY
-            )
-        else:
-            mock_transport_cls.create_channel.assert_called_once()
-            kwargs = mock_transport_cls.create_channel.call_args.kwargs
-            assert kwargs.get("host") == expected_host
+        mock_transport_cls.create_channel.assert_called_once()
+        kwargs = mock_transport_cls.create_channel.call_args.kwargs
+        assert kwargs.get("host") == expected_host
 
 
 def test_extended_gcsfs_retry_init():

--- a/gcsfs/tests/utils.py
+++ b/gcsfs/tests/utils.py
@@ -44,4 +44,13 @@ def tmpfile(extension="", dir=None):
 
 def is_real_gcs():
     """Checks if tests are explicitly running against real GCS."""
-    return os.environ.get("STORAGE_EMULATOR_HOST") == "https://storage.googleapis.com"
+    if (
+        "STORAGE_EMULATOR_HOST" not in os.environ
+        and "GOOGLE_CLOUD_UNIVERSE_DOMAIN" not in os.environ
+    ):
+        return False
+
+    from gcsfs.core import _location
+
+    host = _location()
+    return host.startswith("https://")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,4 +73,4 @@ log_cli_level = "DEBUG"
 
 [tool.isort]
 profile = "black"
-known_third_party = ["aiohttp", "click", "decorator", "fsspec", "fuse", "google", "google_auth_oauthlib", "numpy", "prettytable", "psutil", "pytest", "pytest_asyncio", "requests", "resource_monitor", "yaml"]
+known_third_party = ["aiohttp", "click", "decorator", "fsspec", "fuse", "google", "google_auth_oauthlib", "grpc", "numpy", "prettytable", "psutil", "pytest", "pytest_asyncio", "requests", "resource_monitor", "yaml"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,4 +73,4 @@ log_cli_level = "DEBUG"
 
 [tool.isort]
 profile = "black"
-known_third_party = ["aiohttp", "click", "decorator", "fsspec", "fuse", "google", "google_auth_oauthlib", "grpc", "numpy", "prettytable", "psutil", "pytest", "pytest_asyncio", "requests", "resource_monitor", "yaml"]
+known_third_party = ["aiohttp", "click", "decorator", "fsspec", "fuse", "google", "google_auth_oauthlib", "numpy", "prettytable", "psutil", "pytest", "pytest_asyncio", "requests", "resource_monitor", "yaml"]


### PR DESCRIPTION
This PR fixes the endpoint resolution for the Storage Control API in ExtendedGcsFileSystem to support TPC environments correctly.

Changes
- gcsfs/extended_gcsfs.py: Refactored _get_control_plane_client to use self._location for deriving secure or insecure channel endpoints dynamically
- gcsfs/tests/test_extended_hns_gcsfs.py: Added test_get_control_plane_client_endpoint to cover explicit endpoint, universe domain, emulator, and default fallback scenarios.
- cloudbuild/setup_vm.sh: Added a log to print the fsspec version after installing it from head, to help debug CI issues.
- Improved is_real_gcs() to dynamically detect custom universes using _location().
- Configured gcs_factory to inject default project and location parameters to prevent location and project validation errors in private clouds. In TPC universe, providing a location is must while creating the buckets unlike standard production where it has a default region
