### PR TITLE
Use pytest markers to gate Rapid/HNS tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,8 @@ jobs:
       - name: Run Extended tests (Zonal & HNS Enabled)
         run: |
           export GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/gcsfs/tests/fake-service-account-credentials.json
-          export GCSFS_EXPERIMENTAL_ZB_HNS_SUPPORT="true"
+          export GCSFS_RUN_HNS_TESTS="true"
+          export GCSFS_RUN_RAPID_TESTS="true"
           pytest -vv -s \
             --cov=gcsfs --cov-append --cov-report=xml \
             --log-format="%(asctime)s %(levelname)s %(message)s" \

--- a/cloudbuild/run_tests.sh
+++ b/cloudbuild/run_tests.sh
@@ -39,6 +39,8 @@ case "$TEST_SUITE" in
     export GCSFS_HNS_TEST_BUCKET="gcsfs-test-zonal-${SHORT_BUILD_ID}"
     export GCSFS_HNS_TEST_REQ_PAYS_BUCKET="gcsfs-test-zonal-${SHORT_BUILD_ID}"
     ulimit -n 4096
+    export GCSFS_RUN_HNS_TESTS="true"
+    export GCSFS_RUN_RAPID_TESTS="true"
     export GCSFS_EXPERIMENTAL_ZB_HNS_SUPPORT='true'
     # Excludes tests related to requster pays as Zonal buckets do not support requester pays feature
     pytest "${ARGS[@]}" \
@@ -56,6 +58,7 @@ case "$TEST_SUITE" in
     export GCSFS_HNS_TEST_BUCKET="gcsfs-test-hns-${SHORT_BUILD_ID}"
     export GCSFS_TEST_REQ_PAYS_BUCKET="gcsfs-test-hns-req-pay-${SHORT_BUILD_ID}"
     export GCSFS_HNS_TEST_REQ_PAYS_BUCKET="gcsfs-test-hns-req-pay-${SHORT_BUILD_ID}"
+    export GCSFS_RUN_HNS_TESTS="true"
     export GCSFS_EXPERIMENTAL_ZB_HNS_SUPPORT='true'
     # Excludes tests that are not applicable to HNS buckets:
     # - test_extended_gcsfs.py, test_zonal_file.py: Zonal bucket specific tests which won't work on HNS bucket.

--- a/gcsfs/tests/conftest.py
+++ b/gcsfs/tests/conftest.py
@@ -29,6 +29,25 @@ from gcsfs.tests.settings import (
 )
 from gcsfs.tests.utils import is_real_gcs
 
+# Bucket type helpers
+is_real_gcs_bucket = is_real_gcs()
+is_hns_bucket = os.environ.get("GCSFS_RUN_HNS_TESTS", "false").lower() in ("true", "1")
+is_rapid_bucket = os.environ.get("GCSFS_RUN_RAPID_TESTS", "false").lower() in ("true", "1")
+
+# Skip markers for test decoration
+requires_real_gcs = pytest.mark.skipif(
+    not is_real_gcs_bucket,
+    reason="Requires real GCS (STORAGE_EMULATOR_HOST must be https://storage.googleapis.com)",
+)
+requires_hns = pytest.mark.skipif(
+    not is_hns_bucket,
+    reason="Requires HNS support (GCSFS_HNS_TEST_BUCKET env var must be set)",
+)
+requires_rapid = pytest.mark.skipif(
+    not is_rapid_bucket,
+    reason="Requires zonal support (GCSFS_RAPID_TEST_BUCKET env var must be set)",
+)
+
 files = {
     "test/accounts.1.json": (
         b'{"amount": 100, "name": "Alice"}\n'
@@ -581,3 +600,4 @@ def pytest_ignore_collect(collection_path, config):
                     return True
 
     return None
+

--- a/gcsfs/tests/conftest.py
+++ b/gcsfs/tests/conftest.py
@@ -32,7 +32,10 @@ from gcsfs.tests.utils import is_real_gcs
 # Bucket type helpers
 is_real_gcs_bucket = is_real_gcs()
 is_hns_bucket = os.environ.get("GCSFS_RUN_HNS_TESTS", "false").lower() in ("true", "1")
-is_rapid_bucket = os.environ.get("GCSFS_RUN_RAPID_TESTS", "false").lower() in ("true", "1")
+is_rapid_bucket = os.environ.get("GCSFS_RUN_RAPID_TESTS", "false").lower() in (
+    "true",
+    "1",
+)
 
 # Skip markers for test decoration
 requires_real_gcs = pytest.mark.skipif(
@@ -41,11 +44,11 @@ requires_real_gcs = pytest.mark.skipif(
 )
 requires_hns = pytest.mark.skipif(
     not is_hns_bucket,
-    reason="Requires HNS support (GCSFS_HNS_TEST_BUCKET env var must be set)",
+    reason="Requires HNS support (GCSFS_RUN_HNS_TESTS env var must be set)",
 )
 requires_rapid = pytest.mark.skipif(
     not is_rapid_bucket,
-    reason="Requires zonal support (GCSFS_RAPID_TEST_BUCKET env var must be set)",
+    reason="Requires zonal support (GCSFS_RUN_RAPID_TESTS env var must be set)",
 )
 
 files = {
@@ -600,4 +603,3 @@ def pytest_ignore_collect(collection_path, config):
                     return True
 
     return None
-

--- a/gcsfs/tests/integration/test_async_gcsfs.py
+++ b/gcsfs/tests/integration/test_async_gcsfs.py
@@ -18,9 +18,7 @@ import pytest
 import pytest_asyncio
 
 from gcsfs.extended_gcsfs import ExtendedGcsFileSystem
-from gcsfs.tests.conftest import requires_hns
-from gcsfs.tests.conftest import requires_rapid
-from gcsfs.tests.conftest import requires_real_gcs
+from gcsfs.tests.conftest import requires_hns, requires_rapid, requires_real_gcs
 from gcsfs.tests.settings import TEST_HNS_BUCKET
 
 pytestmark = [requires_real_gcs, requires_hns, requires_rapid]

--- a/gcsfs/tests/integration/test_async_gcsfs.py
+++ b/gcsfs/tests/integration/test_async_gcsfs.py
@@ -12,14 +12,15 @@ These tests require specific configuration:
 - The `GCSFS_EXPERIMENTAL_ZB_HNS_SUPPORT` environment variable must be 'true'.
 """
 
-import os
 import uuid
 
 import pytest
 import pytest_asyncio
 
 from gcsfs.extended_gcsfs import ExtendedGcsFileSystem
-from gcsfs.tests.conftest import requires_real_gcs, requires_hns, requires_rapid
+from gcsfs.tests.conftest import requires_hns
+from gcsfs.tests.conftest import requires_rapid
+from gcsfs.tests.conftest import requires_real_gcs
 from gcsfs.tests.settings import TEST_HNS_BUCKET
 
 pytestmark = [requires_real_gcs, requires_hns, requires_rapid]

--- a/gcsfs/tests/integration/test_async_gcsfs.py
+++ b/gcsfs/tests/integration/test_async_gcsfs.py
@@ -19,26 +19,10 @@ import pytest
 import pytest_asyncio
 
 from gcsfs.extended_gcsfs import ExtendedGcsFileSystem
+from gcsfs.tests.conftest import requires_real_gcs, requires_hns, requires_rapid
 from gcsfs.tests.settings import TEST_HNS_BUCKET
-from gcsfs.tests.utils import is_real_gcs
 
-REQUIRED_ENV_VAR = "GCSFS_EXPERIMENTAL_ZB_HNS_SUPPORT"
-
-# If the condition is True, only then tests in this file are run.
-should_run = os.getenv(REQUIRED_ENV_VAR, "false").lower() in (
-    "true",
-    "1",
-)
-pytestmark = [
-    pytest.mark.skipif(
-        not should_run,
-        reason=f"Skipping tests: {REQUIRED_ENV_VAR} env variable is not set",
-    ),
-    pytest.mark.skipif(
-        not is_real_gcs(),
-        reason="Skipping tests on emulator, requires real GCS.",
-    ),
-]
+pytestmark = [requires_real_gcs, requires_hns, requires_rapid]
 
 
 @pytest_asyncio.fixture

--- a/gcsfs/tests/integration/test_extended_hns.py
+++ b/gcsfs/tests/integration/test_extended_hns.py
@@ -18,19 +18,10 @@ import uuid
 import pytest
 
 from gcsfs.extended_gcsfs import BucketType
-from gcsfs.tests.settings import TEST_HNS_BUCKET
-from gcsfs.tests.utils import is_real_gcs
+from gcsfs.tests.conftest import requires_hns, requires_real_gcs
+from gcsfs.tests.settings import TEST_HNS_BUCKET, TEST_PROJECT
 
-should_run_hns = os.getenv("GCSFS_EXPERIMENTAL_ZB_HNS_SUPPORT", "false").lower() in (
-    "true",
-    "1",
-)
-
-# Skip these tests if not running against a real GCS backend or if experimentation flag is not set.
-pytestmark = pytest.mark.skipif(
-    not is_real_gcs() or not should_run_hns,
-    reason="This test class is for real GCS HNS buckets only and requires experimental flag.",
-)
+pytestmark = [requires_real_gcs, requires_hns]
 
 
 class TestExtendedGcsFileSystemMv:

--- a/gcsfs/tests/integration/test_extended_hns.py
+++ b/gcsfs/tests/integration/test_extended_hns.py
@@ -17,8 +17,7 @@ import uuid
 import pytest
 
 from gcsfs.extended_gcsfs import BucketType
-from gcsfs.tests.conftest import requires_hns
-from gcsfs.tests.conftest import requires_real_gcs
+from gcsfs.tests.conftest import requires_hns, requires_real_gcs
 from gcsfs.tests.settings import TEST_HNS_BUCKET
 
 pytestmark = [requires_real_gcs, requires_hns]

--- a/gcsfs/tests/integration/test_extended_hns.py
+++ b/gcsfs/tests/integration/test_extended_hns.py
@@ -12,14 +12,14 @@ that has been extended or modified to support HNS features, such as `mv` (rename
 and `mkdir`.
 """
 
-import os
 import uuid
 
 import pytest
 
 from gcsfs.extended_gcsfs import BucketType
-from gcsfs.tests.conftest import requires_hns, requires_real_gcs
-from gcsfs.tests.settings import TEST_HNS_BUCKET, TEST_PROJECT
+from gcsfs.tests.conftest import requires_hns
+from gcsfs.tests.conftest import requires_real_gcs
+from gcsfs.tests.settings import TEST_HNS_BUCKET
 
 pytestmark = [requires_real_gcs, requires_hns]
 

--- a/gcsfs/tests/test_extended_gcsfs.py
+++ b/gcsfs/tests/test_extended_gcsfs.py
@@ -30,7 +30,7 @@ from gcsfs.extended_gcsfs import (
     simple_upload,
     upload_chunk,
 )
-from gcsfs.tests.conftest import csv_files, files, text_files, requires_rapid
+from gcsfs.tests.conftest import csv_files, files, requires_rapid, text_files
 from gcsfs.tests.settings import TEST_BUCKET, TEST_ZONAL_BUCKET
 from gcsfs.tests.utils import is_real_gcs, tempdir, tmpfile
 from gcsfs.zb_hns_utils import MRDPool

--- a/gcsfs/tests/test_extended_gcsfs.py
+++ b/gcsfs/tests/test_extended_gcsfs.py
@@ -30,7 +30,7 @@ from gcsfs.extended_gcsfs import (
     simple_upload,
     upload_chunk,
 )
-from gcsfs.tests.conftest import csv_files, files, text_files
+from gcsfs.tests.conftest import csv_files, files, text_files, requires_rapid
 from gcsfs.tests.settings import TEST_BUCKET, TEST_ZONAL_BUCKET
 from gcsfs.tests.utils import is_real_gcs, tempdir, tmpfile
 from gcsfs.zb_hns_utils import MRDPool
@@ -45,20 +45,11 @@ file2 = "test/accounts.2.json"
 file2_path = f"{TEST_ZONAL_BUCKET}/{file2}"
 json_data2 = files[file2]
 
-REQUIRED_ENV_VAR = "GCSFS_EXPERIMENTAL_ZB_HNS_SUPPORT"
-
 a = TEST_ZONAL_BUCKET + "/zonal/test/a"
 b = TEST_ZONAL_BUCKET + "/zonal/test/b"
 c = TEST_ZONAL_BUCKET + "/zonal/test/c"
 
-# If the condition is True, only then tests in this file are run.
-should_run = os.getenv(REQUIRED_ENV_VAR, "false").lower() in (
-    "true",
-    "1",
-)
-pytestmark = pytest.mark.skipif(
-    not should_run, reason=f"Skipping tests: {REQUIRED_ENV_VAR} env variable is not set"
-)
+pytestmark = [requires_rapid]
 
 
 @pytest.fixture

--- a/gcsfs/tests/test_extended_gcsfs_unit.py
+++ b/gcsfs/tests/test_extended_gcsfs_unit.py
@@ -18,7 +18,7 @@ from gcsfs.extended_gcsfs import (
     simple_upload,
     upload_chunk,
 )
-from gcsfs.tests.conftest import csv_files, files
+from gcsfs.tests.conftest import csv_files, files, requires_rapid
 from gcsfs.tests.settings import TEST_BUCKET, TEST_ZONAL_BUCKET
 from gcsfs.tests.test_extended_gcsfs import gcs_bucket_mocks  # noqa: F401
 from gcsfs.tests.utils import is_real_gcs, tmpfile
@@ -33,18 +33,8 @@ a = TEST_ZONAL_BUCKET + "/zonal/test/a"
 b = TEST_ZONAL_BUCKET + "/zonal/test/b"
 c = TEST_ZONAL_BUCKET + "/zonal/test/c"
 
-REQUIRED_ENV_VAR = "GCSFS_EXPERIMENTAL_ZB_HNS_SUPPORT"
-
-# If the condition is True, only then tests in this file are run.
-should_run = os.getenv(REQUIRED_ENV_VAR, "false").lower() in (
-    "true",
-    "1",
-)
 pytestmark = [
-    pytest.mark.skipif(
-        not should_run,
-        reason=f"Skipping tests: {REQUIRED_ENV_VAR} env variable is not set",
-    ),
+    requires_rapid,
     pytest.mark.skipif(
         is_real_gcs(),
         reason="Contains Unit tests using mocks, does not require testing on real GCS.",

--- a/gcsfs/tests/test_extended_gcsfs_unit.py
+++ b/gcsfs/tests/test_extended_gcsfs_unit.py
@@ -9,22 +9,18 @@ from google.cloud.storage.asyncio.async_multi_range_downloader import (
 )
 from google.cloud.storage.exceptions import DataCorruption
 
-from gcsfs.checkers import ConsistencyChecker
-from gcsfs.checkers import MD5Checker
-from gcsfs.checkers import SizeChecker
-from gcsfs.extended_gcsfs import BucketType
-from gcsfs.extended_gcsfs import ExtendedGcsFileSystem
-from gcsfs.extended_gcsfs import initiate_upload
-from gcsfs.extended_gcsfs import simple_upload
-from gcsfs.extended_gcsfs import upload_chunk
-from gcsfs.tests.conftest import csv_files
-from gcsfs.tests.conftest import files
-from gcsfs.tests.conftest import requires_rapid
-from gcsfs.tests.settings import TEST_BUCKET
-from gcsfs.tests.settings import TEST_ZONAL_BUCKET
+from gcsfs.checkers import ConsistencyChecker, MD5Checker, SizeChecker
+from gcsfs.extended_gcsfs import (
+    BucketType,
+    ExtendedGcsFileSystem,
+    initiate_upload,
+    simple_upload,
+    upload_chunk,
+)
+from gcsfs.tests.conftest import csv_files, files, requires_rapid
+from gcsfs.tests.settings import TEST_BUCKET, TEST_ZONAL_BUCKET
 from gcsfs.tests.test_extended_gcsfs import gcs_bucket_mocks  # noqa: F401
-from gcsfs.tests.utils import is_real_gcs
-from gcsfs.tests.utils import tmpfile
+from gcsfs.tests.utils import is_real_gcs, tmpfile
 
 file = "test/accounts.1.json"
 file_path = f"{TEST_ZONAL_BUCKET}/{file}"

--- a/gcsfs/tests/test_extended_gcsfs_unit.py
+++ b/gcsfs/tests/test_extended_gcsfs_unit.py
@@ -1,7 +1,6 @@
 # Unit tests for ExtendedGCSFileSystem.
 import io
 import logging
-import os
 from unittest import mock
 
 import pytest
@@ -10,18 +9,22 @@ from google.cloud.storage.asyncio.async_multi_range_downloader import (
 )
 from google.cloud.storage.exceptions import DataCorruption
 
-from gcsfs.checkers import ConsistencyChecker, MD5Checker, SizeChecker
-from gcsfs.extended_gcsfs import (
-    BucketType,
-    ExtendedGcsFileSystem,
-    initiate_upload,
-    simple_upload,
-    upload_chunk,
-)
-from gcsfs.tests.conftest import csv_files, files, requires_rapid
-from gcsfs.tests.settings import TEST_BUCKET, TEST_ZONAL_BUCKET
+from gcsfs.checkers import ConsistencyChecker
+from gcsfs.checkers import MD5Checker
+from gcsfs.checkers import SizeChecker
+from gcsfs.extended_gcsfs import BucketType
+from gcsfs.extended_gcsfs import ExtendedGcsFileSystem
+from gcsfs.extended_gcsfs import initiate_upload
+from gcsfs.extended_gcsfs import simple_upload
+from gcsfs.extended_gcsfs import upload_chunk
+from gcsfs.tests.conftest import csv_files
+from gcsfs.tests.conftest import files
+from gcsfs.tests.conftest import requires_rapid
+from gcsfs.tests.settings import TEST_BUCKET
+from gcsfs.tests.settings import TEST_ZONAL_BUCKET
 from gcsfs.tests.test_extended_gcsfs import gcs_bucket_mocks  # noqa: F401
-from gcsfs.tests.utils import is_real_gcs, tmpfile
+from gcsfs.tests.utils import is_real_gcs
+from gcsfs.tests.utils import tmpfile
 
 file = "test/accounts.1.json"
 file_path = f"{TEST_ZONAL_BUCKET}/{file}"

--- a/gcsfs/tests/test_extended_hns_gcsfs.py
+++ b/gcsfs/tests/test_extended_hns_gcsfs.py
@@ -17,19 +17,11 @@ from google.cloud import storage_control_v2
 
 from gcsfs.extended_gcsfs import BucketType, ExtendedGcsFileSystem
 from gcsfs.retry import DEFAULT_RETRY_CONFIG, HttpError
+from gcsfs.tests.conftest import requires_hns
 from gcsfs.tests.settings import TEST_HNS_BUCKET
 from gcsfs.tests.utils import is_real_gcs
 
-REQUIRED_ENV_VAR = "GCSFS_EXPERIMENTAL_ZB_HNS_SUPPORT"
-
-# If the condition is True, only then tests in this file are run.
-should_run = os.getenv(REQUIRED_ENV_VAR, "false").lower() in (
-    "true",
-    "1",
-)
-pytestmark = pytest.mark.skipif(
-    not should_run, reason=f"Skipping tests: {REQUIRED_ENV_VAR} env variable is not set"
-)
+pytestmark = [requires_hns]
 
 ORIGINAL_GET_BUCKET_TYPE = ExtendedGcsFileSystem._get_bucket_type
 

--- a/gcsfs/tests/test_zonal_file.py
+++ b/gcsfs/tests/test_zonal_file.py
@@ -8,22 +8,14 @@ from google.cloud.storage.asyncio.async_appendable_object_writer import (
     _DEFAULT_FLUSH_INTERVAL_BYTES,
 )
 
+from gcsfs.tests.conftest import requires_rapid
 from gcsfs.tests.settings import TEST_ZONAL_BUCKET
 from gcsfs.tests.utils import is_real_gcs, tempdir, tmpfile
 from gcsfs.zonal_file import ZonalFile
 
 test_data = b"hello world"
 
-REQUIRED_ENV_VAR = "GCSFS_EXPERIMENTAL_ZB_HNS_SUPPORT"
-
-# If the condition is True, only then tests in this file are run.
-should_run = os.getenv(REQUIRED_ENV_VAR, "false").lower() in (
-    "true",
-    "1",
-)
-pytestmark = pytest.mark.skipif(
-    not should_run, reason=f"Skipping tests: {REQUIRED_ENV_VAR} env variable is not set"
-)
+pytestmark = [requires_rapid]
 
 
 @pytest.fixture

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,11 @@ version-file = "gcsfs/_version.py"
 addopts = "--color=yes --timeout=1800"
 log_cli = false
 log_cli_level = "DEBUG"
+markers = [
+    "requires_real_gcs: mark test as requiring real Google Cloud Storage",
+    "requires_hns: mark test as requiring Hierarchical Namespace (HNS) bucket support",
+    "requires_rapid: mark test as requiring zonal (Rapid) bucket support",
+]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
- This PR removes HNS and Rapid support experimemtal feature flag as primary gate for HNS/Rapid tests.
- This PR refactors the test suite by introducing standardized pytest markers (requires_real_gcs, requires_hns, and requires_rapid) to replace manual environment variable checks for bucket types. 
- These markers are defined in conftest.py and registered in pyproject.toml. 
