### PR TITLE
Update default value of mrd_pool_size in micro benchmark to None and add pool parameters to benchmark schema

### DIFF
--- a/cloudbuild/benchmarks/benchmarks_schema.json
+++ b/cloudbuild/benchmarks/benchmarks_schema.json
@@ -20,6 +20,8 @@
       {"name": "files", "type": "INTEGER"},
       {"name": "folders", "type": "STRING"},
       {"name": "mem_max", "type": "FLOAT"},
+      {"name": "mrd_pool_cache_size", "type": "STRING"},
+      {"name": "mrd_pool_size", "type": "STRING"},
       {"name": "net_throughput_s", "type": "FLOAT"},
       {"name": "pattern", "type": "STRING"},
       {"name": "processes", "type": "INTEGER"},

--- a/gcsfs/tests/perf/microbenchmarks/read/configs.py
+++ b/gcsfs/tests/perf/microbenchmarks/read/configs.py
@@ -22,7 +22,7 @@ class ReadConfigurator(BaseBenchmarkConfigurator):
         )
         block_sizes_mb = scenario.get("block_sizes_mb", [5])
         mrd_pool_cache_sizes = scenario.get("mrd_pool_cache_sizes", [16])
-        mrd_pool_sizes = scenario.get("mrd_pool_sizes", [1])
+        mrd_pool_sizes = scenario.get("mrd_pool_sizes", [None])
 
         pattern = scenario.get("pattern", "seq")
         runtime = common_config.get("runtime", 30)

--- a/gcsfs/tests/perf/microbenchmarks/read/parameters.py
+++ b/gcsfs/tests/perf/microbenchmarks/read/parameters.py
@@ -21,5 +21,5 @@ class ReadBenchmarkParameters(IOBenchmarkParameters):
     # Size of the MRD pool cache. Default is 16.
     mrd_pool_cache_size: int = 16
 
-    # Size of the MRD pool. Default is 1.
-    mrd_pool_size: int = 1
+    # Size of the MRD pool. Default is None.
+    mrd_pool_size: int | None = None

--- a/gcsfs/tests/perf/microbenchmarks/test_configs.py
+++ b/gcsfs/tests/perf/microbenchmarks/test_configs.py
@@ -95,7 +95,7 @@ def test_read_configurator(mock_config_dependencies):
     case = cases[0]
     assert (
         case.name
-        == "read_test_mrd_pool_cache_16_mrd_pool_1_1procs_1threads_1MB_file_16MB_chunk_16MB_block_regional"
+        == "read_test_mrd_pool_cache_16_mrd_pool_None_1procs_1threads_1MB_file_16MB_chunk_16MB_block_regional"
     )
     assert case.file_size_bytes == 1 * MB
     assert case.block_size_bytes == 16 * MB


### PR DESCRIPTION
- The read microbenchmarks were previously defaulting mrd_pool_size to 1. It will overrode the environment's DEFAULT_GCSFS_CONCURRENCY and forced the use of only a single gRPC stream. I have changed the default to None, allowing it to correctly inherit environment concurrency settings and restore multi-stream gRPC read performance with the default config.
- Updates the BigQuery staging schema definition to declare both mrd_pool_cache_size and mrd_pool_size as STRING fields. This allows the ingestion pipeline to gracefully parse new results.