### PR TITLE
Fix swapped arguments in _process_object inside inventory_report.py

### DIFF
--- a/gcsfs/inventory_report.py
+++ b/gcsfs/inventory_report.py
@@ -512,13 +512,13 @@ class InventoryReport:
         # need to fetch the name.
         if use_snapshot_listing is True:
             obj = gcs_file_system._process_object(
+                bucket,
                 {
                     key: value
                     for key, value in zip(
                         metadata_fields, inventory_report_line.strip().split(delimiter)
                     )
                 },
-                bucket,
             )
         else:
             obj = {"name": inventory_report_line.strip().split(delimiter)[obj_name_idx]}

--- a/gcsfs/tests/test_inventory_report.py
+++ b/gcsfs/tests/test_inventory_report.py
@@ -422,7 +422,7 @@ class TestInventoryReport:
 
         # Mock GCSFileSystem.
         gcs_file_system = mock.MagicMock(spec=GCSFileSystem)
-        gcs_file_system._process_object = mock.Mock(side_effect=lambda obj, bucket: obj)
+        gcs_file_system._process_object = mock.Mock(side_effect=lambda bucket, obj: obj)
 
         result = InventoryReport._parse_inventory_report_line(
             inventory_report_line=inventory_report_line,


### PR DESCRIPTION
The `gcs_file_system._process_object` function has the signature `def _process_object(self, bucket, object_metadata)`. However, `_parse_inventory_report_line` was calling it with `(object_metadata, bucket)`, which caused a `ValueError`/`AttributeError`. This commit swaps the arguments to correctly match the signature, and updates the tests which were incorrectly mocking the old behavior.