### PR TITLE
Fix concurrent MRD reuse by tracking in-flight MRDs on close

### DIFF
--- a/gcsfs/tests/test_zb_hns_utils.py
+++ b/gcsfs/tests/test_zb_hns_utils.py
@@ -750,7 +750,7 @@ async def test_mrd_pool_close_donates_and_repools(mock_cache):
     await mrd_pool.close()
 
     assert mrd_pool._closed is True
-    assert mrd_pool._free_mrds.qsize() == 2
+    assert mrd_pool._free_mrds.qsize() == 0
     assert len(mock_cache.queue) == 2
     assert captured == [(mrd_pool._key, [mock_mrd_a, mock_mrd_b])]
 

--- a/gcsfs/zb_hns_utils.py
+++ b/gcsfs/zb_hns_utils.py
@@ -446,8 +446,11 @@ class MRDPool:
             # Only return the MRD to the free queue if we were the ones who took it out
             # or if we just spawned it. This prevents duplicate entries in the queue
             # when multiple concurrent tasks share the same MRD via round-robin.
-            if (create_new or used_from_queue) and not self._closed:
-                self._free_mrds.put_nowait(mrd)
+            if create_new or used_from_queue:
+                if self._closed:
+                    await close_mrd(mrd)
+                else:
+                    self._free_mrds.put_nowait(mrd)
 
     async def close(self):
         """
@@ -459,15 +462,19 @@ class MRDPool:
         async with self._lock:
             if self._closed:
                 return
+            self._closed = True
+
+            free_mrds = []
+            while not self._free_mrds.empty():
+                free_mrds.append(self._free_mrds.get_nowait())
 
             try:
                 if self._cache is not None:
-                    await self._cache.release(self._key, self._all_mrds)
+                    await self._cache.release(self._key, free_mrds)
                 else:
-                    await _close_mrds(self._all_mrds, raise_exception=True)
+                    await _close_mrds(free_mrds, raise_exception=True)
             finally:
                 self._all_mrds.clear()
-                self._closed = True
 
 
 def _drain_queue(q):

--- a/test_dummy.py
+++ b/test_dummy.py
@@ -1,5 +1,0 @@
-import pytest
-
-@pytest.mark.asyncio
-async def test_dummy():
-    assert True

--- a/test_dummy.py
+++ b/test_dummy.py
@@ -1,0 +1,5 @@
+import pytest
+
+@pytest.mark.asyncio
+async def test_dummy():
+    assert True


### PR DESCRIPTION
Fix concurrent MRD reuse by tracking in-flight MRDs on close

MRDPool.close() previously extracted all instantiated MRDs (`self._all_mrds`), including ones actively yielded by `get_mrd()`, and donated them back to the MRDPoolCache. A concurrent task could acquire the active MRD, driving it from two contexts simultaneously and causing corrupted reads or gRPC errors.

This change drains only `_free_mrds` on `close()`. The pool is marked closed so any in-flight MRDs eventually execute `await close_mrd(mrd)` in their `finally` block instead of being donated to the cache, preventing reuse.
