### PR TITLE
Fix off-by-one error in upload_chunk shortfall recursion

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -2449,7 +2449,7 @@ async def upload_chunk(fs, location, data, offset, size, content_type):
         shortfall = (offset + l - 1) - end
         if shortfall:
             return await upload_chunk(
-                fs, location, data[-shortfall:], end, size, content_type
+                fs, location, data[-shortfall:], end + 1, size, content_type
             )
     return json.loads(txt) if txt else None
 

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -1313,6 +1313,46 @@ def test_get_put_file_in_dir(protocol, gcs):
         assert gcs.cat(protocol + TEST_BUCKET + "/temp_dir/accounts.1.json") == data1
 
 
+@pytest.mark.asyncio
+async def test_upload_chunk_shortfall():
+    from gcsfs.core import upload_chunk
+
+    fs_mock = mock.AsyncMock()
+
+    data = b"0123456789"
+    location = "http://mock-location"
+    offset = 0
+    size = 10
+    content_type = "application/octet-stream"
+
+    call_count = 0
+
+    async def mock_call(method, loc, headers=None, data=None, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return {"Range": "bytes=0-4"}, None
+        else:
+            return {}, '{"generation": "12345"}'
+
+    fs_mock._call.side_effect = mock_call
+
+    result = await upload_chunk(fs_mock, location, data, offset, size, content_type)
+
+    assert result == {"generation": "12345"}
+    assert call_count == 2
+
+    call_args_list = fs_mock._call.call_args_list
+
+    args1, kwargs1 = call_args_list[0]
+    assert kwargs1["headers"]["Content-Range"] == "bytes 0-9/10"
+
+    args2, kwargs2 = call_args_list[1]
+    assert kwargs2["headers"]["Content-Range"] == "bytes 5-9/10"
+
+    assert kwargs2["data"].getvalue() == b"56789"
+
+
 @pytest.mark.parametrize("protocol", ["", "gs://", "gcs://"])
 def test_put_file_resumable_upload_cleanup_on_chunk_failure(protocol, gcs):
     rpath = protocol + TEST_BUCKET + "/resumable_cleanup_test"

--- a/gcsfs/tests/test_extended_gcsfs_unit.py
+++ b/gcsfs/tests/test_extended_gcsfs_unit.py
@@ -763,7 +763,7 @@ def test_finalize_mrd_pool_cache_current_loop_running(monkeypatch):
     ExtendedGcsFileSystem._finalize_mrd_pool_cache(mock_loop, mock_pool)
 
     # Verify that run_coroutine_threadsafe was called
-    mock_run_coroutine_threadsafe.assert_called_once()
+    mock_run_coroutine_threadsafe.assert_called()
     args, _ = mock_run_coroutine_threadsafe.call_args
     assert args[1] == mock_current_loop
 

--- a/gcsfs/tests/test_extended_gcsfs_unit.py
+++ b/gcsfs/tests/test_extended_gcsfs_unit.py
@@ -763,7 +763,7 @@ def test_finalize_mrd_pool_cache_current_loop_running(monkeypatch):
     ExtendedGcsFileSystem._finalize_mrd_pool_cache(mock_loop, mock_pool)
 
     # Verify that run_coroutine_threadsafe was called
-    mock_run_coroutine_threadsafe.assert_called()
+    mock_run_coroutine_threadsafe.assert_called_once()
     args, _ = mock_run_coroutine_threadsafe.call_args
     assert args[1] == mock_current_loop
 


### PR DESCRIPTION
Fixed an off-by-one error in the `upload_chunk` shortfall recursion logic. When a chunk was partially accepted by GCS, the `upload_chunk` function erroneously passed `end` instead of `end + 1` to the recursive call, causing data corruption due to shifted bytes. This change makes it consistent with `GCSFile._upload_chunk`, which already handles the offset correctly.
