### PR TITLE
Refcount in-flight MRDs in MRDPool

### DIFF
--- a/gcsfs/tests/test_zb_hns_utils.py
+++ b/gcsfs/tests/test_zb_hns_utils.py
@@ -19,14 +19,9 @@ generation = "12345"
 
 @pytest.mark.asyncio
 async def test_shared_mrd_closed_only_by_last_holder():
-    from unittest import mock
-
-    from gcsfs.zb_hns_utils import MRDPool
-
     class FakeMRD:
         def __init__(self):
             self.persisted_size = 0
-            self.bucket_name, self.object_name = "b", "o"
             self.close_count = 0
 
         async def close(self):

--- a/gcsfs/tests/test_zb_hns_utils.py
+++ b/gcsfs/tests/test_zb_hns_utils.py
@@ -18,6 +18,39 @@ generation = "12345"
 
 
 @pytest.mark.asyncio
+async def test_shared_mrd_closed_only_by_last_holder():
+    from unittest import mock
+    from gcsfs.zb_hns_utils import MRDPool
+
+    class FakeMRD:
+        def __init__(self):
+            self.persisted_size = 0
+            self.bucket_name, self.object_name = "b", "o"
+            self.close_count = 0
+        async def close(self):
+            self.close_count += 1
+
+    pool = MRDPool(mock.Mock(), "b", "o", 1, pool_size=1, cache=None)
+    pool.mrd_supports_multi_request = True
+    pool._create_mrd = mock.AsyncMock(side_effect=lambda: FakeMRD())
+
+    await pool.initialize()
+
+    cm_a = pool.get_mrd(); mrd_a = await cm_a.__aenter__()   # exclusive
+    cm_b = pool.get_mrd(); mrd_b = await cm_b.__aenter__()   # round-robin share
+    assert mrd_a is mrd_b                                    # same MRD shared
+
+    await pool.close()
+    assert mrd_a.close_count == 0                            # still in use -> not closed
+
+    await cm_a.__aexit__(None, None, None)
+    assert mrd_a.close_count == 0                            # B still holds it
+
+    await cm_b.__aexit__(None, None, None)
+    assert mrd_a.close_count == 1                            # last holder closes it exactly once
+
+
+@pytest.mark.asyncio
 async def test_download_range():
     """
     Tests that download_range calls mrd.download_ranges with the correct
@@ -295,9 +328,12 @@ def mock_gcsfs():
     new_callable=mock.AsyncMock,
 )
 async def test_mrd_pool_scaling(create_mrd_mock, mock_gcsfs):
-    mrd_instance_mock = mock.AsyncMock()
-    mrd_instance_mock.persisted_size = 1024
-    create_mrd_mock.return_value = mrd_instance_mock
+    def mock_mrd_factory(*args, **kwargs):
+        m = mock.AsyncMock()
+        m.persisted_size = 1024
+        return m
+
+    create_mrd_mock.side_effect = mock_mrd_factory
 
     pool = MRDPool(mock_gcsfs, "bucket", "obj", "123", pool_size=2)
 
@@ -307,12 +343,11 @@ async def test_mrd_pool_scaling(create_mrd_mock, mock_gcsfs):
     create_mrd_mock.assert_awaited_once()
 
     async with pool.get_mrd() as mrd1:
-        assert mrd1 == mrd_instance_mock
-
         # Since mrd1 is in use, getting another one should spawn a new MRD
-        async with pool.get_mrd() as _:
+        async with pool.get_mrd() as mrd2:
             assert pool._active_count == 2
             assert create_mrd_mock.call_count == 2
+            assert mrd1 is not mrd2
 
     # Both should have been returned to the free queue
     assert pool._free_mrds.qsize() == 2

--- a/gcsfs/tests/test_zb_hns_utils.py
+++ b/gcsfs/tests/test_zb_hns_utils.py
@@ -20,6 +20,7 @@ generation = "12345"
 @pytest.mark.asyncio
 async def test_shared_mrd_closed_only_by_last_holder():
     from unittest import mock
+
     from gcsfs.zb_hns_utils import MRDPool
 
     class FakeMRD:
@@ -27,6 +28,7 @@ async def test_shared_mrd_closed_only_by_last_holder():
             self.persisted_size = 0
             self.bucket_name, self.object_name = "b", "o"
             self.close_count = 0
+
         async def close(self):
             self.close_count += 1
 
@@ -36,18 +38,20 @@ async def test_shared_mrd_closed_only_by_last_holder():
 
     await pool.initialize()
 
-    cm_a = pool.get_mrd(); mrd_a = await cm_a.__aenter__()   # exclusive
-    cm_b = pool.get_mrd(); mrd_b = await cm_b.__aenter__()   # round-robin share
-    assert mrd_a is mrd_b                                    # same MRD shared
+    cm_a = pool.get_mrd()
+    mrd_a = await cm_a.__aenter__()  # exclusive
+    cm_b = pool.get_mrd()
+    mrd_b = await cm_b.__aenter__()  # round-robin share
+    assert mrd_a is mrd_b  # same MRD shared
 
     await pool.close()
-    assert mrd_a.close_count == 0                            # still in use -> not closed
+    assert mrd_a.close_count == 0  # still in use -> not closed
 
     await cm_a.__aexit__(None, None, None)
-    assert mrd_a.close_count == 0                            # B still holds it
+    assert mrd_a.close_count == 0  # B still holds it
 
     await cm_b.__aexit__(None, None, None)
-    assert mrd_a.close_count == 1                            # last holder closes it exactly once
+    assert mrd_a.close_count == 1  # last holder closes it exactly once
 
 
 @pytest.mark.asyncio

--- a/gcsfs/zb_hns_utils.py
+++ b/gcsfs/zb_hns_utils.py
@@ -458,9 +458,10 @@ class MRDPool:
                     self._rr_index = (self._rr_index + 1) % len(self._all_mrds)
 
             if mrd is None:
-                # Either the queue was non-empty, or the pool is full and sharing
-                # is disabled: block until a holder returns an MRD. NOTE: the lock
-                # is intentionally held across this await -- get_mrd's finally
+                # If the queue was non-empty, this gets an MRD immediately without blocking.
+                # If the queue was empty (pool is full and sharing is disabled), this blocks
+                # until a holder returns an MRD.
+                # NOTE: the lock is intentionally held across this await -- get_mrd's finally
                 # returns MRDs via put_nowait WITHOUT the lock, so a waiter blocked
                 # here is still unblocked by a concurrent release (no deadlock).
                 mrd = await self._free_mrds.get()

--- a/gcsfs/zb_hns_utils.py
+++ b/gcsfs/zb_hns_utils.py
@@ -360,6 +360,31 @@ class MRDPool:
         self.mrd_supports_multi_request = (
             False  # Change this to true once mrd supports concurrent requests.
         )
+        # Maps each checked-out AsyncMultiRangeDownloader to its number of active
+        # get_mrd() holders. An MRD is only requeued into _free_mrds (or closed,
+        # when the pool is closing) by whichever holder releases it LAST, so an
+        # MRD still being driven by a round-robin sharer is never closed/requeued
+        # out from under it.
+        self._inflight = {}
+
+    def _mark_inflight(self, mrd):
+        """Record one more holder of `mrd`. Called under self._lock while the MRD
+        is handed to exactly one get_mrd() caller."""
+        self._inflight[mrd] = self._inflight.get(mrd, 0) + 1
+
+    def _release_inflight(self, mrd):
+        """Drop one holder of `mrd`; return True iff this was the LAST holder
+        (so the caller must now requeue or close it).
+
+        Both helpers only do synchronous dict mutations with no `await`, so they
+        are atomic under asyncio even though get_mrd's finally runs WITHOUT
+        self._lock."""
+        count = self._inflight.get(mrd, 0) - 1
+        if count > 0:
+            self._inflight[mrd] = count
+            return False
+        self._inflight.pop(mrd, None)
+        return True
 
     async def _create_mrd(self):
         await self.gcsfs._get_grpc_client()
@@ -410,8 +435,6 @@ class MRDPool:
         Raises:
             Exception: Bubbles up any exceptions encountered during MRD creation.
         """
-        create_new = False
-        used_from_queue = False
         mrd = None
 
         async with self._lock:
@@ -421,32 +444,36 @@ class MRDPool:
             if self._free_mrds.empty():
                 if self._active_count < self.pool_size:
                     self._active_count += 1
-                    create_new = True
+                    try:
+                        mrd = await self._get_or_create_mrd()
+                    except BaseException as e:
+                        self._active_count -= 1
+                        raise e
                 elif self.mrd_supports_multi_request and self._all_mrds:
-                    # Pool is full, queue is empty, and we are allowed to share a busy MRD.
-                    # Get the mrd in round robin fasion.
+                    # Pool is full and the queue is empty: share a busy MRD in
+                    # round-robin fashion. The MRD now has multiple holders;
+                    # refcounting ensures it is requeued/closed only once the
+                    # LAST holder is done with it.
                     mrd = self._all_mrds[self._rr_index]
                     self._rr_index = (self._rr_index + 1) % len(self._all_mrds)
 
-            if create_new:
-                try:
-                    mrd = await self._get_or_create_mrd()
-                except BaseException as e:
-                    self._active_count -= 1
-                    raise e
-            elif mrd is None:
-                # We did not spawn a new one and we did not grab one via round-robin.
-                # This means we must wait for a free one from the queue.
+            if mrd is None:
+                # Either the queue was non-empty, or the pool is full and sharing
+                # is disabled: block until a holder returns an MRD. NOTE: the lock
+                # is intentionally held across this await -- get_mrd's finally
+                # returns MRDs via put_nowait WITHOUT the lock, so a waiter blocked
+                # here is still unblocked by a concurrent release (no deadlock).
                 mrd = await self._free_mrds.get()
-                used_from_queue = True
+
+            self._mark_inflight(mrd)
 
         try:
             yield mrd
         finally:
-            # Only return the MRD to the free queue if we were the ones who took it out
-            # or if we just spawned it. This prevents duplicate entries in the queue
-            # when multiple concurrent tasks share the same MRD via round-robin.
-            if create_new or used_from_queue:
+            # Intentionally lock-free (see note above). Only the holder that
+            # releases the MRD last requeues or closes it, so a round-robin
+            # sharer is never torn down by a peer or by close().
+            if self._release_inflight(mrd):
                 if self._closed:
                     await close_mrd(mrd)
                 else:
@@ -458,6 +485,8 @@ class MRDPool:
 
         Iterates through all instantiated downloaders and releases them back to
         the cache if available, otherwise closes them.
+
+        In-flight MRDs are not touched here; the last get_mrd() holder closes them on return once _closed is set.
         """
         async with self._lock:
             if self._closed:


### PR DESCRIPTION
Fixes an issue where shared MRDs could be closed or requeued by the first caller to finish while other callers were still driving them. This replaces the old flag logic with a per-MRD refcount to ensure an MRD is only requeued/closed by its last active holder.