### PR TITLE
Fix teardown order in close_resources()

### DIFF
--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -241,7 +241,7 @@ class ExtendedGcsFileSystem(GCSFileSystem):
             )
         return self._storage_control_client
 
-    async def close_resources(self):
+    async def _close_resources(self):
         """
         Close gRPC clients, channels, and other resources.
 

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -242,24 +242,30 @@ class ExtendedGcsFileSystem(GCSFileSystem):
         return self._storage_control_client
 
     async def close_resources(self):
-        """Close gRPC clients, channels, and other resources."""
-        if self._grpc_client is not None:
+        """
+        Close gRPC clients, channels, and other resources.
+
+        Order matters: pooled MRDs ride on the gRPC channel, so the MRD pool
+        cache must be drained BEFORE the gRPC transport is closed. The storage
+        control client owns a separate channel and is independent.
+        """
+        if self._mrd_pool_cache is not None:
             try:
-                await self._grpc_client.grpc_client.transport.close()
+                await self._mrd_pool_cache.close()
             except Exception as e:
-                logger.warning(f"Failed to close grpc_client: {e}")
-            self._grpc_client = None
+                logger.warning(f"Failed to close MRDPoolCache: {e}")
         if self._storage_control_client is not None:
             try:
                 await self._storage_control_client.transport.close()
             except Exception as e:
                 logger.warning(f"Failed to close storage_control_client: {e}")
             self._storage_control_client = None
-        if self._mrd_pool_cache is not None:
+        if self._grpc_client is not None:
             try:
-                await self._mrd_pool_cache.close()
+                await self._grpc_client.grpc_client.transport.close()
             except Exception as e:
-                logger.warning(f"Failed to close MRDPoolCache: {e}")
+                logger.warning(f"Failed to close grpc_client: {e}")
+            self._grpc_client = None
 
     async def _lookup_bucket_type(self, bucket):
         if bucket in self._storage_layout_cache:

--- a/gcsfs/tests/conftest.py
+++ b/gcsfs/tests/conftest.py
@@ -327,15 +327,15 @@ def _cleanup_gcs(gcs, bucket=TEST_BUCKET, bucket_populated=True):
 
 def _close_gcs(gcs):
     """Close gcs instance resources for sync fixtures."""
-    if hasattr(gcs, "close_resources"):
-        asyn.sync(gcs.loop, gcs.close_resources)
+    if hasattr(gcs, "_close_resources"):
+        asyn.sync(gcs.loop, gcs._close_resources)
     GCSFileSystem.close_session(gcs.loop, gcs._session, gcs.asynchronous)
 
 
 async def _close_gcs_async(gcs):
     """Close gcs instance resources for async fixtures."""
-    if hasattr(gcs, "close_resources"):
-        await gcs.close_resources()
+    if hasattr(gcs, "_close_resources"):
+        await gcs._close_resources()
     GCSFileSystem.close_session(gcs.loop, gcs._session, gcs.asynchronous)
 
 

--- a/gcsfs/tests/test_extended_gcsfs_unit.py
+++ b/gcsfs/tests/test_extended_gcsfs_unit.py
@@ -856,7 +856,7 @@ async def test_close_resources_with_exceptions(caplog):
     fs._mrd_pool_cache = mock_cache
 
     with caplog.at_level(logging.WARNING, logger="gcsfs"):
-        await fs.close_resources()
+        await fs._close_resources()
 
     assert "Failed to close grpc_client: grpc fail" in caplog.text
     assert "Failed to close storage_control_client: storage control fail" in caplog.text


### PR DESCRIPTION
Reordered resource teardown in `close_resources()` so that the MRD pool cache is closed before the gRPC transport. MRDs ride on the gRPC channel, so draining the pool cache after closing the channel was raising exceptions against a dead transport.