### PR TITLE
Route rm paths independently per bucket to support mixed HNS/flat deletions

### DIFF
--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -1192,8 +1192,11 @@ class ExtendedGcsFileSystem(GCSFileSystem):
         Deletes files and directories.
 
         This method overrides the parent `_rm` to correctly handle directory
-        deletion in HNS-enabled buckets. For non-HNS buckets, it falls back
-        to the parent implementation.
+        deletion in HNS-enabled buckets. Input paths are grouped by bucket and
+        each bucket is routed independently: HNS buckets use HNS-specific
+        deletion, while non-HNS buckets fall back to the parent implementation.
+        This means a single call may mix paths from HNS and flat buckets, and
+        the per-bucket groups are deleted concurrently.
 
         For HNS buckets, it first expands the path to get a list of all files
         and directories, then categorizes them. It deletes files in batches
@@ -1205,16 +1208,61 @@ class ExtendedGcsFileSystem(GCSFileSystem):
             maxdepth (int, optional): The maximum depth to traverse for deletion.
             batchsize (int): The number of files to delete in a single batch request.
         """
-        if isinstance(path, list):
-            # For HNS check, we can check for bucket type from the first path.
-            bucket, _, _ = self.split_path(path[0]) if path else (None, None, None)
-        else:
-            bucket, _, _ = self.split_path(path)
+        # Normalize to a list so single-path and multi-path inputs share a
+        # single code path.
+        if isinstance(path, str):
+            path = [path]
 
-        is_hns = await self._is_bucket_hns_enabled(bucket)
+        if not path:
+            return []
 
-        if not is_hns:
-            # Fall back to the parent's async rm implementation for non-HNS buckets.
+        # Group paths by bucket so each bucket is routed independently to the
+        # correct deletion strategy (HNS vs. flat), while same-bucket paths are
+        # still batched together.
+        grouped = {}
+        for p in path:
+            bucket, _, _ = self.split_path(p)
+            grouped.setdefault(bucket, []).append(p)
+
+        # Buckets are independent of one another, so delete each group
+        # concurrently.
+        bucket_results = await asyn._run_coros_in_chunks(
+            [
+                self._rm_bucket_paths(
+                    bucket,
+                    bucket_paths,
+                    recursive=recursive,
+                    maxdepth=maxdepth,
+                    batchsize=batchsize,
+                )
+                for bucket, bucket_paths in grouped.items()
+            ],
+            return_exceptions=True,
+        )
+
+        results = []
+        succeeded = False
+        for res in bucket_results:
+            if isinstance(res, FileNotFoundError):
+                # A bucket group matched nothing; tolerated unless every group
+                # fails.
+                continue
+            if isinstance(res, Exception):
+                raise res
+            succeeded = True
+            if res:
+                results.extend(res)
+
+        if not succeeded:
+            raise FileNotFoundError(path)
+
+        return results
+
+    async def _rm_bucket_paths(
+        self, bucket, path, recursive=False, maxdepth=None, batchsize=20
+    ):
+        """Helper method to handle the rm operation for paths within a single bucket."""
+        if not await self._is_bucket_hns_enabled(bucket):
             return await super()._rm(
                 path, recursive=recursive, maxdepth=maxdepth, batchsize=batchsize
             )
@@ -1223,11 +1271,11 @@ class ExtendedGcsFileSystem(GCSFileSystem):
             path, recursive=recursive, maxdepth=maxdepth, detail=True
         )
 
-        # Separate files and directories based on their type.
-        # Directories must be deleted from the deepest first.
+        # Separate files and directories based on their type. Directories are
+        # sorted in reverse so they are deleted from the deepest first.
         files = list({p["name"] for p in paths if p["type"] == "file"})
         dirs = sorted(
-            list({p["name"] for p in paths if p["type"] == "directory"}),
+            {p["name"] for p in paths if p["type"] == "directory"},
             reverse=True,
         )
 

--- a/gcsfs/tests/conftest.py
+++ b/gcsfs/tests/conftest.py
@@ -20,6 +20,7 @@ from gcsfs import GCSFileSystem
 from gcsfs.extended_gcsfs import BucketType
 from gcsfs.tests.settings import (
     TEST_BUCKET,
+    TEST_FLAT_BUCKET,
     TEST_HNS_BUCKET,
     TEST_HNS_REQUESTER_PAYS_BUCKET,
     TEST_PROJECT,
@@ -496,6 +497,31 @@ def gcs_hns(gcs_factory, buckets_to_delete):
         yield gcs
     finally:
         _cleanup_gcs(gcs, bucket=TEST_HNS_BUCKET)
+        _close_gcs(gcs)
+
+
+@pytest.fixture
+def flat_bucket(gcs_factory, buckets_to_delete):
+    """
+    Provides the name of a dedicated standard (non-HNS) bucket.
+
+    In the HNS test suite TEST_BUCKET and TEST_HNS_BUCKET may both point at
+    HNS-enabled buckets, so tests that need to exercise genuinely mixed
+    HNS/flat behavior cannot rely on TEST_BUCKET being flat. This fixture
+    creates a standard bucket (HNS disabled), registers it for end-of-session
+    cleanup, and cleans its contents before and after the test.
+    """
+    gcs = gcs_factory()
+    try:
+        if not gcs.exists(TEST_FLAT_BUCKET):
+            gcs.mkdir(TEST_FLAT_BUCKET)
+            buckets_to_delete.add(TEST_FLAT_BUCKET)
+        else:
+            _cleanup_gcs(gcs, bucket=TEST_FLAT_BUCKET)
+        gcs.invalidate_cache()
+        yield TEST_FLAT_BUCKET
+    finally:
+        _cleanup_gcs(gcs, bucket=TEST_FLAT_BUCKET)
         _close_gcs(gcs)
 
 

--- a/gcsfs/tests/integration/test_extended_hns.py
+++ b/gcsfs/tests/integration/test_extended_hns.py
@@ -968,6 +968,48 @@ class TestExtendedGcsFileSystemRm:
         assert not gcsfs.exists(files[0])
         assert gcsfs.exists(files[1])  # subdir file still exists
 
+    @pytest.mark.parametrize("order", ["flat_first", "hns_first"])
+    def test_rm_mixed_buckets_order(self, gcs_hns, flat_bucket, order):
+        """Test mixed flat and HNS bucket deletes in different orders."""
+        gcsfs = gcs_hns
+        unique_id = uuid.uuid4().hex
+
+        flat_file = f"{flat_bucket}/mixed_rm_{unique_id}/file.txt"
+        hns_empty_dir = f"{TEST_HNS_BUCKET}/mixed_rm_{unique_id}/empty_dir"
+        hns_file = f"{TEST_HNS_BUCKET}/mixed_rm_{unique_id}/nested_dir/file.txt"
+        hns_nested_dir = f"{TEST_HNS_BUCKET}/mixed_rm_{unique_id}/nested_dir"
+
+        # Ensure clean state and create targets
+        gcsfs.touch(flat_file)
+        gcsfs.mkdir(hns_empty_dir, create_parents=True)
+        gcsfs.touch(hns_file)
+
+        assert gcsfs.exists(flat_file)
+        assert gcsfs.exists(hns_empty_dir) and gcsfs.isdir(hns_empty_dir)
+        assert gcsfs.exists(hns_file)
+
+        if order == "flat_first":
+            paths = [flat_file, hns_empty_dir, hns_nested_dir]
+        else:
+            paths = [hns_empty_dir, hns_nested_dir, flat_file]
+
+        try:
+            gcsfs.rm(paths, recursive=True)
+
+            # Assert all targets no longer exist
+            assert not gcsfs.exists(flat_file)
+            assert not gcsfs.exists(hns_empty_dir)
+            assert not gcsfs.exists(hns_nested_dir)
+            assert not gcsfs.exists(hns_file)
+        finally:
+            # Cleanup if anything remained
+            for p in [flat_file, hns_empty_dir, hns_nested_dir]:
+                try:
+                    if gcsfs.exists(p):
+                        gcsfs.rm(p, recursive=True)
+                except Exception:
+                    pass
+
 
 @pytest.fixture()
 def test_structure(gcs_hns):

--- a/gcsfs/tests/settings.py
+++ b/gcsfs/tests/settings.py
@@ -12,6 +12,8 @@ TEST_VERSIONED_BUCKET = _get_bucket_name(
     "GCSFS_TEST_VERSIONED_BUCKET", "gcsfs_test_versioned"
 )
 TEST_HNS_BUCKET = _get_bucket_name("GCSFS_HNS_TEST_BUCKET", "gcsfs_hns_test")
+# Expected to point at a standard (non-HNS / flat) bucket.
+TEST_FLAT_BUCKET = _get_bucket_name("GCSFS_FLAT_TEST_BUCKET", "gcsfs_flat_test")
 TEST_ZONAL_BUCKET = _get_bucket_name("GCSFS_ZONAL_TEST_BUCKET", "gcsfs_zonal_test")
 TEST_PROJECT = os.getenv("GCSFS_TEST_PROJECT", "project")
 TEST_REGION = os.getenv("GCSFS_TEST_REGION", "us-central1")

--- a/gcsfs/tests/test_extended_hns_gcsfs.py
+++ b/gcsfs/tests/test_extended_hns_gcsfs.py
@@ -36,6 +36,14 @@ def get_mock_folder(folder_path):
     return mock_folder
 
 
+async def _mixed_bucket_type(bucket):
+    """Bucket-type lookup used by the mixed flat/HNS ``rm`` tests."""
+    return {
+        "flat-bucket": BucketType.NON_HIERARCHICAL,
+        "hns-bucket": BucketType.HIERARCHICAL,
+    }.get(bucket, BucketType.UNKNOWN)
+
+
 class AsyncIter:
     """A helper class to simulate an async iterator from a list."""
 
@@ -1936,7 +1944,7 @@ class TestExtendedGcsFileSystemRm:
             gcsfs.rm(file_path)
 
             mock_expand.assert_called_once_with(
-                file_path, recursive=False, maxdepth=None, detail=True
+                [file_path], recursive=False, maxdepth=None, detail=True
             )
             # _info should not be called as details are fetched via _expand_path
             mocks["info"].assert_not_called()
@@ -1976,7 +1984,7 @@ class TestExtendedGcsFileSystemRm:
 
             # Verify correct calls
             mock_expand.assert_called_once_with(
-                base_dir, recursive=True, maxdepth=None, detail=True
+                [base_dir], recursive=True, maxdepth=None, detail=True
             )
             mocks["info"].assert_not_called()
             files_to_delete = sorted([file_path, nested_file1, nested_file2])
@@ -2013,7 +2021,7 @@ class TestExtendedGcsFileSystemRm:
 
             # Verify it called the parent's _rm and not the HNS-specific logic
             mocks["super_rm"].assert_awaited_once_with(
-                path, recursive=True, maxdepth=None, batchsize=self.BATCH_SIZE
+                [path], recursive=True, maxdepth=None, batchsize=self.BATCH_SIZE
             )
 
     def test_rm_non_existent_path_hns(self, gcs_hns, gcs_hns_mocks):
@@ -2033,7 +2041,7 @@ class TestExtendedGcsFileSystemRm:
                 gcsfs.rm(path)
 
             mock_expand.assert_awaited_once_with(
-                path, recursive=False, maxdepth=None, detail=True
+                [path], recursive=False, maxdepth=None, detail=True
             )
             mocks["control_client"].delete_folder.assert_not_called()
 
@@ -2056,7 +2064,7 @@ class TestExtendedGcsFileSystemRm:
             gcsfs.rm(dir_path, recursive=True)
 
             mock_expand.assert_awaited_once_with(
-                dir_path, recursive=True, maxdepth=None, detail=True
+                [dir_path], recursive=True, maxdepth=None, detail=True
             )
             mock_delete_files.assert_awaited_once_with([], self.BATCH_SIZE)
             expected_request = self._get_delete_folder_request(gcsfs, dir_path)
@@ -2087,7 +2095,7 @@ class TestExtendedGcsFileSystemRm:
                 gcsfs.rm(dir_path, recursive=False)
 
             mock_expand.assert_called_once_with(
-                dir_path, recursive=False, maxdepth=None, detail=True
+                [dir_path], recursive=False, maxdepth=None, detail=True
             )
             expected_request = self._get_delete_folder_request(gcsfs, dir_path)
             mocks["control_client"].delete_folder.assert_called_once_with(
@@ -2133,6 +2141,162 @@ class TestExtendedGcsFileSystemRm:
             mocks["control_client"].delete_folder.assert_called_once_with(
                 request=expected_request, retry=mock.ANY, timeout=mock.ANY
             )
+
+    @pytest.mark.parametrize("order", ["flat_first", "hns_first"])
+    def test_rm_mixed_buckets_routes_per_bucket(self, gcs_hns, gcs_hns_mocks, order):
+        """rm routes each bucket independently regardless of input order."""
+        gcsfs = gcs_hns
+        flat_file = "flat-bucket/file.txt"
+        hns_empty_dir = "hns-bucket/empty_dir"
+        paths = (
+            [flat_file, hns_empty_dir]
+            if order == "flat_first"
+            else [hns_empty_dir, flat_file]
+        )
+
+        mock_expand = mock.AsyncMock(
+            return_value=[{"name": hns_empty_dir, "type": "directory"}]
+        )
+        mock_delete_files = mock.AsyncMock(return_value=[])
+
+        with (
+            gcs_hns_mocks(BucketType.HIERARCHICAL, gcsfs) as mocks,
+            mock.patch.object(gcsfs, "_expand_path_with_details", new=mock_expand),
+            mock.patch.object(gcsfs, "_delete_files", new=mock_delete_files),
+        ):
+            mocks["async_lookup_bucket_type"].side_effect = _mixed_bucket_type
+
+            gcsfs.rm(paths, recursive=True)
+
+            # Flat bucket routes to the parent _rm with ONLY the flat path.
+            mocks["super_rm"].assert_awaited_once_with(
+                [flat_file], recursive=True, maxdepth=None, batchsize=self.BATCH_SIZE
+            )
+            # HNS bucket routes to HNS-specific deletion with ONLY the HNS path.
+            mock_expand.assert_awaited_once_with(
+                [hns_empty_dir], recursive=True, maxdepth=None, detail=True
+            )
+            expected_request = self._get_delete_folder_request(gcsfs, hns_empty_dir)
+            mocks["control_client"].delete_folder.assert_called_once_with(
+                request=expected_request, retry=mock.ANY, timeout=mock.ANY
+            )
+
+    def test_rm_empty_list_returns_empty_no_lookup(self, gcs_hns, gcs_hns_mocks):
+        """Test that rm([]) returns [] and doesn't do bucket lookup."""
+        gcsfs = gcs_hns
+
+        with gcs_hns_mocks(BucketType.HIERARCHICAL, gcsfs) as mocks:
+            assert gcsfs.rm([]) == []
+
+            mocks["async_lookup_bucket_type"].assert_not_called()
+
+    def test_rm_same_bucket_hns_efficiency(self, gcs_hns, gcs_hns_mocks):
+        """Test that rm on multiple HNS paths in the same bucket remains efficient."""
+        gcsfs = gcs_hns
+        hns_file1 = "hns-bucket/file1.txt"
+        hns_file2 = "hns-bucket/file2.txt"
+
+        mock_expand = mock.AsyncMock()
+        mock_delete_files = mock.AsyncMock()
+
+        with (
+            gcs_hns_mocks(BucketType.HIERARCHICAL, gcsfs) as mocks,
+            mock.patch.object(gcsfs, "_expand_path_with_details", new=mock_expand),
+            mock.patch.object(gcsfs, "_delete_files", new=mock_delete_files),
+        ):
+            mock_expand.return_value = [
+                {"name": hns_file1, "type": "file"},
+                {"name": hns_file2, "type": "file"},
+            ]
+            mock_delete_files.return_value = []
+
+            gcsfs.rm([hns_file1, hns_file2])
+
+            # Calls _expand_path_with_details exactly once for the whole group
+            mock_expand.assert_awaited_once_with(
+                [hns_file1, hns_file2], recursive=False, maxdepth=None, detail=True
+            )
+            mock_delete_files.assert_awaited_once_with(mock.ANY, self.BATCH_SIZE)
+            assert sorted(mock_delete_files.await_args[0][0]) == sorted(
+                [hns_file1, hns_file2]
+            )
+            mocks["super_rm"].assert_not_called()
+
+    def test_rm_same_bucket_flat_efficiency(self, gcs_hns, gcs_hns_mocks):
+        """Test that rm on multiple flat paths in the same bucket remains efficient."""
+        gcsfs = gcs_hns
+        flat_file1 = "flat-bucket/file1.txt"
+        flat_file2 = "flat-bucket/file2.txt"
+
+        with gcs_hns_mocks(BucketType.NON_HIERARCHICAL, gcsfs) as mocks:
+            gcsfs.rm([flat_file1, flat_file2])
+
+            # Calls super()._rm exactly once for the whole group
+            mocks["super_rm"].assert_awaited_once_with(
+                [flat_file1, flat_file2],
+                recursive=False,
+                maxdepth=None,
+                batchsize=self.BATCH_SIZE,
+            )
+
+    def test_rm_mixed_buckets_all_dne_raises_error(self, gcs_hns, gcs_hns_mocks):
+        """Test mixed bucket rm raises FileNotFoundError if all bucket groups fail."""
+        gcsfs = gcs_hns
+        flat_file = "flat-bucket/file.txt"
+        hns_file = "hns-bucket/file.txt"
+
+        with gcs_hns_mocks(BucketType.HIERARCHICAL, gcsfs) as mocks:
+            mocks["async_lookup_bucket_type"].side_effect = _mixed_bucket_type
+            mocks["super_rm"].side_effect = FileNotFoundError()
+            mocks["info"].side_effect = FileNotFoundError()  # For HNS file check
+
+            with pytest.raises(FileNotFoundError):
+                gcsfs.rm([flat_file, hns_file])
+
+    def test_rm_mixed_buckets_one_dne_one_exists_succeeds(self, gcs_hns, gcs_hns_mocks):
+        """Test mixed bucket rm succeeds if at least one bucket group succeeds."""
+        gcsfs = gcs_hns
+        flat_file = "flat-bucket/file.txt"
+        hns_file = "hns-bucket/file.txt"
+
+        mock_expand = mock.AsyncMock(return_value=[{"name": hns_file, "type": "file"}])
+        mock_delete_files = mock.AsyncMock(return_value=[])
+
+        with (
+            gcs_hns_mocks(BucketType.HIERARCHICAL, gcsfs) as mocks,
+            mock.patch.object(gcsfs, "_expand_path_with_details", new=mock_expand),
+            mock.patch.object(gcsfs, "_delete_files", new=mock_delete_files),
+        ):
+            mocks["async_lookup_bucket_type"].side_effect = _mixed_bucket_type
+            # Flat fails, but HNS succeeds
+            mocks["super_rm"].side_effect = FileNotFoundError()
+
+            # This should succeed since the HNS group succeeded, suppressing flat's FileNotFoundError
+            gcsfs.rm([flat_file, hns_file])
+
+            mocks["super_rm"].assert_awaited_once()
+            mock_expand.assert_awaited_once()
+
+    def test_rm_mixed_buckets_non_fnf_error_propagates(self, gcs_hns, gcs_hns_mocks):
+        """A non-FNF error from one bucket propagates even when another group would succeed."""
+        gcsfs = gcs_hns
+        flat_file = "flat-bucket/file.txt"
+        hns_file = "hns-bucket/file.txt"
+
+        mock_expand = mock.AsyncMock(return_value=[{"name": hns_file, "type": "file"}])
+        mock_delete_files = mock.AsyncMock(return_value=[])
+
+        with (
+            gcs_hns_mocks(BucketType.HIERARCHICAL, gcsfs) as mocks,
+            mock.patch.object(gcsfs, "_expand_path_with_details", new=mock_expand),
+            mock.patch.object(gcsfs, "_delete_files", new=mock_delete_files),
+        ):
+            mocks["async_lookup_bucket_type"].side_effect = _mixed_bucket_type
+            # Flat group raises a non-FileNotFoundError; HNS group would succeed.
+            mocks["super_rm"].side_effect = OSError("boom")
+
+            with pytest.raises(OSError, match="boom"):
+                gcsfs.rm([flat_file, hns_file])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Previously, `ExtendedGcsFileSystem.rm` determined whether to use HNS-specific deletion logic based solely on the bucket of the first path in the input list. This led to incorrect routing and failures when the input list contained a mix of paths from both HNS-enabled and non-HNS (flat) buckets.

This change:
- Groups input paths in `rm` by bucket and processes each group independently.
- Routes HNS buckets to HNS-specific deletion and flat buckets to standard `super()._rm`.
- Ensures that multiple paths within the same bucket (HNS or flat) are still grouped efficiently for batch operations.

Includes comprehensive unit and integration tests to verify:
- Correct independent routing and execution order of mixed HNS/flat paths.
- Efficiency is maintained for same-bucket multi-path deletions.
- Expected error handling for empty input lists.