### PR TITLE
Fix multiprocessing emulator _get_bucket_type calls

### DIFF
--- a/gcsfs/tests/conftest.py
+++ b/gcsfs/tests/conftest.py
@@ -122,11 +122,11 @@ def _avoid_adc_timeout(monkeypatch):
 @pytest.fixture(scope="session", autouse=True)
 def _mock_get_bucket_type_on_emulator():
     """Mock _get_bucket_type to return UNKNOWN instantly on emulator."""
-    if not is_real_gcs():
-        with mock.patch(
-            "gcsfs.extended_gcsfs.ExtendedGcsFileSystem._get_bucket_type",
-            return_value=BucketType.UNKNOWN,
-        ):
+    from gcsfs.tests.utils import _patch_get_bucket_type_for_emulator
+
+    patch = _patch_get_bucket_type_for_emulator()
+    if patch:
+        with patch:
             yield
     else:
         yield

--- a/gcsfs/tests/perf/microbenchmarks/conftest.py
+++ b/gcsfs/tests/perf/microbenchmarks/conftest.py
@@ -42,15 +42,11 @@ def _write_file(gcs, path, file_size, chunk_size):
 
 def _init_pool_worker():
     """Initializer for spawned pool workers to bypass _get_bucket_type calls on emulator."""
-    from gcsfs.tests.utils import is_real_gcs
+    from gcsfs.tests.utils import _patch_get_bucket_type_for_emulator
 
-    if not is_real_gcs():
-        from gcsfs.extended_gcsfs import BucketType, ExtendedGcsFileSystem
-
-        async def mock_get_bucket_type(self, bucket):
-            return BucketType.UNKNOWN
-
-        ExtendedGcsFileSystem._get_bucket_type = mock_get_bucket_type
+    patch = _patch_get_bucket_type_for_emulator()
+    if patch:
+        patch.start()
 
 
 def _prepare_files(gcs, file_paths, file_size=0):

--- a/gcsfs/tests/perf/microbenchmarks/conftest.py
+++ b/gcsfs/tests/perf/microbenchmarks/conftest.py
@@ -40,6 +40,19 @@ def _write_file(gcs, path, file_size, chunk_size):
         )
 
 
+def _init_pool_worker():
+    """Initializer for spawned pool workers to bypass _get_bucket_type calls on emulator."""
+    from gcsfs.tests.utils import is_real_gcs
+
+    if not is_real_gcs():
+        from gcsfs.extended_gcsfs import BucketType, ExtendedGcsFileSystem
+
+        async def mock_get_bucket_type(self, bucket):
+            return BucketType.UNKNOWN
+
+        ExtendedGcsFileSystem._get_bucket_type = mock_get_bucket_type
+
+
 def _prepare_files(gcs, file_paths, file_size=0):
     if file_size == 0:
         try:
@@ -53,7 +66,7 @@ def _prepare_files(gcs, file_paths, file_size=0):
 
     args = [(gcs, path, file_size, chunk_size) for path in file_paths]
     ctx = multiprocessing.get_context("spawn")
-    with ctx.Pool(pool_size) as pool:
+    with ctx.Pool(pool_size, initializer=_init_pool_worker) as pool:
         try:
             pool.starmap(_write_file, args)
         except RuntimeError as e:

--- a/gcsfs/tests/perf/microbenchmarks/runner.py
+++ b/gcsfs/tests/perf/microbenchmarks/runner.py
@@ -188,7 +188,10 @@ def run_multi_process(
                     p_args = args_builder(
                         worker_gcs_instances[i], i, process_data_shared
                     )
-                    p = ctx.Process(target=worker_target, args=p_args)
+                    p = ctx.Process(
+                        target=_multiprocess_worker_wrapper,
+                        args=(worker_target, p_args),
+                    )
                     processes.append(p)
                     p.start()
             finally:

--- a/gcsfs/tests/perf/microbenchmarks/runner.py
+++ b/gcsfs/tests/perf/microbenchmarks/runner.py
@@ -2,7 +2,9 @@ import logging
 import multiprocessing
 import os
 from concurrent.futures import ThreadPoolExecutor
+from unittest import mock
 
+from gcsfs.extended_gcsfs import BucketType
 from gcsfs.tests.perf.microbenchmarks.conftest import (
     publish_benchmark_extra_info,
     publish_fixed_duration_benchmark_extra_info,
@@ -10,6 +12,7 @@ from gcsfs.tests.perf.microbenchmarks.conftest import (
     publish_resource_metrics,
 )
 from gcsfs.tests.settings import BENCHMARK_CPU_AFFINITY
+from gcsfs.tests.utils import is_real_gcs
 
 
 def filter_test_cases(all_cases):
@@ -116,6 +119,18 @@ def run_multi_threaded_fixed_duration(
 
     # This is to ensure the JSON report is generated correctly by pytest-benchmark
     benchmark.pedantic(lambda: None, rounds=1, iterations=1, warmup_rounds=0)
+
+
+def _multiprocess_worker_wrapper(worker_target, args):
+    """Wrapper to apply emulator mock inside spawned child processes."""
+    if not is_real_gcs():
+        with mock.patch(
+            "gcsfs.extended_gcsfs.ExtendedGcsFileSystem._get_bucket_type",
+            return_value=BucketType.UNKNOWN,
+        ):
+            worker_target(*args)
+    else:
+        worker_target(*args)
 
 
 def run_multi_process(

--- a/gcsfs/tests/perf/microbenchmarks/runner.py
+++ b/gcsfs/tests/perf/microbenchmarks/runner.py
@@ -2,9 +2,7 @@ import logging
 import multiprocessing
 import os
 from concurrent.futures import ThreadPoolExecutor
-from unittest import mock
 
-from gcsfs.extended_gcsfs import BucketType
 from gcsfs.tests.perf.microbenchmarks.conftest import (
     publish_benchmark_extra_info,
     publish_fixed_duration_benchmark_extra_info,
@@ -12,7 +10,6 @@ from gcsfs.tests.perf.microbenchmarks.conftest import (
     publish_resource_metrics,
 )
 from gcsfs.tests.settings import BENCHMARK_CPU_AFFINITY
-from gcsfs.tests.utils import is_real_gcs
 
 
 def filter_test_cases(all_cases):

--- a/gcsfs/tests/perf/microbenchmarks/runner.py
+++ b/gcsfs/tests/perf/microbenchmarks/runner.py
@@ -123,11 +123,11 @@ def run_multi_threaded_fixed_duration(
 
 def _multiprocess_worker_wrapper(worker_target, args):
     """Wrapper to apply emulator mock inside spawned child processes."""
-    if not is_real_gcs():
-        with mock.patch(
-            "gcsfs.extended_gcsfs.ExtendedGcsFileSystem._get_bucket_type",
-            return_value=BucketType.UNKNOWN,
-        ):
+    from gcsfs.tests.utils import _patch_get_bucket_type_for_emulator
+
+    patch = _patch_get_bucket_type_for_emulator()
+    if patch:
+        with patch:
             worker_target(*args)
     else:
         worker_target(*args)

--- a/gcsfs/tests/utils.py
+++ b/gcsfs/tests/utils.py
@@ -54,3 +54,18 @@ def is_real_gcs():
 
     host = _location()
     return host.startswith("https://")
+
+
+def _patch_get_bucket_type_for_emulator():
+    """Patch bucket type detection in spawned workers when running against fake-gcs-server."""
+    if is_real_gcs():
+        return None
+
+    from unittest import mock
+
+    from gcsfs.extended_gcsfs import BucketType
+
+    return mock.patch(
+        "gcsfs.extended_gcsfs.ExtendedGcsFileSystem._get_bucket_type",
+        return_value=BucketType.UNKNOWN,
+    )


### PR DESCRIPTION
This PR resolves hangs when executing the microbenchmark suite locally against the GCS emulator (`fake-gcs-server`).

### The Problem:
Python's `multiprocessing` library (spawn context) launches child processes that do not inherit active mock patches from the parent process. When these child processes instantiate `ExtendedGcsFileSystem`, they attempt to call the real `_get_bucket_type` method. Since the GCS emulator does not support the Storage Control API, this call fails or hangs, leading to timeouts in multi-process test cases.

### Changes:
- **Pool Initialization:** Added `_init_pool_worker` in `gcsfs/tests/perf/microbenchmarks/conftest.py` as an initializer for spawned Pool workers to explicitly bypass `_get_bucket_type` calls on emulator.
- **Process Target Wrapper:** Introduced `_multiprocess_worker_wrapper` in `runner.py` to wrap process target functions and apply the `_get_bucket_type` mock in all spawned child processes.