### PR TITLE
Add open microbenchmark

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,3 +1,6 @@
+ignore:
+  - "gcsfs/tests/**/*"
+
 coverage:
   status:
     project:

--- a/gcsfs/tests/conftest.py
+++ b/gcsfs/tests/conftest.py
@@ -606,6 +606,7 @@ def pytest_ignore_collect(collection_path, config):
             "write",
             "info",
             "pipe",
+            "open",
         }
 
         # If only --run-benchmarks-infra is passed, ignore the actual benchmark subfolders.

--- a/gcsfs/tests/perf/microbenchmarks/README.md
+++ b/gcsfs/tests/perf/microbenchmarks/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-GCSFS microbenchmarks are a suite of performance tests designed to evaluate the efficiency and latency of various Google Cloud Storage file system operations, including read, write, listing, delete, and rename.
+GCSFS microbenchmarks are a suite of performance tests designed to evaluate the efficiency and latency of various Google Cloud Storage file system operations, including read, write, listing, delete, rename, and open.
 
 These benchmarks are built using the `pytest` and `pytest-benchmark` frameworks. Each benchmark test is a parameterized pytest case, where the parameters are dynamically configured at runtime from YAML configuration files. This allows for flexible and extensive testing scenarios without modifying the code.
 
@@ -48,6 +48,9 @@ The benchmarks use a set of parameter classes to define the configuration for ea
 *   **Info Parameters**: Specific to Info operations (extends Listing Parameters).
     *    `target_type`: The type of target to query: "bucket", "folder", or "file".
 
+*   **Open Parameters**: Specific to Open operations.
+    *    `folders`: Number of folders to distribute files into.
+
 ## Configuration
 
 Configuration values are stored in YAML files (e.g., `configs.yaml`) located within each benchmark's directory. These files define:
@@ -77,7 +80,7 @@ The `run.py` script is the central entry point for executing benchmarks. It hand
 
 | Option | Description | Required |
 | :--- | :--- | :--- |
-| `--group` | The benchmark group to run (e.g., `read`, `write`, `listing`, `info`). Runs all groups if not specified. | No |
+| `--group` | The benchmark group to run (e.g., `read`, `write`, `listing`, `info`, `open`). Runs all groups if not specified. | No |
 | `--config` | Specific scenario names to run (e.g., `read_seq`, `list_flat`). Accepts multiple values. | No |
 | `--regional-bucket` | Name of the regional GCS bucket. | Yes* |
 | `--zonal-bucket` | Name of the zonal GCS bucket. | Yes* |

--- a/gcsfs/tests/perf/microbenchmarks/conftest.py
+++ b/gcsfs/tests/perf/microbenchmarks/conftest.py
@@ -323,6 +323,23 @@ def gcsfs_benchmark_info(extended_gcs_factory, request):
     )
 
 
+@pytest.fixture
+def gcsfs_benchmark_open(extended_gcs_factory, request):
+    """
+    A fixture that sets up the environment for a open benchmark run.
+    It creates a directory structure with 0-byte files.
+    """
+    params = request.param
+    yield from _benchmark_listing_fixture_helper(
+        extended_gcs_factory,
+        params,
+        "benchmark-open",
+        teardown=True,
+        create_folders=True,
+        require_file_paths=True,
+    )
+
+
 def pytest_benchmark_generate_json(config, benchmarks, machine_info, commit_info):
     """
     Hook to post-process benchmark results before generating the JSON report.

--- a/gcsfs/tests/perf/microbenchmarks/open/configs.py
+++ b/gcsfs/tests/perf/microbenchmarks/open/configs.py
@@ -1,0 +1,103 @@
+from gcsfs.tests.perf.microbenchmarks.configs import BaseBenchmarkConfigurator
+from gcsfs.tests.perf.microbenchmarks.open.parameters import OpenBenchmarkParameters
+
+
+class OpenConfigurator(BaseBenchmarkConfigurator):
+    param_class = OpenBenchmarkParameters
+
+    def build_cases(self, scenario, common_config):
+        cases = []
+        bucket_types = common_config.get("bucket_types", ["zonal"])
+        files_list = scenario.get("files", [1])
+        folders_list = scenario.get("folders", [1])
+        threads_list = scenario.get("threads", [1])
+        procs_list = scenario.get("processes", [1])
+        rounds = scenario.get("rounds", 1)
+
+        for bucket_type in bucket_types:
+            bucket_name = self.get_bucket_name(bucket_type)
+            if not bucket_name:
+                continue
+
+            for files in files_list:
+                for folders in folders_list:
+                    if "threads" in scenario:
+                        for threads in threads_list:
+                            name = (
+                                f"{scenario['name']}_{threads}threads_"
+                                f"{files}files_{folders}folders_{bucket_type}"
+                            )
+                            cases.append(
+                                self._create_params(
+                                    name,
+                                    bucket_name,
+                                    bucket_type,
+                                    threads,
+                                    1,
+                                    files,
+                                    rounds,
+                                    folders,
+                                )
+                            )
+                    elif "processes" in scenario:
+                        for procs in procs_list:
+                            name = (
+                                f"{scenario['name']}_{procs}procs_"
+                                f"{files}files_{folders}folders_{bucket_type}"
+                            )
+                            cases.append(
+                                self._create_params(
+                                    name,
+                                    bucket_name,
+                                    bucket_type,
+                                    1,
+                                    procs,
+                                    files,
+                                    rounds,
+                                    folders,
+                                )
+                            )
+                    else:
+                        name = (
+                            f"{scenario['name']}_1procs_1threads_"
+                            f"{files}files_{folders}folders_{bucket_type}"
+                        )
+                        cases.append(
+                            self._create_params(
+                                name,
+                                bucket_name,
+                                bucket_type,
+                                1,
+                                1,
+                                files,
+                                rounds,
+                                folders,
+                            )
+                        )
+        return cases
+
+    def _create_params(
+        self,
+        name,
+        bucket_name,
+        bucket_type,
+        threads,
+        processes,
+        files,
+        rounds,
+        folders,
+    ):
+        return self.param_class(
+            name=name,
+            bucket_name=bucket_name,
+            bucket_type=bucket_type,
+            threads=threads,
+            processes=processes,
+            files=files,
+            rounds=rounds,
+            folders=folders,
+        )
+
+
+def get_open_benchmark_cases():
+    return OpenConfigurator(__file__).generate_cases()

--- a/gcsfs/tests/perf/microbenchmarks/open/configs.yaml
+++ b/gcsfs/tests/perf/microbenchmarks/open/configs.yaml
@@ -1,0 +1,20 @@
+common:
+  bucket_types:
+    - "regional"
+    - "zonal"
+    - "hns"
+
+scenarios:
+  - name: "open_file"
+    files: [1000]
+    folders: [1]
+
+  - name: "open_multi_thread_file"
+    files: [1000]
+    folders: [1]
+    threads: [4, 16, 64]
+
+  - name: "open_multi_process_file"
+    files: [1000]
+    folders: [1]
+    processes: [4, 16, 64]

--- a/gcsfs/tests/perf/microbenchmarks/open/parameters.py
+++ b/gcsfs/tests/perf/microbenchmarks/open/parameters.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+from gcsfs.tests.perf.microbenchmarks.parameters import BaseBenchmarkParameters
+
+
+@dataclass
+class OpenBenchmarkParameters(BaseBenchmarkParameters):
+    """
+    Parameters for Open benchmarks.
+    """
+    folders: int

--- a/gcsfs/tests/perf/microbenchmarks/open/parameters.py
+++ b/gcsfs/tests/perf/microbenchmarks/open/parameters.py
@@ -8,4 +8,5 @@ class OpenBenchmarkParameters(BaseBenchmarkParameters):
     """
     Parameters for Open benchmarks.
     """
+
     folders: int

--- a/gcsfs/tests/perf/microbenchmarks/open/test_open.py
+++ b/gcsfs/tests/perf/microbenchmarks/open/test_open.py
@@ -1,0 +1,118 @@
+import logging
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from gcsfs.tests.perf.microbenchmarks.open.configs import get_open_benchmark_cases
+from gcsfs.tests.perf.microbenchmarks.runner import (
+    filter_test_cases,
+    run_multi_process,
+    run_multi_threaded,
+    run_single_threaded,
+)
+
+BENCHMARK_GROUP = "open"
+
+
+def _open_op(gcs, path):
+    start_time = time.perf_counter()
+    try:
+        f = gcs.open(path, mode="rb")
+        f.close()
+    except FileNotFoundError:
+        pass
+    duration_ms = (time.perf_counter() - start_time) * 1000
+    logging.debug(f"OPEN : {path} - {duration_ms:.2f} ms.")
+
+
+def _open_ops(gcs, paths):
+    for path in paths:
+        _open_op(gcs, path)
+
+
+all_benchmark_cases = get_open_benchmark_cases()
+single_threaded_cases, multi_threaded_cases, multi_process_cases = filter_test_cases(
+    all_benchmark_cases
+)
+
+
+@pytest.mark.parametrize(
+    "gcsfs_benchmark_open",
+    single_threaded_cases,
+    indirect=True,
+    ids=lambda p: p.name,
+)
+def test_open_single_threaded(benchmark, gcsfs_benchmark_open, monitor):
+    gcs, target_dirs, file_paths, prefix, params = gcsfs_benchmark_open
+
+    run_single_threaded(
+        benchmark, monitor, params, _open_ops, (gcs, file_paths), BENCHMARK_GROUP
+    )
+
+
+def _chunk_list(data, n):
+    k, m = divmod(len(data), n)
+    return [data[i * k + min(i, m) : (i + 1) * k + min(i + 1, m)] for i in range(n)]
+
+
+@pytest.mark.parametrize(
+    "gcsfs_benchmark_open",
+    multi_threaded_cases,
+    indirect=True,
+    ids=lambda p: p.name,
+)
+def test_open_multi_threaded(benchmark, gcsfs_benchmark_open, monitor):
+    gcs, target_dirs, file_paths, prefix, params = gcsfs_benchmark_open
+
+    chunks = _chunk_list(file_paths, params.threads)
+    args_list = [(gcs, chunks[i]) for i in range(params.threads)]
+
+    run_multi_threaded(
+        benchmark, monitor, params, _open_ops, args_list, BENCHMARK_GROUP
+    )
+
+
+def _process_worker(gcs, paths, threads, process_durations_shared, index):
+    """A worker function for each process to run open operations."""
+    start_time = time.perf_counter()
+    chunks = _chunk_list(paths, threads)
+    with ThreadPoolExecutor(max_workers=threads) as executor:
+        futures = [executor.submit(_open_ops, gcs, chunks[i]) for i in range(threads)]
+        [f.result() for f in futures]
+    duration_s = time.perf_counter() - start_time
+    process_durations_shared[index] = duration_s
+
+
+@pytest.mark.parametrize(
+    "gcsfs_benchmark_open",
+    multi_process_cases,
+    indirect=True,
+    ids=lambda p: p.name,
+)
+def test_open_multi_process(
+    benchmark, gcsfs_benchmark_open, extended_gcs_factory, request, monitor
+):
+    gcs, target_dirs, file_paths, prefix, params = gcsfs_benchmark_open
+
+    chunks = _chunk_list(file_paths, params.processes)
+
+    def args_builder(gcs_instance, i, shared_arr):
+        return (
+            gcs_instance,
+            chunks[i],
+            params.threads,
+            shared_arr,
+            i,
+        )
+
+    run_multi_process(
+        benchmark,
+        monitor,
+        params,
+        extended_gcs_factory,
+        worker_target=_process_worker,
+        args_builder=args_builder,
+        benchmark_group=BENCHMARK_GROUP,
+        request=request,
+    )

--- a/gcsfs/tests/perf/microbenchmarks/test_configs.py
+++ b/gcsfs/tests/perf/microbenchmarks/test_configs.py
@@ -12,10 +12,7 @@ from gcsfs.tests.perf.microbenchmarks.listing.configs import (
     ListingConfigurator,
     get_listing_benchmark_cases,
 )
-from gcsfs.tests.perf.microbenchmarks.open.configs import (
-    OpenConfigurator,
-    get_open_benchmark_cases,
-)
+from gcsfs.tests.perf.microbenchmarks.open.configs import get_open_benchmark_cases
 from gcsfs.tests.perf.microbenchmarks.read.configs import (
     ReadConfigurator,
     get_read_benchmark_cases,

--- a/gcsfs/tests/perf/microbenchmarks/test_configs.py
+++ b/gcsfs/tests/perf/microbenchmarks/test_configs.py
@@ -12,6 +12,10 @@ from gcsfs.tests.perf.microbenchmarks.listing.configs import (
     ListingConfigurator,
     get_listing_benchmark_cases,
 )
+from gcsfs.tests.perf.microbenchmarks.open.configs import (
+    OpenConfigurator,
+    get_open_benchmark_cases,
+)
 from gcsfs.tests.perf.microbenchmarks.read.configs import (
     ReadConfigurator,
     get_read_benchmark_cases,
@@ -266,3 +270,7 @@ def test_validate_actual_yaml_configs():
         # Info
         cases = get_info_benchmark_cases()
         assert len(cases) > 0, "Info config produced no cases"
+
+        # Open
+        cases = get_open_benchmark_cases()
+        assert len(cases) > 0, "Open config produced no cases"


### PR DESCRIPTION
This PR introduces a new microbenchmark suite to evaluate the performance of the `open` operation (calling `open()` and `close()` on files) under different concurrency models (single-threaded, multi-threaded, and multi-process).

### Changes:
- **New Benchmark Suite:** Added `gcsfs/tests/perf/microbenchmarks/open/` containing the test cases (`test_open.py`), config setup (`configs.py`, `configs.yaml`), and parameter definition (`parameters.py`).
- **Documentation:** Updated the README in the microbenchmarks directory to include the description of the `open` operation.
- **Test Configs:** Included validation of the new `open` benchmark configuration in `test_configs.py`.