### PR TITLE
Update read performance microbenchmark config to use 1 file

### DIFF
--- a/gcsfs/tests/perf/microbenchmarks/read/configs.yaml
+++ b/gcsfs/tests/perf/microbenchmarks/read/configs.yaml
@@ -26,10 +26,14 @@ scenarios:
   - name: "read_seq_fixed_duration_multi_thread"
     pattern: "seq"
     threads: [32]
+    files: 1
+    processes: [1]
 
   - name: "read_rand_fixed_duration_multi_thread"
     pattern: "rand"
     threads: [32]
+    files: 1
+    processes: [1]
 
   - name: "read_reopen_fixed_duration"
     pattern: "reopen"

--- a/gcsfs/tests/perf/microbenchmarks/test_configs.py
+++ b/gcsfs/tests/perf/microbenchmarks/test_configs.py
@@ -125,7 +125,7 @@ def test_read_fixed_duration_multi_thread_config(mock_config_dependencies):
         name.startswith("read_rand_fixed_duration_multi_thread") for name in names
     )
     assert {case.threads for case in multi_thread_cases} == {32}
-    assert {case.files for case in multi_thread_cases} == {32}
+    assert {case.files for case in multi_thread_cases} == {1}
 
 
 def test_write_configurator(mock_config_dependencies):


### PR DESCRIPTION
Modified scenarios read_seq_fixed_duration_multi_thread and read_rand_fixed_duration_multi_thread in configs.yaml to use 1 file and 1 process. Updated test_configs.py to match the new config.