### PR TITLE
Introduce concurrency in _get_file method

### DIFF
--- a/cloudbuild/run_tests.sh
+++ b/cloudbuild/run_tests.sh
@@ -151,6 +151,12 @@ case "$TEST_SUITE" in
       "--deselect=gcsfs/tests/test_core.py::test_requester_pays_fails_without_user_project"
     )
 
+    # Zonal bucket doesnt have concurrenct disk downloads yet.
+    ZONAL_DESELECTS+=(
+      "--deselect=gcsfs/tests/test_core.py::test_get_file_range_header_fallback"
+      "--deselect=gcsfs/tests/test_core.py::test_get_file_top_level_concurrency"
+    )
+
     pytest "${ARGS[@]}" "${ZONAL_DESELECTS[@]}" gcsfs/tests/test_core.py
     ;;
 esac

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1936,19 +1936,94 @@ class GCSFileSystem(asyn.AsyncFileSystem):
             checker.validate_http_response(r)  # validate file consistency
             return r.status, r.headers, r.request_info, data
 
+    def _init_local_file(self, lpath, total_size):
+        """Creates the target directory and pre-allocates the file size."""
+        os.makedirs(os.path.dirname(lpath) or os.curdir, exist_ok=True)
+        if total_size == 0:
+            open(lpath, "wb").close()
+        else:
+            with open(lpath, "wb") as f:
+                f.truncate(total_size)
+
+    @retry_request(retries=retries)
+    async def _download_chunk_to_file(
+        self,
+        url,
+        rpath,
+        lpath,
+        start_offset,
+        end_offset,
+        chunk_size,
+        headers,
+        callback,
+        **kwargs,
+    ):
+        """Fetches a specific byte range of a file and writes it to disk."""
+        req_headers = {"Range": f"bytes={start_offset}-{end_offset - 1}"}
+        if headers:
+            req_headers.update(headers)
+
+        bytes_written = 0
+        await self._set_session()
+
+        async with self.session.get(
+            url,
+            headers=self._get_headers(req_headers),
+            params=self._get_params(kwargs),
+            timeout=self.requests_timeout,
+        ) as r:
+            validate_response(r.status, None, rpath)
+            local_f = None
+            try:
+                local_f = open(lpath, "rb+")
+                local_f.seek(start_offset)
+                while True:
+                    chunk = await r.content.read(chunk_size)
+                    if not chunk:
+                        break
+
+                    local_f.write(chunk)
+                    callback.relative_update(len(chunk))
+                    bytes_written += len(chunk)
+
+                expected_bytes = end_offset - start_offset
+                if bytes_written != expected_bytes:
+                    raise RuntimeError(
+                        f"Connection closed early. Expected {expected_bytes} bytes, got {bytes_written}."
+                    )
+            except BaseException:
+                callback.relative_update(-bytes_written)
+                raise
+            finally:
+                if local_f is not None:
+                    local_f.close()
+
+    async def _verify_file_consistency(self, lpath, details, consistency):
+        """Verifies the integrity of the downloaded file in a background thread."""
+        loop = asyncio.get_running_loop()
+        checker = get_consistency_checker(consistency)
+
+        def verify_file():
+            with open(lpath, "rb") as f:
+                while True:
+                    data = f.read(1024 * 1024)
+                    if not data:
+                        break
+                    checker.update(data)
+            checker.validate_json_response(details)
+
+        await loop.run_in_executor(None, verify_file)
+
     async def _get_file_concurrent(
         self, rpath, lpath, concurrency, headers=None, callback=None, **kwargs
     ):
-        """
-        Concurrent write the gcs object into the disk.
-        """
+        """Main orchestrator for concurrent file downloads."""
         consistency = kwargs.pop("consistency", self.consistency)
-        chunk_size = kwargs.pop(
-            "chunk_size", 128 * 1024
-        )  # 128KB micro-chunks for streaming
+        chunk_size = kwargs.pop("chunk_size", 128 * 1024)
 
         details = await self._info(rpath, **kwargs)
         total_size = details.get("size", 0)
+
         if total_size < self.MIN_CHUNK_SIZE_FOR_CONCURRENCY:
             concurrency = 1
 
@@ -1962,9 +2037,9 @@ class GCSFileSystem(asyn.AsyncFileSystem):
         callback = callback or NoOpCallback()
         callback.set_size(total_size)
 
-        os.makedirs(os.path.dirname(lpath) or os.curdir, exist_ok=True)
+        self._init_local_file(lpath, total_size)
+
         if total_size == 0:
-            open(lpath, "wb").close()
             if check_consistency:
                 checker = get_consistency_checker(consistency)
                 checker.update(b"")
@@ -1972,57 +2047,26 @@ class GCSFileSystem(asyn.AsyncFileSystem):
             return
 
         part_size = (total_size + concurrency - 1) // max(1, concurrency)
-        with open(lpath, "wb") as f:
-            f.truncate(total_size)
-
-        loop = asyncio.get_running_loop()
         url = self.url(rpath)
-
-        @retry_request(retries=self.retries)
-        async def stream_and_write(start_offset, end_offset):
-            req_headers = {"Range": f"bytes={start_offset}-{end_offset - 1}"}
-            if headers:
-                req_headers.update(headers)
-
-            bytes_written = 0
-            await self._set_session()
-            async with self.session.get(
-                url,
-                headers=self._get_headers(req_headers),
-                params=self._get_params(kwargs),
-                timeout=self.requests_timeout,
-            ) as r:
-                validate_response(r.status, None, rpath)
-                local_f = None
-                try:
-                    local_f = open(lpath, "rb+")
-                    local_f.seek(start_offset)
-                    while True:
-                        chunk = await r.content.read(chunk_size)
-                        if not chunk:
-                            break
-
-                        local_f.write(chunk)
-
-                        callback.relative_update(len(chunk))
-                        bytes_written += len(chunk)
-
-                    expected_bytes = end_offset - start_offset
-                    if bytes_written != expected_bytes:
-                        raise RuntimeError(
-                            f"Connection closed early. Expected {expected_bytes} bytes, got {bytes_written}."
-                        )
-                except BaseException:
-                    callback.relative_update(-bytes_written)
-                    raise
-                finally:
-                    if local_f is not None:
-                        local_f.close()
-
         tasks = []
+
         for offset in range(0, total_size, part_size):
             end = min(offset + part_size, total_size)
-            tasks.append(asyncio.create_task(stream_and_write(offset, end)))
+            tasks.append(
+                asyncio.create_task(
+                    self._download_chunk_to_file(
+                        url,
+                        rpath,
+                        lpath,
+                        offset,
+                        end,
+                        chunk_size,
+                        headers,
+                        callback,
+                        **kwargs,
+                    )
+                )
+            )
 
         try:
             await asyncio.gather(*tasks)
@@ -2038,19 +2082,7 @@ class GCSFileSystem(asyn.AsyncFileSystem):
                 "On-the-fly checksum disabled for concurrent out-of-order downloads. "
                 "Verifying file integrity post-download."
             )
-            checker = get_consistency_checker(consistency)
-
-            def verify_file():
-                with open(lpath, "rb") as f:
-                    while True:
-                        data = f.read(1024 * 1024)
-                        if not data:
-                            break
-                        checker.update(data)
-                checker.validate_json_response(details)
-
-            # Execute the hashing in a background thread to keep the event loop unblocked
-            await loop.run_in_executor(None, verify_file)
+            await self._verify_file_consistency(lpath, details, consistency)
 
     async def _get_file(self, rpath, lpath, callback=None, **kwargs):
         if os.path.isdir(lpath):

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1940,7 +1940,8 @@ class GCSFileSystem(asyn.AsyncFileSystem):
         """Creates the target directory and pre-allocates the file size."""
         os.makedirs(os.path.dirname(lpath) or os.curdir, exist_ok=True)
         if total_size == 0:
-            open(lpath, "wb").close()
+            with open(lpath, "wb"):
+                pass
         else:
             with open(lpath, "wb") as f:
                 f.truncate(total_size)
@@ -1959,9 +1960,10 @@ class GCSFileSystem(asyn.AsyncFileSystem):
         **kwargs,
     ):
         """Fetches a specific byte range of a file and writes it to disk."""
-        req_headers = {"Range": f"bytes={start_offset}-{end_offset - 1}"}
+        req_headers = {}
         if headers:
             req_headers.update(headers)
+        req_headers["Range"] = f"bytes={start_offset}-{end_offset - 1}"
 
         bytes_written = 0
         await self._set_session()
@@ -1988,8 +1990,9 @@ class GCSFileSystem(asyn.AsyncFileSystem):
 
                 expected_bytes = end_offset - start_offset
                 if bytes_written != expected_bytes:
-                    raise RuntimeError(
-                        f"Connection closed early. Expected {expected_bytes} bytes, got {bytes_written}."
+                    raise aiohttp.client_exceptions.ClientPayloadError(
+                        f"Connection closed early. Expected {expected_bytes} bytes, "
+                        f"got {bytes_written} at offset {start_offset}."
                     )
             except BaseException:
                 callback.relative_update(-bytes_written)
@@ -2027,6 +2030,11 @@ class GCSFileSystem(asyn.AsyncFileSystem):
         if total_size < self.MIN_CHUNK_SIZE_FOR_CONCURRENCY:
             concurrency = 1
 
+        if concurrency == 1:
+            return await self._get_file_request(
+                self.url(rpath), lpath, headers=headers, callback=callback, **kwargs
+            )
+
         check_consistency = consistency not in ("none", None)
 
         # Prevent silent corruption by pinning the exact object generation
@@ -2046,7 +2054,7 @@ class GCSFileSystem(asyn.AsyncFileSystem):
                 checker.validate_json_response(details)
             return
 
-        part_size = (total_size + concurrency - 1) // max(1, concurrency)
+        part_size = max(chunk_size, (total_size + concurrency - 1) // concurrency)
         url = self.url(rpath)
         tasks = []
 
@@ -2070,15 +2078,15 @@ class GCSFileSystem(asyn.AsyncFileSystem):
 
         try:
             await asyncio.gather(*tasks)
-        except BaseException as e:
+        except BaseException:
             for t in tasks:
                 if not t.done():
                     t.cancel()
             await asyncio.gather(*tasks, return_exceptions=True)
-            raise e
+            raise
 
         if check_consistency:
-            logger.debug(
+            logger.warning(
                 "On-the-fly checksum disabled for concurrent out-of-order downloads. "
                 "Verifying file integrity post-download."
             )
@@ -2091,13 +2099,32 @@ class GCSFileSystem(asyn.AsyncFileSystem):
         callback = callback or NoOpCallback()
 
         concurrency = kwargs.pop("concurrency", DEFAULT_CONCURRENCY)
-        if concurrency > 1:
-            await self._get_file_concurrent(
-                rpath, lpath, concurrency, callback=callback, **kwargs
+
+        # If the user provides a custom Range header, fall back to the sequential path.
+        # Parsing range headers client-side to spawn concurrent tasks is messy because
+        # formats vary widely (e.g., bytes=-500, bytes=100-, bytes=0-50, 100-150).
+        # Building a flawless parser for this edge case introduces unnecessary risk.
+        # Also, if users want concurrent range downloads, gcsfs already handles that
+        # natively through cat_file(start=..., end=...).
+        headers = kwargs.get("headers", {})
+        if headers and any(k.lower() == "range" for k in headers):
+            logger.debug(
+                "Custom Range header detected. Falling back to sequential download."
             )
-        else:
-            u2 = self.url(rpath)
-            await self._get_file_request(u2, lpath, callback=callback, **kwargs)
+            concurrency = 1
+
+        try:
+            if concurrency > 1:
+                await self._get_file_concurrent(
+                    rpath, lpath, concurrency, callback=callback, **kwargs
+                )
+            else:
+                u2 = self.url(rpath)
+                await self._get_file_request(u2, lpath, callback=callback, **kwargs)
+        except BaseException:
+            if os.path.exists(lpath):
+                os.remove(lpath)
+            raise
 
     def _open(
         self,

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1936,12 +1936,136 @@ class GCSFileSystem(asyn.AsyncFileSystem):
             checker.validate_http_response(r)  # validate file consistency
             return r.status, r.headers, r.request_info, data
 
+    async def _get_file_concurrent(
+        self, rpath, lpath, concurrency, headers=None, callback=None, **kwargs
+    ):
+        """
+        Concurrent write the gcs object into the disk.
+        """
+        consistency = kwargs.pop("consistency", self.consistency)
+        chunk_size = kwargs.pop(
+            "chunk_size", 128 * 1024
+        )  # 128KB micro-chunks for streaming
+
+        details = await self._info(rpath, **kwargs)
+        total_size = details.get("size", 0)
+        if total_size < self.MIN_CHUNK_SIZE_FOR_CONCURRENCY:
+            concurrency = 1
+
+        check_consistency = consistency not in ("none", None)
+
+        # Prevent silent corruption by pinning the exact object generation
+        generation = details.get("generation")
+        if generation and "generation" not in kwargs:
+            kwargs["generation"] = generation
+
+        callback = callback or NoOpCallback()
+        callback.set_size(total_size)
+
+        os.makedirs(os.path.dirname(lpath) or os.curdir, exist_ok=True)
+        if total_size == 0:
+            open(lpath, "wb").close()
+            if check_consistency:
+                checker = get_consistency_checker(consistency)
+                checker.update(b"")
+                checker.validate_json_response(details)
+            return
+
+        part_size = (total_size + concurrency - 1) // max(1, concurrency)
+        with open(lpath, "wb") as f:
+            f.truncate(total_size)
+
+        loop = asyncio.get_running_loop()
+        url = self.url(rpath)
+
+        @retry_request(retries=self.retries)
+        async def stream_and_write(start_offset, end_offset):
+            req_headers = {"Range": f"bytes={start_offset}-{end_offset - 1}"}
+            if headers:
+                req_headers.update(headers)
+
+            bytes_written = 0
+            await self._set_session()
+            async with self.session.get(
+                url,
+                headers=self._get_headers(req_headers),
+                params=self._get_params(kwargs),
+                timeout=self.requests_timeout,
+            ) as r:
+                validate_response(r.status, None, rpath)
+                local_f = None
+                try:
+                    local_f = open(lpath, "rb+")
+                    local_f.seek(start_offset)
+                    while True:
+                        chunk = await r.content.read(chunk_size)
+                        if not chunk:
+                            break
+
+                        local_f.write(chunk)
+
+                        callback.relative_update(len(chunk))
+                        bytes_written += len(chunk)
+
+                    expected_bytes = end_offset - start_offset
+                    if bytes_written != expected_bytes:
+                        raise RuntimeError(
+                            f"Connection closed early. Expected {expected_bytes} bytes, got {bytes_written}."
+                        )
+                except BaseException:
+                    callback.relative_update(-bytes_written)
+                    raise
+                finally:
+                    if local_f is not None:
+                        local_f.close()
+
+        tasks = []
+        for offset in range(0, total_size, part_size):
+            end = min(offset + part_size, total_size)
+            tasks.append(asyncio.create_task(stream_and_write(offset, end)))
+
+        try:
+            await asyncio.gather(*tasks)
+        except BaseException as e:
+            for t in tasks:
+                if not t.done():
+                    t.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            raise e
+
+        if check_consistency:
+            logger.debug(
+                "On-the-fly checksum disabled for concurrent out-of-order downloads. "
+                "Verifying file integrity post-download."
+            )
+            checker = get_consistency_checker(consistency)
+
+            def verify_file():
+                with open(lpath, "rb") as f:
+                    while True:
+                        data = f.read(1024 * 1024)
+                        if not data:
+                            break
+                        checker.update(data)
+                checker.validate_json_response(details)
+
+            # Execute the hashing in a background thread to keep the event loop unblocked
+            await loop.run_in_executor(None, verify_file)
+
     async def _get_file(self, rpath, lpath, callback=None, **kwargs):
-        u2 = self.url(rpath)
         if os.path.isdir(lpath):
             return
+
         callback = callback or NoOpCallback()
-        await self._get_file_request(u2, lpath, callback=callback, **kwargs)
+
+        concurrency = kwargs.pop("concurrency", DEFAULT_CONCURRENCY)
+        if concurrency > 1:
+            await self._get_file_concurrent(
+                rpath, lpath, concurrency, callback=callback, **kwargs
+            )
+        else:
+            u2 = self.url(rpath)
+            await self._get_file_request(u2, lpath, callback=callback, **kwargs)
 
     def _open(
         self,

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1984,6 +1984,8 @@ class GCSFileSystem(asyn.AsyncFileSystem):
                     if not chunk:
                         break
 
+                    # Offloading it to thread doesn't improve performance.
+                    # See https://github.com/fsspec/gcsfs/pull/862#discussion_r3356862167
                     local_f.write(chunk)
                     callback.relative_update(len(chunk))
                     bytes_written += len(chunk)

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -9,6 +9,7 @@ from unittest import mock
 from urllib.parse import parse_qs, unquote, urlparse
 from uuid import uuid4
 
+import aiohttp
 import fsspec.asyn
 import fsspec.core
 import pytest
@@ -1568,6 +1569,163 @@ def test_read_small(gcs):
         assert gcs.cat(fn) == b"".join(out)
         # cache drop
         assert len(f.cache.cache) < len(out)
+
+
+def test_download_chunk_to_file_range_header_override(gcs):
+    rpath = f"{TEST_BUCKET}/test_chunk_range.txt"
+    gcs.pipe(rpath, b"1234567890")
+
+    url = gcs.url(rpath)
+    with tempdir() as tmpdir:
+        os.makedirs(tmpdir, exist_ok=True)
+
+        lpath = os.path.join(tmpdir, "out_range.txt")
+        with open(lpath, "wb") as f:
+            f.truncate(10)
+
+        callback = mock.Mock()
+
+        # User tries to pass a conflicting Range header
+        user_headers = {"Range": "bytes=0-1", "Custom-Header": "test-value"}
+
+        with mock.patch.object(
+            gcs, "_get_headers", wraps=gcs._get_headers
+        ) as mock_get_headers:
+            # Safely run the async function on the fsspec background loop
+            fsspec.asyn.sync(
+                gcs.loop,
+                gcs._download_chunk_to_file,
+                url=url,
+                rpath=rpath,
+                lpath=lpath,
+                start_offset=2,
+                end_offset=5,
+                chunk_size=1024,
+                headers=user_headers,
+                callback=callback,
+            )
+
+            # Verify the strict range calculation forced its way into the final headers
+            req_headers = mock_get_headers.call_args[0][0]
+            assert req_headers["Range"] == "bytes=2-4"
+            assert req_headers["Custom-Header"] == "test-value"
+
+            # Verify the data was written correctly to the local file
+            with open(lpath, "rb") as f:
+                f.seek(2)
+                assert f.read(3) == b"345"
+
+
+def test_get_file_range_header_fallback(gcs, monkeypatch):
+    """
+    Test that passing a custom Range header to get_file forces concurrency=1
+    and routes to the sequential downloader, bypassing the concurrent orchestrator.
+    """
+    rpath = f"{TEST_BUCKET}/test_range_fallback.txt"
+    data = b"0123456789"
+    gcs.pipe(rpath, data)
+
+    # Lower the threshold so it WOULD use concurrency if it weren't for the header
+    monkeypatch.setattr(gcs, "MIN_CHUNK_SIZE_FOR_CONCURRENCY", 2)
+
+    with tempdir() as tmpdir:
+        os.makedirs(tmpdir, exist_ok=True)
+        lpath = os.path.join(tmpdir, "out_range_fallback.txt")
+
+        with mock.patch.object(
+            gcs, "_get_file_concurrent", wraps=gcs._get_file_concurrent
+        ) as mock_conc:
+            with mock.patch.object(
+                gcs, "_get_file_request", wraps=gcs._get_file_request
+            ) as mock_seq:
+
+                # Request bytes 2, 3, and 4 (concurrency=4 is ignored)
+                gcs.get_file(
+                    rpath, lpath, concurrency=4, headers={"Range": "bytes=2-4"}
+                )
+
+                # Assert concurrent orchestrator was completely bypassed
+                mock_conc.assert_not_called()
+
+                # Assert sequential downloader was triggered
+                mock_seq.assert_called_once()
+
+        # Verify the file was created and contains exactly the requested range
+        with open(lpath, "rb") as f:
+            assert f.read() == b"234"
+
+
+def test_get_file_top_level_concurrency(gcs, monkeypatch):
+    """
+    Test that the top-level get_file method correctly accepts the concurrency
+    parameter and routes it to the concurrent implementation.
+    """
+    rpath = f"{TEST_BUCKET}/test_top_level_conc.txt"
+    # Create 2MB of random data
+    data = os.urandom(2 * 1024 * 1024)
+    gcs.pipe(rpath, data)
+
+    # Lower the threshold so we don't need a massive file to trigger concurrency
+    monkeypatch.setattr(gcs, "MIN_CHUNK_SIZE_FOR_CONCURRENCY", 1024)
+
+    with tempdir() as tmpdir:
+        os.makedirs(tmpdir, exist_ok=True)
+        lpath = os.path.join(tmpdir, "out_top_level_conc.txt")
+
+        # Spy on the internal concurrent orchestrator
+        with mock.patch.object(
+            gcs, "_get_file_concurrent", wraps=gcs._get_file_concurrent
+        ) as mock_conc:
+
+            # Call the public-facing, top-level method
+            gcs.get_file(rpath, lpath, concurrency=3)
+
+            # Assert the concurrent path was chosen
+            mock_conc.assert_called_once()
+
+            # Assert the concurrency=3 parameter was successfully passed down
+            # Note: call_args[0] contains the positional arguments (rpath, lpath, concurrency)
+            assert mock_conc.call_args[0][2] == 3
+
+        # Verify the data integrity of the final downloaded file
+        with open(lpath, "rb") as f:
+            assert f.read() == data
+
+
+def test_download_chunk_to_file_early_closure(gcs):
+    rpath = f"{TEST_BUCKET}/test_chunk_early.txt"
+    # Create a 5-byte file
+    gcs.pipe(rpath, b"12345")
+
+    url = gcs.url(rpath)
+    with tempdir() as tmpdir:
+        os.makedirs(tmpdir, exist_ok=True)
+
+        lpath = os.path.join(tmpdir, "out_early.txt")
+        with open(lpath, "wb") as f:
+            f.truncate(10)
+
+        callback = mock.Mock()
+
+        # Request 10 bytes, but the remote file only has 5.
+        # The stream will terminate early, testing our fallback check.
+        with pytest.raises(
+            aiohttp.client_exceptions.ClientPayloadError,
+            match="Connection closed early. Expected 10 bytes",
+        ):
+            # Safely run the async function on the fsspec background loop
+            fsspec.asyn.sync(
+                gcs.loop,
+                gcs._download_chunk_to_file,
+                url=url,
+                rpath=rpath,
+                lpath=lpath,
+                start_offset=0,
+                end_offset=10,
+                chunk_size=1024,
+                headers=None,
+                callback=callback,
+            )
 
 
 def test_seek_delimiter(gcs):

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -1428,6 +1428,134 @@ def test_errors(gcs):
         assert "bucket" in str(e)
 
 
+def test_get_file_request_direct(gcs):
+    rpath = f"{TEST_BUCKET}/test_seq_download.txt"
+    data = b"sequential_data_" * 1024
+    gcs.pipe(rpath, data)
+
+    url = gcs.url(rpath)
+
+    with tempdir() as tmpdir:
+        lpath = os.path.join(tmpdir, "out_seq.txt")
+        callback = mock.Mock()
+
+        fsspec.asyn.sync(gcs.loop, gcs._get_file_request, url, lpath, callback=callback)
+
+        with open(lpath, "rb") as f:
+            assert f.read() == data
+
+        assert callback.set_size.called
+        assert callback.relative_update.called
+
+
+def test_get_file_concurrent_direct(gcs, monkeypatch):
+    rpath = f"{TEST_BUCKET}/test_conc_download.txt"
+    data = os.urandom(5 * 1024 * 1024)
+    gcs.pipe(rpath, data)
+
+    monkeypatch.setattr(gcs, "MIN_CHUNK_SIZE_FOR_CONCURRENCY", 1024)
+
+    with tempdir() as tmpdir:
+        lpath = os.path.join(tmpdir, "out_conc.txt")
+        callback = mock.Mock()
+
+        fsspec.asyn.sync(
+            gcs.loop,
+            gcs._get_file_concurrent,
+            rpath,
+            lpath,
+            concurrency=4,
+            callback=callback,
+            chunk_size=1024 * 1024,
+        )
+
+        with open(lpath, "rb") as f:
+            assert f.read() == data
+
+        assert callback.set_size.called
+        assert callback.relative_update.called
+
+
+def test_get_file_concurrent_zero_bytes(gcs):
+    rpath = f"{TEST_BUCKET}/test_conc_zero.txt"
+    gcs.pipe(rpath, b"")
+
+    with tempdir() as tmpdir:
+        lpath = os.path.join(tmpdir, "out_zero.txt")
+        callback = mock.Mock()
+
+        fsspec.asyn.sync(
+            gcs.loop,
+            gcs._get_file_concurrent,
+            rpath,
+            lpath,
+            concurrency=3,
+            callback=callback,
+        )
+
+        assert os.path.exists(lpath)
+        assert os.path.getsize(lpath) == 0
+
+
+def test_get_file_concurrent_exception_cancellation(gcs, monkeypatch):
+    rpath = f"{TEST_BUCKET}/test_conc_exception.txt"
+    data = os.urandom(2 * 1024 * 1024)
+    gcs.pipe(rpath, data)
+
+    monkeypatch.setattr(gcs, "MIN_CHUNK_SIZE_FOR_CONCURRENCY", 1024)
+
+    import builtins
+
+    original_open = builtins.open
+
+    def mocked_open(name, *args, **kwargs):
+        if name.endswith("out_conc_fail.txt") and args[0] == "rb+":
+            raise OSError("Simulated local disk failure")
+        return original_open(name, *args, **kwargs)
+
+    with tempdir() as tmpdir:
+        lpath = os.path.join(tmpdir, "out_conc_fail.txt")
+        with mock.patch("builtins.open", side_effect=mocked_open):
+            with pytest.raises(OSError, match="Simulated local disk failure"):
+                fsspec.asyn.sync(
+                    gcs.loop,
+                    gcs._get_file_concurrent,
+                    rpath,
+                    lpath,
+                    concurrency=3,
+                    chunk_size=1024 * 100,
+                )
+
+
+def test_get_file_concurrent_consistency_check(gcs, monkeypatch):
+    rpath = f"{TEST_BUCKET}/test_conc_consistency.txt"
+    data = b"consistency_check_data_" * 1024
+    gcs.pipe(rpath, data)
+
+    monkeypatch.setattr(gcs, "MIN_CHUNK_SIZE_FOR_CONCURRENCY", 1024)
+
+    with tempdir() as tmpdir:
+        lpath = os.path.join(tmpdir, "out_conc_consistency.txt")
+
+        with mock.patch("gcsfs.core.get_consistency_checker") as mock_checker_factory:
+            mock_checker = mock.Mock()
+            mock_checker_factory.return_value = mock_checker
+
+            fsspec.asyn.sync(
+                gcs.loop,
+                gcs._get_file_concurrent,
+                rpath,
+                lpath,
+                concurrency=2,
+                consistency="md5",
+                chunk_size=1024,
+            )
+
+            assert mock_checker_factory.called
+            assert mock_checker.update.called
+            assert mock_checker.validate_json_response.called
+
+
 def test_read_small(gcs):
     fn = TEST_BUCKET + "/2014-01-01.csv"
     with gcs.open(fn, "rb", block_size=10) as f:


### PR DESCRIPTION
## 1. Implementation of _get_file_concurrent in gcsfs/core.py

A new asynchronous method, _get_file_concurrent, has been added to handle multi-threaded downloads ([ source](https://github.com/fsspec/gcsfs/compare/main...ankitaluthra1:gcsfs:diskx?expand=1&content_ref=async+def+_get_file_concurrent+self+rpath+lpath+concurrency+headers+none+callback+none+kwargs)). Key features include:

- Parallel Fetching: Splits the file into parts based on the requested concurrency and fetches them using HTTP Range headers.
- Non-blocking Disk I/O: Sequential disk writes are offloaded to background threads using run_in_executor to keep the event loop unblocked.
- Consistency Verification: Since on-the-fly checksumming is not feasible for out-of-order concurrent downloads, integrity is verified post-download if a consistency check is requested.
- Generation Pinning: The exact object generation is pinned during the process to prevent silent corruption if the source object is updated mid-download.
- Robustness: Includes retry logic via @retry_request and explicit task cancellation on failure.

## 2. Integration with _get_file
The primary _get_file entry point has been updated to automatically route requests to the concurrent implementation when the concurrency keyword argument is greater than 1.

