### PR TITLE
Adds log for download range for Rapid Bucket

### DIFF
--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -506,6 +506,13 @@ class ExtendedGcsFileSystem(GCSFileSystem):
 
         async def _download(o, s, b, mrd_or_pool):
             async with _get_mrd_from_pool_or_mrd(mrd_or_pool) as m_client:
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(
+                        f"mrd path: {m_client.bucket_name}/{m_client.object_name} | "
+                        f"Requested 1 ranges: [({o}, {s})] | "
+                        f"total bytes requested: {s} | "
+                        f"total bytes downloaded: {s}"
+                    )
                 await m_client.download_ranges([(o, s, b)])
 
         for i in range(concurrency):

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -509,9 +509,7 @@ class ExtendedGcsFileSystem(GCSFileSystem):
                 if logger.isEnabledFor(logging.DEBUG):
                     logger.debug(
                         f"mrd path: {m_client.bucket_name}/{m_client.object_name} | "
-                        f"Requested 1 ranges: [({o}, {s})] | "
-                        f"total bytes requested: {s} | "
-                        f"total bytes downloaded: {s}"
+                        f"Requested range: [({o}, {s})]"
                     )
                 await m_client.download_ranges([(o, s, b)])
 

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -508,7 +508,7 @@ class ExtendedGcsFileSystem(GCSFileSystem):
             async with _get_mrd_from_pool_or_mrd(mrd_or_pool) as m_client:
                 if logger.isEnabledFor(logging.DEBUG):
                     logger.debug(
-                        f"mrd path: {m_client.bucket_name}/{m_client.object_name} | "
+                        f"mrd path: {m_client.object_name} | "
                         f"Requested range: [({o}, {s})]"
                     )
                 await m_client.download_ranges([(o, s, b)])

--- a/gcsfs/tests/test_extended_gcsfs.py
+++ b/gcsfs/tests/test_extended_gcsfs.py
@@ -1260,7 +1260,6 @@ async def test_concurrent_mrd_fetch_success(extended_gcsfs):
     # Add spec so isinstance() checks pass
     mock_pool = mock.AsyncMock(spec=MRDPool)
     mock_mrd = mock.AsyncMock(spec=AsyncMultiRangeDownloader)
-    mock_mrd.bucket_name = "test_bucket"
     mock_mrd.object_name = "test_object"
 
     # Set up the context manager mock return value
@@ -1289,7 +1288,6 @@ async def test_concurrent_mrd_fetch_exception_masking(extended_gcsfs):
     # Add spec so isinstance() checks pass
     mock_pool = mock.AsyncMock(spec=MRDPool)
     mock_mrd = mock.AsyncMock(spec=AsyncMultiRangeDownloader)
-    mock_mrd.bucket_name = "test_bucket"
     mock_mrd.object_name = "test_object"
 
     # Set up the context manager mock return value
@@ -1570,7 +1568,6 @@ async def test_concurrent_mrd_fetch_buffer_error_surfaced(extended_gcsfs):
     """Tests that BufferError is surfaced if tasks succeed but buffers are underfilled."""
     mock_pool = mock.AsyncMock(spec=MRDPool)
     mock_mrd = mock.AsyncMock(spec=AsyncMultiRangeDownloader)
-    mock_mrd.bucket_name = "test_bucket"
     mock_mrd.object_name = "test_object"
     mock_pool.get_mrd.return_value.__aenter__.return_value = mock_mrd
 

--- a/gcsfs/tests/test_extended_gcsfs.py
+++ b/gcsfs/tests/test_extended_gcsfs.py
@@ -1289,6 +1289,8 @@ async def test_concurrent_mrd_fetch_exception_masking(extended_gcsfs):
     # Add spec so isinstance() checks pass
     mock_pool = mock.AsyncMock(spec=MRDPool)
     mock_mrd = mock.AsyncMock(spec=AsyncMultiRangeDownloader)
+    mock_mrd.bucket_name = "test_bucket"
+    mock_mrd.object_name = "test_object"
 
     # Set up the context manager mock return value
     mock_pool.get_mrd.return_value.__aenter__.return_value = mock_mrd
@@ -1568,6 +1570,8 @@ async def test_concurrent_mrd_fetch_buffer_error_surfaced(extended_gcsfs):
     """Tests that BufferError is surfaced if tasks succeed but buffers are underfilled."""
     mock_pool = mock.AsyncMock(spec=MRDPool)
     mock_mrd = mock.AsyncMock(spec=AsyncMultiRangeDownloader)
+    mock_mrd.bucket_name = "test_bucket"
+    mock_mrd.object_name = "test_object"
     mock_pool.get_mrd.return_value.__aenter__.return_value = mock_mrd
 
     async def underfilling_download(ranges):

--- a/gcsfs/tests/test_extended_gcsfs.py
+++ b/gcsfs/tests/test_extended_gcsfs.py
@@ -1260,6 +1260,8 @@ async def test_concurrent_mrd_fetch_success(extended_gcsfs):
     # Add spec so isinstance() checks pass
     mock_pool = mock.AsyncMock(spec=MRDPool)
     mock_mrd = mock.AsyncMock(spec=AsyncMultiRangeDownloader)
+    mock_mrd.bucket_name = "test_bucket"
+    mock_mrd.object_name = "test_object"
 
     # Set up the context manager mock return value
     mock_pool.get_mrd.return_value.__aenter__.return_value = mock_mrd


### PR DESCRIPTION
This pull request adds debug logging to the _download helper function within _concurrent_mrd_fetch to log range requested from GCS using MRD.