### PR TITLE
Fix ReadTheDocs builds by switching conda environment to conda-forge

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,9 +1,11 @@
 name: gcsfs
 channels:
-  - defaults
+  - conda-forge
+  - nodefaults
 dependencies:
   - python= 3.10
   - docutils<0.17
   - setuptools<81
+  - pip
   - sphinx
   - sphinx_rtd_theme


### PR DESCRIPTION
This PR resolves the intermittent `CondaHTTPError` (`SSL: certificate verify failed`) failures that are currently breaking ReadTheDocs builds across the repository.

**Context:**
Anaconda frequently enforces their Commercial Terms of Service by throttling or IP-blocking massive CI/CD providers (like ReadTheDocs) from pulling packages from their `defaults` channel (`repo.anaconda.com`). When ReadTheDocs hits this firewall, the SSL handshake is dropped and the build fails.

As [officially documented by ReadTheDocs](https://docs.readthedocs.com/platform/stable/guides/conda.html#effective-use-of-channels), the `defaults` channel is subject to Anaconda's Terms of Service. Their documentation recommends completely opting out of the `defaults` channel using `nodefaults` to avoid these restrictions. 

**Changes:**
To ensure reliable documentation builds, this PR updates `docs/environment.yml` to:
1. Exclusively use `conda-forge` (which is hosted on a public CDN that does not block CI servers).
2. Append `nodefaults` to strictly prevent `conda` from attempting to query the blocked Anaconda commercial servers.
3. Explicitly list `pip` to resolve conda's dependency resolution warning.
