### PR TITLE
Refactor directory cache updates and optimize caching logic

### DIFF
--- a/gcsfs/_dircache.py
+++ b/gcsfs/_dircache.py
@@ -6,14 +6,15 @@ consistent with the bucket. This module groups that concern into two mixins so
 the bookkeeping lives in one place rather than being interleaved with the I/O
 in :mod:`gcsfs.core` and :mod:`gcsfs.extended_gcsfs`:
 
-- :class:`DirCacheUpdater` -- the default strategy. Broadly invalidates the
-  affected parent directory and all of its ancestors, so the next listing
-  re-reads them from the bucket.
+- :class:`DirCacheUpdater` -- the default strategy. For deletes and moves it
+  broadly invalidates the affected parent directory and all of its ancestors, so
+  the next listing re-reads them from the bucket. For writes it invalidates only
+  the immediate parent when that parent is already cached (and therefore known to
+  exist), falling back to broad ancestor invalidation otherwise.
 - :class:`HnsDirCacheUpdater` -- a targeted strategy for Hierarchical Namespace
   (HNS) buckets, where directories are first-class persistent objects. It
-  mutates parent listings in place for deletes and moves, and invalidates only
-  the immediate parent listing for writes, falling back to the broad strategy
-  for non-HNS paths.
+  mutates parent listings in place for deletes and moves, falling back to the
+  broad strategy for non-HNS paths.
 
 Both are mixed into a filesystem class and rely on the host class for
 ``dircache``, ``split_path``, ``_parent``, ``_strip_protocol``,
@@ -24,7 +25,12 @@ import asyncio
 
 
 class DirCacheUpdater:
-    """Default ``dircache`` update strategy: broad ancestor invalidation.
+    """Default ``dircache`` update strategy.
+
+    Deletes and moves broadly invalidate the affected parent and all of its
+    ancestors; writes invalidate only the immediate parent when it is already
+    cached (and therefore known to exist), otherwise they fall back to broad
+    ancestor invalidation.
 
     Mixed into :class:`gcsfs.core.GCSFileSystem`. The methods are the hooks that
     the mutating I/O paths (``_rm_file``, ``_rm_files``, ``_put_file``, ...) call
@@ -47,9 +53,28 @@ class DirCacheUpdater:
             self.invalidate_cache(parent)
 
     async def _write_file_cache_update(self, path):
-        # A file was created or overwritten at ``path`` (via put/pipe/cp). The
-        # default behavior invalidates the parent and all of its ancestors.
-        self.invalidate_cache(self._parent(path))
+        # A file was created or overwritten at ``path`` (via put/pipe/cp).
+        #
+        # When the immediate parent's listing is already cached, we have listed
+        # it before, so it already exists and adding a file inside it cannot
+        # create a new directory in any ancestor's listing. Invalidate only that
+        # immediate parent so the new file is picked up on its next listing.
+        #
+        # When the parent is not cached, this write may have implicitly created
+        # it (and intermediate directories) -- flat buckets simulate directories
+        # from object prefixes, and HNS buckets auto-create missing parents on
+        # object write. Leaving a cached ancestor untouched would hide the new
+        # directory, so fall back to invalidating the parent and all ancestors.
+        #
+        # Like the rest of this module, this relies on the dircache being
+        # consistent with the bucket (this client is the sole mutator between
+        # listings); concurrent external mutations are reconciled only by
+        # ``invalidate_cache`` / listings expiry, not here.
+        parent = self._parent(path)
+        if parent in self.dircache:
+            self.dircache.pop(parent, None)
+        else:
+            self.invalidate_cache(parent)
 
 
 class HnsDirCacheUpdater(DirCacheUpdater):
@@ -57,10 +82,10 @@ class HnsDirCacheUpdater(DirCacheUpdater):
 
     Mixed into :class:`gcsfs.extended_gcsfs.ExtendedGcsFileSystem`. For HNS
     buckets directories are persistent objects, so deletes and moves usually
-    only change the contents of the immediate parent's listing. Writes
-    invalidate the immediate parent listing without walking every ancestor up to
-    the bucket root. Non-HNS / cross-bucket paths defer to
-    :class:`DirCacheUpdater` via ``super()``.
+    only change the contents of the immediate parent's listing. Non-HNS /
+    cross-bucket paths defer to :class:`DirCacheUpdater` via ``super()``. The
+    write path is bucket-type-agnostic and handled entirely by
+    :meth:`DirCacheUpdater._write_file_cache_update`.
     """
 
     def _cache_drop_entries(self, parent, names):
@@ -118,6 +143,12 @@ class HnsDirCacheUpdater(DirCacheUpdater):
             path1 (str): The source path that was renamed.
             path2 (str): The destination path.
         """
+        # dircache keys and entry names are stored without the protocol, so
+        # normalize the incoming paths first; otherwise the pop/startswith
+        # matching below silently misses every cached entry for a ``gs://`` path.
+        path1 = self._strip_protocol(path1)
+        path2 = self._strip_protocol(path2)
+
         # 1. Find and remove all descendant paths of the source from the cache.
         source_prefix = f"{path1.rstrip('/')}/"
         for key in list(self.dircache):
@@ -217,26 +248,3 @@ class HnsDirCacheUpdater(DirCacheUpdater):
 
         if non_hns_paths:
             await super()._rm_files_cache_update(non_hns_paths)
-
-    async def _write_file_cache_update(self, path):
-        """
-        Update the cache after a file create/overwrite (put/pipe/cp).
-
-        For HNS-enabled buckets the single-level shortcut (invalidate only the
-        immediate parent, not every ancestor up to the bucket root) is taken
-        only when that parent is already cached. A cached parent is one we have
-        listed, so it already exists, which means creating a file inside it
-        cannot add a new directory to any ancestor's listing.
-
-        When the parent is not cached we cannot rule out that this write
-        implicitly created it (HNS auto-creates missing parent folders on object
-        write); leaving a cached ancestor untouched would hide the new directory
-        from a subsequent listing. In that case, and for non-HNS buckets, fall
-        back to the default broad invalidation of the parent and all ancestors.
-        """
-        bucket, _, _ = self.split_path(path)
-        parent = self._parent(path)
-        if await self._is_bucket_hns_enabled(bucket) and parent in self.dircache:
-            self.dircache.pop(parent, None)
-        else:
-            await super()._write_file_cache_update(path)

--- a/gcsfs/_dircache.py
+++ b/gcsfs/_dircache.py
@@ -1,0 +1,242 @@
+"""Directory-listing cache (``dircache``) update strategies.
+
+The filesystem keeps a cache of directory listings in ``self.dircache``. After
+any mutating operation (delete, write, move, ...) that cache must be kept
+consistent with the bucket. This module groups that concern into two mixins so
+the bookkeeping lives in one place rather than being interleaved with the I/O
+in :mod:`gcsfs.core` and :mod:`gcsfs.extended_gcsfs`:
+
+- :class:`DirCacheUpdater` -- the default strategy. Broadly invalidates the
+  affected parent directory and all of its ancestors, so the next listing
+  re-reads them from the bucket.
+- :class:`HnsDirCacheUpdater` -- a targeted strategy for Hierarchical Namespace
+  (HNS) buckets, where directories are first-class persistent objects. It
+  mutates parent listings in place for deletes and moves, and invalidates only
+  the immediate parent listing for writes, falling back to the broad strategy
+  for non-HNS paths.
+
+Both are mixed into a filesystem class and rely on the host class for
+``dircache``, ``split_path``, ``_parent``, ``_strip_protocol``,
+``invalidate_cache``, ``_is_bucket_hns_enabled`` and ``_process_object``.
+"""
+
+import asyncio
+
+
+class DirCacheUpdater:
+    """Default ``dircache`` update strategy: broad ancestor invalidation.
+
+    Mixed into :class:`gcsfs.core.GCSFileSystem`. The methods are the hooks that
+    the mutating I/O paths (``_rm_file``, ``_rm_files``, ``_put_file``, ...) call
+    after a successful operation; subclasses override them to provide a more
+    targeted strategy.
+    """
+
+    async def _mv_file_cache_update(self, path1, path2, response=None):
+        self.invalidate_cache(self._parent(path1))
+        self.invalidate_cache(self._parent(path2))
+
+    async def _rm_file_cache_update(self, path):
+        # Single-path form of _rm_files_cache_update; kept as one code path so
+        # subclasses only need to override the batch method.
+        await self._rm_files_cache_update([path])
+
+    async def _rm_files_cache_update(self, paths):
+        parents = set(self._parent(p) for p in paths) | set(paths)
+        for parent in parents:
+            self.invalidate_cache(parent)
+
+    async def _write_file_cache_update(self, path):
+        # A file was created or overwritten at ``path`` (via put/pipe/cp). The
+        # default behavior invalidates the parent and all of its ancestors.
+        self.invalidate_cache(self._parent(path))
+
+
+class HnsDirCacheUpdater(DirCacheUpdater):
+    """Targeted ``dircache`` update strategy for HNS buckets.
+
+    Mixed into :class:`gcsfs.extended_gcsfs.ExtendedGcsFileSystem`. For HNS
+    buckets directories are persistent objects, so deletes and moves usually
+    only change the contents of the immediate parent's listing. Writes
+    invalidate the immediate parent listing without walking every ancestor up to
+    the bucket root. Non-HNS / cross-bucket paths defer to
+    :class:`DirCacheUpdater` via ``super()``.
+    """
+
+    def _cache_drop_entries(self, parent, names):
+        """Remove entries whose ``name`` is in ``names`` from ``parent``'s
+        cached listing. No-op when ``parent`` is not cached.
+
+        ``names`` is a set of stripped ``bucket/key`` names matching the
+        ``name`` field of the cached entries.
+        """
+        if parent in self.dircache:
+            self.dircache[parent] = [
+                e for e in self.dircache[parent] if e.get("name") not in names
+            ]
+
+    def _cache_add_entry(self, parent, entry):
+        """Append ``entry`` to ``parent``'s cached listing. No-op when
+        ``parent`` is not cached."""
+        if parent in self.dircache:
+            self.dircache[parent].append(entry)
+
+    def _cache_upsert_entry(self, parent, entry):
+        """Replace any cached entry with the same name before appending
+        ``entry``. No-op when ``parent`` is not cached."""
+        if parent in self.dircache:
+            name = entry.get("name")
+            self.dircache[parent] = [
+                e for e in self.dircache[parent] if e.get("name") != name
+            ]
+            self.dircache[parent].append(entry)
+
+    @staticmethod
+    def _directory_cache_entry(name, key):
+        """Build a cached directory-listing entry for an HNS folder located at
+        ``name`` (stripped ``bucket/key`` path) with object key ``key``."""
+        return {
+            "Key": key,
+            "Size": 0,
+            "name": name,
+            "size": 0,
+            "type": "directory",
+            "storageClass": "DIRECTORY",
+        }
+
+    def _update_dircache_after_rename(self, path1, path2):
+        """
+        Performs a targeted update of the directory cache after a successful
+        folder rename operation.
+
+        This involves three main steps:
+        1. Removing the source folder and all its descendants from the cache.
+        2. Removing the source folder's entry from its parent's listing.
+        3. Adding the new destination folder's entry to its parent's listing.
+
+        Args:
+            path1 (str): The source path that was renamed.
+            path2 (str): The destination path.
+        """
+        # 1. Find and remove all descendant paths of the source from the cache.
+        source_prefix = f"{path1.rstrip('/')}/"
+        for key in list(self.dircache):
+            if key.startswith(source_prefix):
+                self.dircache.pop(key, None)
+
+        # 2. Remove the old source entry from its parent's listing.
+        self.dircache.pop(path1, None)
+        self._cache_drop_entries(self._parent(path1), {path1})
+
+        # 3. Invalidate the destination path/subtree and update its parent's cache.
+        dest_prefix = f"{path2.rstrip('/')}/"
+        for key in list(self.dircache):
+            if key == path2 or key.startswith(dest_prefix):
+                self.dircache.pop(key, None)
+        _, key2, _ = self.split_path(path2)
+        self._cache_upsert_entry(
+            self._parent(path2), self._directory_cache_entry(path2, key2)
+        )
+
+    async def _mv_file_cache_update(self, path1, path2, response=None):
+        """
+        Update the cache after a file move operation.
+
+        For HNS-enabled buckets where the move is within the same bucket, this method
+        directly updates the directory cache by removing the source entry from it's
+        parent cache and adding destination path as a new entry in it's corresponding parent cache.
+        This avoids invalidating the entire parent directory cache, which is beneficial for HNS
+        performance.
+
+        For non-HNS buckets or cross-bucket moves, it falls back to the default
+        behavior (invalidating the cache for both source and destination parents).
+        """
+        src_bucket, _, _ = self.split_path(path1)
+        dest_bucket, _, _ = self.split_path(path2)
+
+        if await self._is_bucket_hns_enabled(src_bucket) and src_bucket == dest_bucket:
+            # Source: removing the entry never changes an ancestor's listing, so
+            # drop it in place.
+            self._cache_drop_entries(self._parent(path1), {self._strip_protocol(path1)})
+            dest_parent = self._parent(path2)
+            if response and dest_parent in self.dircache:
+                # Destination parent is already cached (so it existed before the
+                # move) -> updating it in place cannot leave an ancestor stale.
+                self._cache_upsert_entry(
+                    dest_parent, self._process_object(dest_bucket, response)
+                )
+            else:
+                # The destination parent may have been created by this move;
+                # broad-invalidate it so a cached ancestor can't hide the new
+                # directory (also covers a missing/empty move response).
+                self.invalidate_cache(dest_parent)
+        else:
+            await super()._mv_file_cache_update(path1, path2, response)
+
+    async def _rm_files_cache_update(self, paths):
+        """
+        Update the cache after a (batch) file delete operation.
+
+        For HNS-enabled buckets, directories are first-class persistent objects,
+        so deleting a file only changes the contents of its immediate parent.
+        Each deleted entry is removed from its immediate parent's listing
+        (grouped per parent so each listing is rewritten only once), avoiding the
+        redundant invalidation of all ancestor directories up to the root.
+
+        Entries are matched by name only; the object generation is not taken
+        into account. Non-HNS paths fall back to the default broad invalidation
+        of the parents and all of their ancestors.
+        """
+        # Split each path once and resolve each distinct bucket's HNS status
+        # once, concurrently, rather than awaiting a (cached) lookup per path.
+        split_paths = [(path, *self.split_path(path)) for path in paths]
+        buckets = list({bucket for _, bucket, _, _ in split_paths})
+        hns_enabled = dict(
+            zip(
+                buckets,
+                await asyncio.gather(
+                    *(self._is_bucket_hns_enabled(bucket) for bucket in buckets)
+                ),
+            )
+        )
+
+        # Group the names to drop by their immediate parent so each listing is
+        # rewritten only once. Non-HNS paths fall back to broad invalidation.
+        removed_names_by_parent = {}
+        non_hns_paths = []
+        for path, bucket, key, _ in split_paths:
+            if hns_enabled[bucket]:
+                removed_names_by_parent.setdefault(self._parent(path), set()).add(
+                    f"{bucket}/{key}"
+                )
+            else:
+                non_hns_paths.append(path)
+
+        for parent, removed_names in removed_names_by_parent.items():
+            self._cache_drop_entries(parent, removed_names)
+
+        if non_hns_paths:
+            await super()._rm_files_cache_update(non_hns_paths)
+
+    async def _write_file_cache_update(self, path):
+        """
+        Update the cache after a file create/overwrite (put/pipe/cp).
+
+        For HNS-enabled buckets the single-level shortcut (invalidate only the
+        immediate parent, not every ancestor up to the bucket root) is taken
+        only when that parent is already cached. A cached parent is one we have
+        listed, so it already exists, which means creating a file inside it
+        cannot add a new directory to any ancestor's listing.
+
+        When the parent is not cached we cannot rule out that this write
+        implicitly created it (HNS auto-creates missing parent folders on object
+        write); leaving a cached ancestor untouched would hide the new directory
+        from a subsequent listing. In that case, and for non-HNS buckets, fall
+        back to the default broad invalidation of the parent and all ancestors.
+        """
+        bucket, _, _ = self.split_path(path)
+        parent = self._parent(path)
+        if await self._is_bucket_hns_enabled(bucket) and parent in self.dircache:
+            self.dircache.pop(parent, None)
+        else:
+            await super()._write_file_cache_update(path)

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1480,13 +1480,18 @@ class GCSFileSystem(asyn.AsyncFileSystem):
 
     mv_file = asyn.sync_wrapper(_mv_file)
 
+    async def _rm_file_cache_update(self, path):
+        self.invalidate_cache(posixpath.dirname(self._strip_protocol(path)))
+
+    async def _rm_files_cache_update(self, paths):
+        parents = set(self._parent(p) for p in paths) | set(paths)
+        [self.invalidate_cache(parent) for parent in parents]
+
     async def _rm_file(self, path, **kwargs):
         bucket, key, generation = self.split_path(path)
         if key:
             await self._call("DELETE", "b/{}/o/{}", bucket, key, generation=generation)
-            # TODO: This can be optimized for HNS buckets by not invalidating the entire parent
-            # directory structure from cache but to just remove the deleted file entry from immediate parent's cache.
-            self.invalidate_cache(posixpath.dirname(self._strip_protocol(path)))
+            await self._rm_file_cache_update(path)
         else:
             await self._rmdir(path)
 
@@ -1539,15 +1544,15 @@ class GCSFileSystem(asyn.AsyncFileSystem):
             )
 
             boundary = headers["Content-Type"].split("=", 1)[1]
-            parents = set(self._parent(p) for p in paths) | set(paths)
-            [self.invalidate_cache(parent) for parent in parents]
             txt = content.decode()
             responses = txt.split(boundary)[1:-1]
+            deleted = []
             for path, response in zip(paths, responses):
                 m = re.search("HTTP/[0-9.]+ ([0-9]+)", response)
                 code = int(m.groups()[0]) if m else None
                 if code in [200, 204]:
                     out.append(path)
+                    deleted.append(path)
                 elif code in errs and retry < 5:
                     remaining.append(path)
                 else:
@@ -1560,6 +1565,12 @@ class GCSFileSystem(asyn.AsyncFileSystem):
                         out.append(OSError(msg2.groups()[0]))
                     else:
                         out.append(OSError(f"{path}: {code}"))
+            # Only update the cache for objects we actually deleted. Updating it
+            # for failed paths would evict still-present objects from the cache
+            # (the HNS targeted update mutates the parent listing in place and
+            # does not self-correct on the next listing).
+            if deleted:
+                await self._rm_files_cache_update(deleted)
             if remaining:
                 paths = remaining
                 await asyncio.sleep(min(random.random() + 2 ** (retry - 1), 32))

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -27,6 +27,7 @@ from fsspec.implementations.http import get_client
 from fsspec.utils import other_paths, setup_logging, stringify_path
 
 from . import __version__ as version
+from ._dircache import DirCacheUpdater
 from .checkers import get_consistency_checker
 from .concurrency import parallel_tasks_first_completed
 from .credentials import GoogleCredentials
@@ -179,7 +180,7 @@ def _is_directory_marker(entry):
     return entry["size"] == 0 and entry["name"].endswith("/")
 
 
-class GCSFileSystem(asyn.AsyncFileSystem):
+class GCSFileSystem(DirCacheUpdater, asyn.AsyncFileSystem):
     r"""
     Connect to Google Cloud Storage.
 
@@ -1438,10 +1439,6 @@ class GCSFileSystem(asyn.AsyncFileSystem):
             )
         await self._write_file_cache_update(path2)
 
-    async def _mv_file_cache_update(self, path1, path2, response=None):
-        self.invalidate_cache(self._parent(path1))
-        self.invalidate_cache(self._parent(path2))
-
     async def _mv_file(self, path1, path2, **kwargs):
         src_bucket, src_key, generation1 = self.split_path(path1)
         dest_bucket, dest_key, generation2 = self.split_path(path2)
@@ -1479,20 +1476,6 @@ class GCSFileSystem(asyn.AsyncFileSystem):
         await super()._mv_file(path1, path2, **kwargs)
 
     mv_file = asyn.sync_wrapper(_mv_file)
-
-    async def _rm_file_cache_update(self, path):
-        # Single-path form of _rm_files_cache_update; kept as one code path so
-        # subclasses only need to override the batch method.
-        await self._rm_files_cache_update([path])
-
-    async def _rm_files_cache_update(self, paths):
-        parents = set(self._parent(p) for p in paths) | set(paths)
-        [self.invalidate_cache(parent) for parent in parents]
-
-    async def _write_file_cache_update(self, path):
-        # A file was created or overwritten at ``path`` (via put/pipe/cp). The
-        # default behavior invalidates the parent and all of its ancestors.
-        self.invalidate_cache(self._parent(path))
 
     async def _rm_file(self, path, **kwargs):
         bucket, key, generation = self.split_path(path)

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1436,7 +1436,7 @@ class GCSFileSystem(asyn.AsyncFileSystem):
                 json_out=True,
                 sourceGeneration=g1,
             )
-        self.invalidate_cache(self._parent(path2))
+        await self._write_file_cache_update(path2)
 
     async def _mv_file_cache_update(self, path1, path2, response=None):
         self.invalidate_cache(self._parent(path1))
@@ -1481,11 +1481,18 @@ class GCSFileSystem(asyn.AsyncFileSystem):
     mv_file = asyn.sync_wrapper(_mv_file)
 
     async def _rm_file_cache_update(self, path):
-        self.invalidate_cache(posixpath.dirname(self._strip_protocol(path)))
+        # Single-path form of _rm_files_cache_update; kept as one code path so
+        # subclasses only need to override the batch method.
+        await self._rm_files_cache_update([path])
 
     async def _rm_files_cache_update(self, paths):
         parents = set(self._parent(p) for p in paths) | set(paths)
         [self.invalidate_cache(parent) for parent in parents]
+
+    async def _write_file_cache_update(self, path):
+        # A file was created or overwritten at ``path`` (via put/pipe/cp). The
+        # default behavior invalidates the parent and all of its ancestors.
+        self.invalidate_cache(self._parent(path))
 
     async def _rm_file(self, path, **kwargs):
         bucket, key, generation = self.split_path(path)
@@ -1547,6 +1554,7 @@ class GCSFileSystem(asyn.AsyncFileSystem):
             txt = content.decode()
             responses = txt.split(boundary)[1:-1]
             deleted = []
+            confirmed_absent = []
             for path, response in zip(paths, responses):
                 m = re.search("HTTP/[0-9.]+ ([0-9]+)", response)
                 code = int(m.groups()[0]) if m else None
@@ -1556,6 +1564,8 @@ class GCSFileSystem(asyn.AsyncFileSystem):
                 elif code in errs and retry < 5:
                     remaining.append(path)
                 else:
+                    if code == 404:
+                        confirmed_absent.append(path)
                     msg = re.search("{(.*)}", response.replace("\n", ""))
                     if msg:
                         msg2 = re.search("({.*})", msg.groups()[0])
@@ -1565,12 +1575,14 @@ class GCSFileSystem(asyn.AsyncFileSystem):
                         out.append(OSError(msg2.groups()[0]))
                     else:
                         out.append(OSError(f"{path}: {code}"))
-            # Only update the cache for objects we actually deleted. Updating it
-            # for failed paths would evict still-present objects from the cache
-            # (the HNS targeted update mutates the parent listing in place and
-            # does not self-correct on the next listing).
-            if deleted:
-                await self._rm_files_cache_update(deleted)
+            # Only update the cache for objects we actually deleted, or that GCS
+            # confirms are already absent. Updating it for other failed paths
+            # would evict still-present objects from the cache (the HNS targeted
+            # update mutates the parent listing in place and does not self-correct
+            # on the next listing).
+            cache_updates = deleted + confirmed_absent
+            if cache_updates:
+                await self._rm_files_cache_update(cache_updates)
             if remaining:
                 paths = remaining
                 await asyncio.sleep(min(random.random() + 2 ** (retry - 1), 32))
@@ -1690,7 +1702,7 @@ class GCSFileSystem(asyn.AsyncFileSystem):
             checker.update(data)
             checker.validate_json_response(out)
 
-        self.invalidate_cache(self._parent(path))
+        await self._write_file_cache_update(path)
         return location
 
     async def _put_file(
@@ -1769,7 +1781,7 @@ class GCSFileSystem(asyn.AsyncFileSystem):
 
                 checker.validate_json_response(out)
 
-            self.invalidate_cache(self._parent(rpath))
+            await self._write_file_cache_update(rpath)
 
     async def _isdir(self, path):
 

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -26,6 +26,7 @@ from google.cloud.storage.asyncio.async_multi_range_downloader import (
 
 from gcsfs import __version__ as version
 from gcsfs import zb_hns_utils
+from gcsfs._dircache import HnsDirCacheUpdater
 from gcsfs.core import GCSFile, GCSFileSystem
 from gcsfs.retry import DEFAULT_RETRY_CONFIG, get_storage_control_retry_config
 from gcsfs.zb_hns_utils import DirectMemmoveBuffer, MRDPool
@@ -77,7 +78,7 @@ async def _get_mrd_size(mrd_or_pool):
         return m.persisted_size
 
 
-class ExtendedGcsFileSystem(GCSFileSystem):
+class ExtendedGcsFileSystem(HnsDirCacheUpdater, GCSFileSystem):
     """
     This class will be used when GCSFS_EXPERIMENTAL_ZB_HNS_SUPPORT env variable is set to true.
     ExtendedGcsFileSystem is a subclass of GCSFileSystem that adds new logic for bucket types
@@ -632,164 +633,6 @@ class ExtendedGcsFileSystem(GCSFileSystem):
 
         return bucket_type in [BucketType.ZONAL_HIERARCHICAL, BucketType.HIERARCHICAL]
 
-    def _cache_drop_entries(self, parent, names):
-        """Remove entries whose ``name`` is in ``names`` from ``parent``'s
-        cached listing. No-op when ``parent`` is not cached.
-
-        ``names`` is a set of stripped ``bucket/key`` names matching the
-        ``name`` field of the cached entries.
-        """
-        if parent in self.dircache:
-            self.dircache[parent] = [
-                e for e in self.dircache[parent] if e.get("name") not in names
-            ]
-
-    def _cache_add_entry(self, parent, entry):
-        """Append ``entry`` to ``parent``'s cached listing. No-op when
-        ``parent`` is not cached."""
-        if parent in self.dircache:
-            self.dircache[parent].append(entry)
-
-    def _update_dircache_after_rename(self, path1, path2):
-        """
-        Performs a targeted update of the directory cache after a successful
-        folder rename operation.
-
-        This involves three main steps:
-        1. Removing the source folder and all its descendants from the cache.
-        2. Removing the source folder's entry from its parent's listing.
-        3. Adding the new destination folder's entry to its parent's listing.
-
-        Args:
-            path1 (str): The source path that was renamed.
-            path2 (str): The destination path.
-        """
-        # 1. Find and remove all descendant paths of the source from the cache.
-        source_prefix = f"{path1.rstrip('/')}/"
-        for key in list(self.dircache):
-            if key.startswith(source_prefix):
-                self.dircache.pop(key, None)
-
-        # 2. Remove the old source entry from its parent's listing.
-        self.dircache.pop(path1, None)
-        self._cache_drop_entries(self._parent(path1), {path1})
-
-        # 3. Invalidate the destination path and update its parent's cache.
-        self.dircache.pop(path2, None)
-        _, key2, _ = self.split_path(path2)
-        new_entry = {
-            "Key": key2,
-            "Size": 0,
-            "name": path2,
-            "size": 0,
-            "type": "directory",
-            "storageClass": "DIRECTORY",
-        }
-        self._cache_add_entry(self._parent(path2), new_entry)
-
-    async def _mv_file_cache_update(self, path1, path2, response=None):
-        """
-        Update the cache after a file move operation.
-
-        For HNS-enabled buckets where the move is within the same bucket, this method
-        directly updates the directory cache by removing the source entry from it's
-        parent cache and adding destination path as a new entry in it's corresponding parent cache.
-        This avoids invalidating the entire parent directory cache, which is beneficial for HNS
-        performance.
-
-        For non-HNS buckets or cross-bucket moves, it falls back to the default
-        behavior (invalidating the cache for both source and destination parents).
-        """
-        src_bucket, _, _ = self.split_path(path1)
-        dest_bucket, _, _ = self.split_path(path2)
-
-        if await self._is_bucket_hns_enabled(src_bucket) and src_bucket == dest_bucket:
-            # Source: removing the entry never changes an ancestor's listing, so
-            # drop it in place.
-            self._cache_drop_entries(self._parent(path1), {self._strip_protocol(path1)})
-            dest_parent = self._parent(path2)
-            if response and dest_parent in self.dircache:
-                # Destination parent is already cached (so it existed before the
-                # move) -> updating it in place cannot leave an ancestor stale.
-                self._cache_add_entry(
-                    dest_parent, self._process_object(dest_bucket, response)
-                )
-            else:
-                # The destination parent may have been created by this move;
-                # broad-invalidate it so a cached ancestor can't hide the new
-                # directory (also covers a missing/empty move response).
-                self.invalidate_cache(dest_parent)
-        else:
-            await super()._mv_file_cache_update(path1, path2, response)
-
-    async def _rm_files_cache_update(self, paths):
-        """
-        Update the cache after a (batch) file delete operation.
-
-        For HNS-enabled buckets, directories are first-class persistent objects,
-        so deleting a file only changes the contents of its immediate parent.
-        Each deleted entry is removed from its immediate parent's listing
-        (grouped per parent so each listing is rewritten only once), avoiding the
-        redundant invalidation of all ancestor directories up to the root.
-
-        Entries are matched by name only; the object generation is not taken
-        into account. Non-HNS paths fall back to the default broad invalidation
-        of the parents and all of their ancestors.
-        """
-        # Split each path once and resolve each distinct bucket's HNS status
-        # once, concurrently, rather than awaiting a (cached) lookup per path.
-        split_paths = [(path, *self.split_path(path)) for path in paths]
-        buckets = list({bucket for _, bucket, _, _ in split_paths})
-        hns_enabled = dict(
-            zip(
-                buckets,
-                await asyncio.gather(
-                    *(self._is_bucket_hns_enabled(bucket) for bucket in buckets)
-                ),
-            )
-        )
-
-        # Group the names to drop by their immediate parent so each listing is
-        # rewritten only once. Non-HNS paths fall back to broad invalidation.
-        removed_names_by_parent = {}
-        non_hns_paths = []
-        for path, bucket, key, _ in split_paths:
-            if hns_enabled[bucket]:
-                removed_names_by_parent.setdefault(self._parent(path), set()).add(
-                    f"{bucket}/{key}"
-                )
-            else:
-                non_hns_paths.append(path)
-
-        for parent, removed_names in removed_names_by_parent.items():
-            self._cache_drop_entries(parent, removed_names)
-
-        if non_hns_paths:
-            await super()._rm_files_cache_update(non_hns_paths)
-
-    async def _write_file_cache_update(self, path):
-        """
-        Update the cache after a file create/overwrite (put/pipe/cp).
-
-        For HNS-enabled buckets the single-level shortcut (invalidate only the
-        immediate parent, not every ancestor up to the bucket root) is taken
-        only when that parent is already cached. A cached parent is one we have
-        listed, so it already exists, which means creating a file inside it
-        cannot add a new directory to any ancestor's listing.
-
-        When the parent is not cached we cannot rule out that this write
-        implicitly created it (HNS auto-creates missing parent folders on object
-        write); leaving a cached ancestor untouched would hide the new directory
-        from a subsequent listing. In that case, and for non-HNS buckets, fall
-        back to the default broad invalidation of the parent and all ancestors.
-        """
-        bucket, _, _ = self.split_path(path)
-        parent = self._parent(path)
-        if await self._is_bucket_hns_enabled(bucket) and parent in self.dircache:
-            self.dircache.pop(parent, None)
-        else:
-            await super()._write_file_cache_update(path)
-
     async def _mv(self, path1, path2, **kwargs):
         """
         Move a file or directory. Overrides the parent `_mv` to provide an
@@ -1018,15 +861,10 @@ class ExtendedGcsFileSystem(GCSFileSystem):
                 timeout=STORAGE_CONTROL_RPC_TIMEOUT,
             )
             # Instead of invalidating the parent cache, update it to add the new entry.
-            new_entry = {
-                "Key": key.rstrip("/"),
-                "Size": 0,
-                "name": path,
-                "size": 0,
-                "type": "directory",
-                "storageClass": "DIRECTORY",
-            }
-            self._cache_add_entry(self._parent(path), new_entry)
+            self._cache_add_entry(
+                self._parent(path),
+                self._directory_cache_entry(path, key.rstrip("/")),
+            )
         except api_exceptions.Conflict as e:
             logger.debug(f"Directory already exists: {path}: {e}")
         except api_exceptions.FailedPrecondition as e:

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -707,6 +707,65 @@ class ExtendedGcsFileSystem(GCSFileSystem):
         else:
             await super()._mv_file_cache_update(path1, path2, response)
 
+    async def _rm_file_cache_update(self, path):
+        """
+        Update the cache after a file delete operation.
+
+        This is the single-path form of :meth:`_rm_files_cache_update`; see that
+        method for the HNS-aware behavior.
+        """
+        await self._rm_files_cache_update([path])
+
+    async def _rm_files_cache_update(self, paths):
+        """
+        Update the cache after a (batch) file delete operation.
+
+        For HNS-enabled buckets, directories are first-class persistent objects,
+        so deleting a file only changes the contents of its immediate parent.
+        Each deleted entry is removed from its immediate parent's listing
+        (grouped per parent so each listing is rewritten only once), avoiding the
+        redundant invalidation of all ancestor directories up to the root.
+
+        Entries are matched by name only; the object generation is not taken
+        into account. Non-HNS paths fall back to the default broad invalidation
+        of the parents and all of their ancestors.
+        """
+        # Split each path once and resolve each distinct bucket's HNS status
+        # once, concurrently, rather than awaiting a (cached) lookup per path.
+        split_paths = [(path, *self.split_path(path)) for path in paths]
+        buckets = list({bucket for _, bucket, _, _ in split_paths})
+        hns_enabled = dict(
+            zip(
+                buckets,
+                await asyncio.gather(
+                    *(self._is_bucket_hns_enabled(bucket) for bucket in buckets)
+                ),
+            )
+        )
+
+        # Group the names to drop by their immediate parent so each listing is
+        # rewritten only once. Non-HNS paths fall back to broad invalidation.
+        removed_names_by_parent = {}
+        non_hns_paths = []
+        for path, bucket, key, _ in split_paths:
+            if hns_enabled[bucket]:
+                removed_names_by_parent.setdefault(self._parent(path), set()).add(
+                    f"{bucket}/{key}"
+                )
+            else:
+                non_hns_paths.append(path)
+
+        for parent, removed_names in removed_names_by_parent.items():
+            if parent in self.dircache:
+                self.dircache[parent] = [
+                    e
+                    for e in self.dircache[parent]
+                    if e.get("name") not in removed_names
+                ]
+
+        if non_hns_paths:
+            await super()._rm_files_cache_update(non_hns_paths)
+
     async def _mv(self, path1, path2, **kwargs):
         """
         Move a file or directory. Overrides the parent `_mv` to provide an

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -632,6 +632,24 @@ class ExtendedGcsFileSystem(GCSFileSystem):
 
         return bucket_type in [BucketType.ZONAL_HIERARCHICAL, BucketType.HIERARCHICAL]
 
+    def _cache_drop_entries(self, parent, names):
+        """Remove entries whose ``name`` is in ``names`` from ``parent``'s
+        cached listing. No-op when ``parent`` is not cached.
+
+        ``names`` is a set of stripped ``bucket/key`` names matching the
+        ``name`` field of the cached entries.
+        """
+        if parent in self.dircache:
+            self.dircache[parent] = [
+                e for e in self.dircache[parent] if e.get("name") not in names
+            ]
+
+    def _cache_add_entry(self, parent, entry):
+        """Append ``entry`` to ``parent``'s cached listing. No-op when
+        ``parent`` is not cached."""
+        if parent in self.dircache:
+            self.dircache[parent].append(entry)
+
     def _update_dircache_after_rename(self, path1, path2):
         """
         Performs a targeted update of the directory cache after a successful
@@ -654,26 +672,20 @@ class ExtendedGcsFileSystem(GCSFileSystem):
 
         # 2. Remove the old source entry from its parent's listing.
         self.dircache.pop(path1, None)
-        parent1 = self._parent(path1)
-        if parent1 in self.dircache:
-            self.dircache[parent1] = [
-                e for e in self.dircache[parent1] if e.get("name") != path1
-            ]
+        self._cache_drop_entries(self._parent(path1), {path1})
 
         # 3. Invalidate the destination path and update its parent's cache.
         self.dircache.pop(path2, None)
-        parent2 = self._parent(path2)
-        if parent2 in self.dircache:
-            _, key2, _ = self.split_path(path2)
-            new_entry = {
-                "Key": key2,
-                "Size": 0,
-                "name": path2,
-                "size": 0,
-                "type": "directory",
-                "storageClass": "DIRECTORY",
-            }
-            self.dircache[parent2].append(new_entry)
+        _, key2, _ = self.split_path(path2)
+        new_entry = {
+            "Key": key2,
+            "Size": 0,
+            "name": path2,
+            "size": 0,
+            "type": "directory",
+            "storageClass": "DIRECTORY",
+        }
+        self._cache_add_entry(self._parent(path2), new_entry)
 
     async def _mv_file_cache_update(self, path1, path2, response=None):
         """
@@ -692,29 +704,23 @@ class ExtendedGcsFileSystem(GCSFileSystem):
         dest_bucket, _, _ = self.split_path(path2)
 
         if await self._is_bucket_hns_enabled(src_bucket) and src_bucket == dest_bucket:
-            src_parent = self._parent(path1)
-            if src_parent in self.dircache:
-                path1_stripped = self._strip_protocol(path1)
-                self.dircache[src_parent] = [
-                    e
-                    for e in self.dircache[src_parent]
-                    if e.get("name") != path1_stripped
-                ]
+            # Source: removing the entry never changes an ancestor's listing, so
+            # drop it in place.
+            self._cache_drop_entries(self._parent(path1), {self._strip_protocol(path1)})
             dest_parent = self._parent(path2)
-            if dest_parent in self.dircache and response:
-                new_entry = self._process_object(dest_bucket, response)
-                self.dircache[dest_parent].append(new_entry)
+            if response and dest_parent in self.dircache:
+                # Destination parent is already cached (so it existed before the
+                # move) -> updating it in place cannot leave an ancestor stale.
+                self._cache_add_entry(
+                    dest_parent, self._process_object(dest_bucket, response)
+                )
+            else:
+                # The destination parent may have been created by this move;
+                # broad-invalidate it so a cached ancestor can't hide the new
+                # directory (also covers a missing/empty move response).
+                self.invalidate_cache(dest_parent)
         else:
             await super()._mv_file_cache_update(path1, path2, response)
-
-    async def _rm_file_cache_update(self, path):
-        """
-        Update the cache after a file delete operation.
-
-        This is the single-path form of :meth:`_rm_files_cache_update`; see that
-        method for the HNS-aware behavior.
-        """
-        await self._rm_files_cache_update([path])
 
     async def _rm_files_cache_update(self, paths):
         """
@@ -756,15 +762,33 @@ class ExtendedGcsFileSystem(GCSFileSystem):
                 non_hns_paths.append(path)
 
         for parent, removed_names in removed_names_by_parent.items():
-            if parent in self.dircache:
-                self.dircache[parent] = [
-                    e
-                    for e in self.dircache[parent]
-                    if e.get("name") not in removed_names
-                ]
+            self._cache_drop_entries(parent, removed_names)
 
         if non_hns_paths:
             await super()._rm_files_cache_update(non_hns_paths)
+
+    async def _write_file_cache_update(self, path):
+        """
+        Update the cache after a file create/overwrite (put/pipe/cp).
+
+        For HNS-enabled buckets the single-level shortcut (invalidate only the
+        immediate parent, not every ancestor up to the bucket root) is taken
+        only when that parent is already cached. A cached parent is one we have
+        listed, so it already exists, which means creating a file inside it
+        cannot add a new directory to any ancestor's listing.
+
+        When the parent is not cached we cannot rule out that this write
+        implicitly created it (HNS auto-creates missing parent folders on object
+        write); leaving a cached ancestor untouched would hide the new directory
+        from a subsequent listing. In that case, and for non-HNS buckets, fall
+        back to the default broad invalidation of the parent and all ancestors.
+        """
+        bucket, _, _ = self.split_path(path)
+        parent = self._parent(path)
+        if await self._is_bucket_hns_enabled(bucket) and parent in self.dircache:
+            self.dircache.pop(parent, None)
+        else:
+            await super()._write_file_cache_update(path)
 
     async def _mv(self, path1, path2, **kwargs):
         """
@@ -994,17 +1018,15 @@ class ExtendedGcsFileSystem(GCSFileSystem):
                 timeout=STORAGE_CONTROL_RPC_TIMEOUT,
             )
             # Instead of invalidating the parent cache, update it to add the new entry.
-            parent_path = self._parent(path)
-            if parent_path in self.dircache:
-                new_entry = {
-                    "Key": key.rstrip("/"),
-                    "Size": 0,
-                    "name": path,
-                    "size": 0,
-                    "type": "directory",
-                    "storageClass": "DIRECTORY",
-                }
-                self.dircache[parent_path].append(new_entry)
+            new_entry = {
+                "Key": key.rstrip("/"),
+                "Size": 0,
+                "name": path,
+                "size": 0,
+                "type": "directory",
+                "storageClass": "DIRECTORY",
+            }
+            self._cache_add_entry(self._parent(path), new_entry)
         except api_exceptions.Conflict as e:
             logger.debug(f"Directory already exists: {path}: {e}")
         except api_exceptions.FailedPrecondition as e:
@@ -1123,12 +1145,8 @@ class ExtendedGcsFileSystem(GCSFileSystem):
 
             # Remove the directory from the cache and from its parent's listing.
             self.dircache.pop(path, None)
-            parent = self._parent(path)
-            if parent in self.dircache:
-                # Remove the deleted directory entry from the parent's listing.
-                self.dircache[parent] = [
-                    e for e in self.dircache[parent] if e.get("name") != path
-                ]
+            # Remove the deleted directory entry from the parent's listing.
+            self._cache_drop_entries(self._parent(path), {path})
             return
         except api_exceptions.NotFound as e:
             # This can happen if the directory does not exist, or if the path
@@ -1644,7 +1662,7 @@ class ExtendedGcsFileSystem(GCSFileSystem):
             finalize_on_close = kwargs.get("finalize_on_close", self.finalize_on_close)
             await zb_hns_utils.close_aaow(writer, finalize_on_close=finalize_on_close)
 
-        self.invalidate_cache(self._parent(rpath))
+        await self._write_file_cache_update(rpath)
 
     async def _pipe_file(
         self,
@@ -1716,7 +1734,7 @@ class ExtendedGcsFileSystem(GCSFileSystem):
             finalize_on_close = kwargs.get("finalize_on_close", self.finalize_on_close)
             await zb_hns_utils.close_aaow(writer, finalize_on_close=finalize_on_close)
 
-        self.invalidate_cache(self._parent(path))
+        await self._write_file_cache_update(path)
 
     async def _get_file(self, rpath, lpath, callback=None, **kwargs):
         """

--- a/gcsfs/tests/integration/test_extended_hns.py
+++ b/gcsfs/tests/integration/test_extended_hns.py
@@ -1024,6 +1024,119 @@ class TestExtendedGcsFileSystemRm:
                     pass
 
 
+class TestExtendedGcsFileSystemWriteCacheInvalidation:
+    """Integration tests for write-path (pipe/put) dircache updates.
+
+    Writing a file invalidates only its immediate parent's listing when that
+    parent is already cached (and therefore known to exist); otherwise it falls
+    back to invalidating the parent and all of its ancestors. This behavior is
+    bucket-type-agnostic, so it is exercised on both HNS and standard buckets.
+    """
+
+    def test_write_file_cache_invalidates_only_immediate_parent_hns(self, gcs_hns):
+        """On an HNS bucket, writing into a cached directory invalidates only
+        that immediate parent (so the new file is re-listed), leaving ancestor
+        and sibling caches untouched."""
+        gcsfs = gcs_hns
+        base_dir = f"{TEST_HNS_BUCKET}/write_cache_hns_{uuid.uuid4().hex}"
+        parent_dir = f"{base_dir}/parent"
+        sibling_dir = f"{base_dir}/sibling"
+        new_file = f"{parent_dir}/new.txt"
+
+        # --- Setup ---
+        gcsfs.touch(f"{parent_dir}/existing.txt")
+        gcsfs.touch(f"{sibling_dir}/sibling_file.txt")
+
+        # --- Populate Cache ---
+        gcsfs.ls(base_dir)
+        gcsfs.ls(parent_dir)
+        gcsfs.ls(sibling_dir)
+        assert base_dir in gcsfs.dircache
+        assert parent_dir in gcsfs.dircache
+        assert sibling_dir in gcsfs.dircache
+
+        # --- Perform write ---
+        gcsfs.pipe_file(new_file, b"hello world")
+
+        # The immediate parent is invalidated so its next listing re-reads it.
+        assert (
+            parent_dir not in gcsfs.dircache
+        ), "Immediate parent of written file should be invalidated."
+        # Ancestor and sibling caches are left untouched.
+        assert (
+            base_dir in gcsfs.dircache
+        ), "Ancestor directory should not be invalidated on write."
+        assert (
+            sibling_dir in gcsfs.dircache
+        ), "Sibling directory cache should not be invalidated on write."
+
+        # The new file is visible once the parent is re-listed.
+        assert new_file in gcsfs.ls(parent_dir, detail=False)
+
+    def test_write_file_cache_invalidates_only_immediate_parent_standard(
+        self, gcs_hns, flat_bucket
+    ):
+        """The single-level write shortcut is bucket-type-agnostic: on a standard
+        (non-HNS) bucket, writing into a cached directory likewise invalidates
+        only the immediate parent and leaves ancestor/sibling caches intact."""
+        gcsfs = gcs_hns
+        base_dir = f"{flat_bucket}/write_cache_std_{uuid.uuid4().hex}"
+        parent_dir = f"{base_dir}/parent"
+        sibling_dir = f"{base_dir}/sibling"
+        new_file = f"{parent_dir}/new.txt"
+
+        # --- Setup ---
+        gcsfs.touch(f"{parent_dir}/existing.txt")
+        gcsfs.touch(f"{sibling_dir}/sibling_file.txt")
+
+        # --- Populate Cache ---
+        gcsfs.ls(base_dir)
+        gcsfs.ls(parent_dir)
+        gcsfs.ls(sibling_dir)
+        assert base_dir in gcsfs.dircache
+        assert parent_dir in gcsfs.dircache
+        assert sibling_dir in gcsfs.dircache
+
+        # --- Perform write ---
+        gcsfs.pipe_file(new_file, b"hello world")
+
+        assert (
+            parent_dir not in gcsfs.dircache
+        ), "Immediate parent of written file should be invalidated."
+        assert (
+            base_dir in gcsfs.dircache
+        ), "Ancestor directory should not be invalidated on write."
+        assert (
+            sibling_dir in gcsfs.dircache
+        ), "Sibling directory cache should not be invalidated on write."
+
+        assert new_file in gcsfs.ls(parent_dir, detail=False)
+
+    def test_write_file_uncached_parent_invalidates_ancestors(self, gcs_hns):
+        """Writing the first file into a not-yet-cached directory invalidates the
+        cached ancestor, so the newly created directory is picked up on re-list
+        rather than being hidden behind a stale ancestor listing."""
+        gcsfs = gcs_hns
+        base_dir = f"{TEST_HNS_BUCKET}/write_cache_uncached_{uuid.uuid4().hex}"
+        new_dir = f"{base_dir}/newdir"
+        new_file = f"{new_dir}/new.txt"
+
+        # --- Setup & cache the ancestor only ---
+        gcsfs.touch(f"{base_dir}/seed.txt")
+        gcsfs.ls(base_dir)
+        assert base_dir in gcsfs.dircache
+        assert new_dir not in gcsfs.dircache
+
+        # --- Write into the uncached (newly created) subdirectory ---
+        gcsfs.pipe_file(new_file, b"data")
+
+        # The cached ancestor is invalidated so a re-list reflects the new dir.
+        assert (
+            base_dir not in gcsfs.dircache
+        ), "Cached ancestor should be invalidated when the parent was uncached."
+        assert new_dir in gcsfs.ls(base_dir, detail=False)
+
+
 @pytest.fixture()
 def test_structure(gcs_hns):
     """Sets up a standard directory structure for find tests and cleans it up afterward."""

--- a/gcsfs/tests/integration/test_extended_hns.py
+++ b/gcsfs/tests/integration/test_extended_hns.py
@@ -793,8 +793,8 @@ class TestExtendedGcsFileSystemRm:
 
     def test_rm_file_cache_invalidation(self, gcs_hns):
         """
-        Test that rm on a file invalidates the cache for the file's direct
-        parent and all ancestor directories, but not sibling directories.
+        Test that rm on a file in an HNS bucket updates the parent's cache in-place
+        (does not invalidate it) and does not invalidate sibling or ancestor directories.
         """
         gcsfs = gcs_hns
         base_dir = f"{TEST_HNS_BUCKET}/rm_file_cache_base"
@@ -816,13 +816,20 @@ class TestExtendedGcsFileSystemRm:
         gcsfs.rm(file_to_delete)
 
         # --- Assert Cache Invalidation ---
-        # The parent of the deleted file and all its ancestors should be invalidated.
+        # The parent of the deleted file should not be invalidated (it remains in dircache).
         assert (
-            parent_dir not in gcsfs.dircache
-        ), "Direct parent of deleted file should be invalidated."
+            parent_dir in gcsfs.dircache
+        ), "Direct parent of deleted file should not be invalidated."
+        # The deleted file itself should be removed from the parent's cache listing.
+        parent_listing = gcsfs.dircache[parent_dir]
+        assert not any(
+            e["name"] == file_to_delete for e in parent_listing
+        ), "Deleted file should be removed from parent's cache listing."
+
+        # Ancestor directories should also remain in cache.
         assert (
-            base_dir not in gcsfs.dircache
-        ), "Ancestor directory of deleted file should be invalidated."
+            base_dir in gcsfs.dircache
+        ), "Ancestor directory of deleted file should not be invalidated."
 
         # The cache for sibling directories should remain untouched.
         assert (
@@ -831,8 +838,8 @@ class TestExtendedGcsFileSystemRm:
 
     def test_rm_recursive_cache_invalidation(self, gcs_hns):
         """
-        Test that recursive rm invalidates the cache for the deleted directory,
-        its descendants, and its direct parent, but not unrelated directories.
+        Test that recursive rm in HNS bucket invalidates the cache for the deleted directory
+        and its descendants, and updates the direct parent's cache in-place (does not invalidate it).
         """
         gcsfs = gcs_hns
         base_dir = f"{TEST_HNS_BUCKET}/rm_rec_cache_base"
@@ -860,10 +867,16 @@ class TestExtendedGcsFileSystemRm:
             nested_dir not in gcsfs.dircache
         ), "Descendant of deleted dir should be gone."
 
-        # The direct parent's cache should be invalidated.
+        # The direct parent's cache should not be invalidated (it remains in dircache).
         assert (
-            base_dir not in gcsfs.dircache
-        ), "Parent of deleted dir should be invalidated."
+            base_dir in gcsfs.dircache
+        ), "Parent of deleted dir should not be invalidated."
+
+        # The deleted directory should be removed from the parent's listing.
+        parent_listing = gcsfs.dircache[base_dir]
+        assert not any(
+            e["name"] == dir_to_delete for e in parent_listing
+        ), "Deleted directory should be removed from parent's cache listing."
 
         # The cache for sibling directories should remain untouched.
         assert (

--- a/gcsfs/tests/integration/test_extended_hns.py
+++ b/gcsfs/tests/integration/test_extended_hns.py
@@ -10,6 +10,10 @@ configuration:
 Each test class within this module should focus on a specific filesystem operation
 that has been extended or modified to support HNS features, such as `mv` (rename)
 and `mkdir`.
+
+Test placement: keep real-GCS HNS behavior in this file. Standard-bucket
+integration behavior belongs in test_core.py; zonal-specific behavior belongs
+in zonal test modules such as test_zonal_file.py.
 """
 
 import uuid
@@ -1071,45 +1075,6 @@ class TestExtendedGcsFileSystemWriteCacheInvalidation:
         ), "Sibling directory cache should not be invalidated on write."
 
         # The new file is visible once the parent is re-listed.
-        assert new_file in gcsfs.ls(parent_dir, detail=False)
-
-    def test_write_file_cache_invalidates_only_immediate_parent_standard(
-        self, gcs_hns, flat_bucket
-    ):
-        """The single-level write shortcut is bucket-type-agnostic: on a standard
-        (non-HNS) bucket, writing into a cached directory likewise invalidates
-        only the immediate parent and leaves ancestor/sibling caches intact."""
-        gcsfs = gcs_hns
-        base_dir = f"{flat_bucket}/write_cache_std_{uuid.uuid4().hex}"
-        parent_dir = f"{base_dir}/parent"
-        sibling_dir = f"{base_dir}/sibling"
-        new_file = f"{parent_dir}/new.txt"
-
-        # --- Setup ---
-        gcsfs.touch(f"{parent_dir}/existing.txt")
-        gcsfs.touch(f"{sibling_dir}/sibling_file.txt")
-
-        # --- Populate Cache ---
-        gcsfs.ls(base_dir)
-        gcsfs.ls(parent_dir)
-        gcsfs.ls(sibling_dir)
-        assert base_dir in gcsfs.dircache
-        assert parent_dir in gcsfs.dircache
-        assert sibling_dir in gcsfs.dircache
-
-        # --- Perform write ---
-        gcsfs.pipe_file(new_file, b"hello world")
-
-        assert (
-            parent_dir not in gcsfs.dircache
-        ), "Immediate parent of written file should be invalidated."
-        assert (
-            base_dir in gcsfs.dircache
-        ), "Ancestor directory should not be invalidated on write."
-        assert (
-            sibling_dir in gcsfs.dircache
-        ), "Sibling directory cache should not be invalidated on write."
-
         assert new_file in gcsfs.ls(parent_dir, detail=False)
 
     def test_write_file_uncached_parent_invalidates_ancestors(self, gcs_hns):

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -29,6 +29,11 @@ TEST_PROJECT = gcsfs.tests.settings.TEST_PROJECT
 TEST_REQUESTER_PAYS_BUCKET = gcsfs.tests.settings.TEST_REQUESTER_PAYS_BUCKET
 TEST_KMS_KEY = gcsfs.tests.settings.TEST_KMS_KEY
 
+# Test placement: keep common behavior and standard-bucket coverage in this
+# file. HNS-specific filesystem behavior belongs in test_extended_hns_gcsfs.py
+# or integration/test_extended_hns.py; zonal-specific behavior belongs in
+# test_zonal_file.py.
+
 
 def test_simple(gcs, monkeypatch):
     monkeypatch.setattr(GoogleCredentials, "tokens", None)
@@ -2419,6 +2424,31 @@ def test_copy_cache_invalidated(gcs):
 
     # Prior to fix the following failed as cache stale
     assert gcs.isfile(target_file2)
+
+
+def test_write_file_cache_invalidates_only_immediate_parent_standard(gcs, flat_bucket):
+    """Standard buckets use the write-cache shortcut when the parent is cached."""
+    base_dir = f"{flat_bucket}/write_cache_std_{uuid.uuid4().hex}"
+    parent_dir = f"{base_dir}/parent"
+    sibling_dir = f"{base_dir}/sibling"
+    new_file = f"{parent_dir}/new.txt"
+
+    gcs.touch(f"{parent_dir}/existing.txt")
+    gcs.touch(f"{sibling_dir}/sibling_file.txt")
+
+    gcs.ls(base_dir)
+    gcs.ls(parent_dir)
+    gcs.ls(sibling_dir)
+    assert base_dir in gcs.dircache
+    assert parent_dir in gcs.dircache
+    assert sibling_dir in gcs.dircache
+
+    gcs.pipe_file(new_file, b"hello world")
+
+    assert parent_dir not in gcs.dircache
+    assert base_dir in gcs.dircache
+    assert sibling_dir in gcs.dircache
+    assert new_file in gcs.ls(parent_dir, detail=False)
 
 
 def test_transaction(gcs):

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -482,6 +482,11 @@ async def test_rm_batch_not_found_invalidates_stale_cache(gcs):
     parent = TEST_BUCKET + "/cached"
     path = parent + "/already_gone"
     gcs.dircache[parent] = [{"name": path, "type": "file"}]
+    is_hns = (
+        await gcs._is_bucket_hns_enabled(TEST_BUCKET)
+        if hasattr(gcs, "_is_bucket_hns_enabled")
+        else False
+    )
 
     boundary = "==========7330845974216740156=="
     mock_response_content = (
@@ -504,7 +509,11 @@ async def test_rm_batch_not_found_invalidates_stale_cache(gcs):
         assert len(out) == 1
         assert isinstance(out[0], OSError)
         assert "No such object" in str(out[0])
-        assert parent not in gcs.dircache
+        if is_hns:
+            assert parent in gcs.dircache
+            assert path not in [entry["name"] for entry in gcs.dircache[parent]]
+        else:
+            assert parent not in gcs.dircache
 
 
 def test_rm_recursive(gcs):

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -477,6 +477,36 @@ async def test_rm_batch_error(gcs):
         assert f"{path}: 400" in str(out[0])
 
 
+@pytest.mark.asyncio
+async def test_rm_batch_not_found_invalidates_stale_cache(gcs):
+    parent = TEST_BUCKET + "/cached"
+    path = parent + "/already_gone"
+    gcs.dircache[parent] = [{"name": path, "type": "file"}]
+
+    boundary = "==========7330845974216740156=="
+    mock_response_content = (
+        f"\n--{boundary}\n"
+        "Content-Type: application/http\n"
+        "\n"
+        "HTTP/1.1 404 Not Found\n"
+        "Content-Type: application/json\n"
+        "\n"
+        '{"error": {"code": 404, "message": "No such object"}}\n'
+        f"--{boundary}--\n"
+    ).encode()
+    mock_headers = {"Content-Type": f"multipart/mixed; boundary={boundary}"}
+
+    with mock.patch.object(gcs, "_call", new_callable=mock.AsyncMock) as mock_call:
+        mock_call.return_value = (mock_headers, mock_response_content)
+
+        out = await gcs._rm_files([path])
+
+        assert len(out) == 1
+        assert isinstance(out[0], OSError)
+        assert "No such object" in str(out[0])
+        assert parent not in gcs.dircache
+
+
 def test_rm_recursive(gcs):
     files = ["/a", "/a/b", "/a/c"]
     for fn in files:

--- a/gcsfs/tests/test_dircache.py
+++ b/gcsfs/tests/test_dircache.py
@@ -1,0 +1,113 @@
+"""Unit tests for the default :class:`gcsfs._dircache.DirCacheUpdater` strategy.
+
+These cover the base ``dircache`` update behavior mixed into
+:class:`gcsfs.core.GCSFileSystem`: broad ancestor invalidation for deletes and
+moves, and the single-level shortcut (invalidate only an already-cached parent)
+for writes. The HNS-specific overrides for deletes and moves live in
+:class:`gcsfs._dircache.HnsDirCacheUpdater` and are exercised in
+``test_extended_hns_gcsfs.py``.
+
+The methods under test are pure in-memory operations on ``self.dircache`` (via
+``invalidate_cache`` / ``_parent``), so no GCS backend is required.
+"""
+
+import pytest
+
+from gcsfs.core import GCSFileSystem
+
+BUCKET = "dircache-test-bucket"
+
+
+def _fs():
+    return GCSFileSystem(token="anon", skip_instance_cache=True)
+
+
+def _seed_tree(fs):
+    """Cache a small tree: bucket / dir / sub, each with one listing."""
+    fs.dircache[BUCKET] = [{"name": f"{BUCKET}/dir", "type": "directory"}]
+    fs.dircache[f"{BUCKET}/dir"] = [
+        {"name": f"{BUCKET}/dir/sub", "type": "directory"},
+        {"name": f"{BUCKET}/dir/f.txt", "type": "file"},
+    ]
+    fs.dircache[f"{BUCKET}/dir/sub"] = [
+        {"name": f"{BUCKET}/dir/sub/g.txt", "type": "file"}
+    ]
+
+
+class TestDirCacheUpdaterWrite:
+    @pytest.mark.asyncio
+    async def test_write_with_cached_parent_invalidates_only_immediate_parent(self):
+        """When the immediate parent is already cached (so it is known to exist),
+        a write invalidates only that parent; ancestor caches stay intact because
+        adding a file cannot create a new directory in any ancestor's listing."""
+        fs = _fs()
+        _seed_tree(fs)
+
+        # Parent (BUCKET/dir/sub) is cached.
+        await fs._write_file_cache_update(f"{BUCKET}/dir/sub/new.txt")
+
+        assert f"{BUCKET}/dir/sub" not in fs.dircache
+        assert f"{BUCKET}/dir" in fs.dircache
+        assert BUCKET in fs.dircache
+
+    @pytest.mark.asyncio
+    async def test_write_with_uncached_parent_invalidates_ancestors(self):
+        """When the immediate parent is not cached, the write may have implicitly
+        created it (and intermediate directories), so the parent and every cached
+        ancestor are invalidated to avoid hiding the new directory."""
+        fs = _fs()
+        _seed_tree(fs)
+
+        # Parent (BUCKET/dir/sub/deeper) is NOT cached; its ancestors are.
+        await fs._write_file_cache_update(f"{BUCKET}/dir/sub/deeper/new.txt")
+
+        assert f"{BUCKET}/dir/sub" not in fs.dircache
+        assert f"{BUCKET}/dir" not in fs.dircache
+        assert BUCKET not in fs.dircache
+
+
+class TestDirCacheUpdaterRm:
+    @pytest.mark.asyncio
+    async def test_rm_file_invalidates_parent_chain(self):
+        fs = _fs()
+        _seed_tree(fs)
+
+        await fs._rm_file_cache_update(f"{BUCKET}/dir/sub/g.txt")
+
+        # _rm_file_cache_update delegates to the batch form; the deleted file's
+        # parent and ancestors are invalidated.
+        assert f"{BUCKET}/dir/sub" not in fs.dircache
+        assert f"{BUCKET}/dir" not in fs.dircache
+        assert BUCKET not in fs.dircache
+
+    @pytest.mark.asyncio
+    async def test_rm_files_invalidates_each_path_and_its_ancestors(self):
+        fs = _fs()
+        _seed_tree(fs)
+        # An unrelated sibling subtree that must be left untouched.
+        other = f"{BUCKET}/other"
+        fs.dircache[other] = [{"name": f"{other}/h.txt", "type": "file"}]
+
+        await fs._rm_files_cache_update([f"{BUCKET}/dir/sub"])
+
+        # The path itself, its parent, and ancestors are invalidated...
+        assert f"{BUCKET}/dir/sub" not in fs.dircache
+        assert f"{BUCKET}/dir" not in fs.dircache
+        assert BUCKET not in fs.dircache
+        # ...but an unrelated subtree is preserved.
+        assert other in fs.dircache
+
+
+class TestDirCacheUpdaterMv:
+    @pytest.mark.asyncio
+    async def test_mv_invalidates_both_source_and_dest_parents(self):
+        fs = _fs()
+        src_parent = f"{BUCKET}/srcdir"
+        dst_parent = f"{BUCKET}/dstdir"
+        fs.dircache[src_parent] = [{"name": f"{src_parent}/a.txt", "type": "file"}]
+        fs.dircache[dst_parent] = [{"name": f"{dst_parent}/b.txt", "type": "file"}]
+
+        await fs._mv_file_cache_update(f"{src_parent}/a.txt", f"{dst_parent}/a.txt")
+
+        assert src_parent not in fs.dircache
+        assert dst_parent not in fs.dircache

--- a/gcsfs/tests/test_dircache.py
+++ b/gcsfs/tests/test_dircache.py
@@ -7,6 +7,11 @@ for writes. The HNS-specific overrides for deletes and moves live in
 :class:`gcsfs._dircache.HnsDirCacheUpdater` and are exercised in
 ``test_extended_hns_gcsfs.py``.
 
+Test placement: keep pure in-memory dircache strategy tests here. Filesystem
+integration and bucket-specific routing tests belong in test_core.py,
+test_extended_hns_gcsfs.py, integration/test_extended_hns.py, or
+test_zonal_file.py according to the bucket type they exercise.
+
 The methods under test are pure in-memory operations on ``self.dircache`` (via
 ``invalidate_cache`` / ``_parent``), so no GCS backend is required.
 """

--- a/gcsfs/tests/test_extended_hns_gcsfs.py
+++ b/gcsfs/tests/test_extended_hns_gcsfs.py
@@ -18,8 +18,8 @@ from google.cloud import storage_control_v2
 from gcsfs.extended_gcsfs import BucketType, ExtendedGcsFileSystem
 from gcsfs.retry import DEFAULT_RETRY_CONFIG, HttpError
 from gcsfs.tests.conftest import requires_hns
-from gcsfs.tests.settings import TEST_HNS_BUCKET
-from gcsfs.tests.utils import is_real_gcs
+from gcsfs.tests.settings import TEST_HNS_BUCKET, TEST_ZONAL_BUCKET
+from gcsfs.tests.utils import is_real_gcs, tmpfile
 
 pytestmark = [requires_hns]
 
@@ -671,6 +671,35 @@ class TestExtendedGcsFileSystemMvFile:
                 await gcsfs._mv_file_cache_update(path3, path4)
                 mock_super_update.assert_awaited_once_with(path3, path4, None)
 
+    @pytest.mark.asyncio
+    async def test_mv_file_hns_uncached_dest_parent_invalidates_dest_ancestors(self):
+        """Moving a file into a destination parent that is not cached (which the
+        move may have created) must invalidate the destination's ancestors,
+        while the source entry is still dropped in place."""
+        fs = ExtendedGcsFileSystem(token="anon", skip_instance_cache=True)
+        src_parent = f"{TEST_HNS_BUCKET}/src"
+        src = f"{src_parent}/a.txt"
+        dest_grandparent = f"{TEST_HNS_BUCKET}/destgp"
+        dest_parent = f"{dest_grandparent}/p"
+        dst = f"{dest_parent}/a.txt"
+
+        # Source parent cached (with the file); destination parent NOT cached,
+        # but a destination ancestor IS cached.
+        fs.dircache[src_parent] = [{"name": src, "type": "file"}]
+        fs.dircache[dest_grandparent] = [{"name": dest_parent, "type": "directory"}]
+        fs.dircache[TEST_HNS_BUCKET] = [{"name": dest_grandparent, "type": "directory"}]
+
+        response = {"bucket": TEST_HNS_BUCKET, "name": "destgp/p/a.txt", "size": 5}
+        with mock.patch.object(fs, "_is_bucket_hns_enabled", return_value=True):
+            await fs._mv_file_cache_update(src, dst, response)
+
+        # The source entry is dropped in place (removal never affects ancestors).
+        assert src not in [e["name"] for e in fs.dircache.get(src_parent, [])]
+        # The destination's ancestors are invalidated, since the move may have
+        # created dest_parent.
+        assert dest_grandparent not in fs.dircache
+        assert TEST_HNS_BUCKET not in fs.dircache
+
 
 class TestExtendedGcsFileSystemRmFile:
     """Unit tests for the _rm_file cache update in ExtendedGcsFileSystem."""
@@ -835,6 +864,225 @@ class TestExtendedGcsFileSystemRmFile:
         names = [e["name"] for e in fs.dircache[parent]]
         assert ok_path not in names
         assert bad_path in names
+
+
+class TestExtendedGcsFileSystemWriteFileCacheUpdate:
+    """Unit tests for the write-path cache update (_write_file_cache_update),
+    shared by put_file, pipe_file, and cp_file."""
+
+    @pytest.mark.asyncio
+    async def test_write_file_cache_update_hns_pops_only_immediate_parent(self):
+        """For HNS buckets, creating a file invalidates only the immediate
+        parent's listing; ancestor directory caches are left intact because in
+        HNS the ancestors' listings are unaffected by adding a file."""
+        fs = ExtendedGcsFileSystem(token="anon")
+        grandparent = f"{TEST_HNS_BUCKET}/gp"
+        parent = f"{grandparent}/p"
+        path = f"{parent}/new.txt"
+
+        fs.dircache[parent] = [{"name": f"{parent}/existing.txt", "type": "file"}]
+        fs.dircache[grandparent] = [{"name": parent, "type": "directory"}]
+        fs.dircache[TEST_HNS_BUCKET] = [{"name": grandparent, "type": "directory"}]
+
+        with mock.patch.object(fs, "_is_bucket_hns_enabled", return_value=True):
+            await fs._write_file_cache_update(path)
+
+        # Only the immediate parent is invalidated.
+        assert parent not in fs.dircache
+        # Ancestors are left intact (no walk to the root).
+        assert grandparent in fs.dircache
+        assert TEST_HNS_BUCKET in fs.dircache
+
+    @pytest.mark.asyncio
+    async def test_write_file_cache_update_non_hns_broad_invalidate(self):
+        """For non-HNS buckets, the write-path cache update falls back to the
+        base broad invalidation of the parent and all of its ancestors."""
+        fs = ExtendedGcsFileSystem(token="anon")
+        grandparent = f"{TEST_HNS_BUCKET}/gp"
+        parent = f"{grandparent}/p"
+        path = f"{parent}/new.txt"
+
+        fs.dircache[parent] = [{"name": f"{parent}/existing.txt", "type": "file"}]
+        fs.dircache[grandparent] = [{"name": parent, "type": "directory"}]
+        fs.dircache[TEST_HNS_BUCKET] = [{"name": grandparent, "type": "directory"}]
+
+        with mock.patch.object(fs, "_is_bucket_hns_enabled", return_value=False):
+            await fs._write_file_cache_update(path)
+
+        # The base behavior invalidates the parent and walks up to the root.
+        assert parent not in fs.dircache
+        assert grandparent not in fs.dircache
+        assert TEST_HNS_BUCKET not in fs.dircache
+
+    @pytest.mark.asyncio
+    async def test_cp_file_hns_invalidates_only_immediate_parent(self):
+        """A standard-bucket cp on an HNS bucket invalidates only the
+        destination's immediate parent, leaving the destination's ancestors and
+        the source's parent untouched."""
+        fs = ExtendedGcsFileSystem(token="anon")
+        grandparent = f"{TEST_HNS_BUCKET}/gp"
+        dest_parent = f"{grandparent}/p"
+        dst = f"{dest_parent}/new.txt"
+        src_parent = f"{TEST_HNS_BUCKET}/src"
+        src = f"{src_parent}/old.txt"
+
+        fs.dircache[dest_parent] = [
+            {"name": f"{dest_parent}/existing.txt", "type": "file"}
+        ]
+        fs.dircache[grandparent] = [{"name": dest_parent, "type": "directory"}]
+        fs.dircache[TEST_HNS_BUCKET] = [{"name": grandparent, "type": "directory"}]
+        fs.dircache[src_parent] = [{"name": src, "type": "file"}]
+
+        with (
+            mock.patch.object(fs, "_is_zonal_bucket", return_value=False),
+            mock.patch.object(fs, "_is_bucket_hns_enabled", return_value=True),
+            mock.patch.object(fs, "_call", new_callable=mock.AsyncMock) as mock_call,
+        ):
+            mock_call.return_value = {"done": True}
+            await fs._cp_file(src, dst)
+
+        # Only the destination's immediate parent is invalidated.
+        assert dest_parent not in fs.dircache
+        # Ancestors of the destination and the source's parent are untouched.
+        assert grandparent in fs.dircache
+        assert TEST_HNS_BUCKET in fs.dircache
+        assert src_parent in fs.dircache
+
+    @pytest.mark.asyncio
+    async def test_write_file_cache_update_hns_uncached_parent_falls_back_to_broad(
+        self,
+    ):
+        """When the immediate parent is not cached, the write may have created
+        it (HNS auto-creates missing parent folders on object write), so a
+        cached ancestor must be invalidated rather than left to hide the new
+        directory. The single-level shortcut only applies to an already-cached
+        (known to exist) parent."""
+        fs = ExtendedGcsFileSystem(token="anon", skip_instance_cache=True)
+        grandparent = f"{TEST_HNS_BUCKET}/gp"
+        parent = f"{grandparent}/p"
+        path = f"{parent}/new.txt"
+
+        # The immediate parent is NOT cached; an ancestor IS cached.
+        fs.dircache[grandparent] = [{"name": parent, "type": "directory"}]
+        fs.dircache[TEST_HNS_BUCKET] = [{"name": grandparent, "type": "directory"}]
+
+        with mock.patch.object(fs, "_is_bucket_hns_enabled", return_value=True):
+            await fs._write_file_cache_update(path)
+
+        # Broad invalidation: cached ancestors are popped so a re-list picks up
+        # any directory the write implicitly created.
+        assert grandparent not in fs.dircache
+        assert TEST_HNS_BUCKET not in fs.dircache
+
+    @pytest.mark.asyncio
+    async def test_pipe_file_zonal_routes_through_write_cache_update(self):
+        """The zonal pipe_file path routes its cache update through
+        _write_file_cache_update so the HNS single-level invalidation applies."""
+        fs = ExtendedGcsFileSystem(token="anon", skip_instance_cache=True)
+        fs._grpc_client = mock.MagicMock()
+        path = f"{TEST_ZONAL_BUCKET}/dir/file.txt"
+
+        writer = mock.MagicMock()
+        writer.append = mock.AsyncMock()
+
+        with (
+            mock.patch.object(fs, "_is_zonal_bucket", return_value=True),
+            mock.patch.object(fs, "_get_grpc_client", new_callable=mock.AsyncMock),
+            mock.patch(
+                "gcsfs.extended_gcsfs.zb_hns_utils.init_aaow",
+                new_callable=mock.AsyncMock,
+                return_value=writer,
+            ),
+            mock.patch(
+                "gcsfs.extended_gcsfs.zb_hns_utils.close_aaow",
+                new_callable=mock.AsyncMock,
+            ),
+            mock.patch.object(
+                fs, "_write_file_cache_update", new_callable=mock.AsyncMock
+            ) as mock_update,
+        ):
+            await fs._pipe_file(path, b"some-data")
+
+        mock_update.assert_awaited_once_with(path)
+
+    @pytest.mark.asyncio
+    async def test_put_file_zonal_routes_through_write_cache_update(self):
+        """The zonal put_file path routes its cache update through
+        _write_file_cache_update so the HNS single-level invalidation applies."""
+        fs = ExtendedGcsFileSystem(token="anon", skip_instance_cache=True)
+        fs._grpc_client = mock.MagicMock()
+        rpath = f"{TEST_ZONAL_BUCKET}/dir/file.txt"
+
+        writer = mock.MagicMock()
+        writer.append_from_file = mock.AsyncMock()
+
+        with tmpfile() as lpath:
+            with open(lpath, "wb") as f:
+                f.write(b"some-data")
+
+            with (
+                mock.patch.object(fs, "_is_zonal_bucket", return_value=True),
+                mock.patch.object(fs, "_get_grpc_client", new_callable=mock.AsyncMock),
+                mock.patch(
+                    "gcsfs.extended_gcsfs.zb_hns_utils.init_aaow",
+                    new_callable=mock.AsyncMock,
+                    return_value=writer,
+                ),
+                mock.patch(
+                    "gcsfs.extended_gcsfs.zb_hns_utils.close_aaow",
+                    new_callable=mock.AsyncMock,
+                ),
+                mock.patch.object(
+                    fs, "_write_file_cache_update", new_callable=mock.AsyncMock
+                ) as mock_update,
+            ):
+                await fs._put_file(lpath, rpath)
+
+        mock_update.assert_awaited_once_with(rpath)
+
+
+class TestExtendedGcsFileSystemCacheHelpers:
+    """Unit tests for the shared low-level dircache primitives."""
+
+    def test_cache_drop_entries_removes_named_entries(self):
+        fs = ExtendedGcsFileSystem(token="anon", skip_instance_cache=True)
+        parent = f"{TEST_HNS_BUCKET}/p"
+        fs.dircache[parent] = [
+            {"name": f"{parent}/a", "type": "file"},
+            {"name": f"{parent}/b", "type": "file"},
+            {"name": f"{parent}/c", "type": "file"},
+        ]
+
+        fs._cache_drop_entries(parent, {f"{parent}/a", f"{parent}/c"})
+
+        assert [e["name"] for e in fs.dircache[parent]] == [f"{parent}/b"]
+
+    def test_cache_drop_entries_noop_when_parent_uncached(self):
+        fs = ExtendedGcsFileSystem(token="anon", skip_instance_cache=True)
+        parent = f"{TEST_HNS_BUCKET}/p"
+
+        # Must not raise and must not materialize the missing key.
+        fs._cache_drop_entries(parent, {f"{parent}/a"})
+
+        assert parent not in fs.dircache
+
+    def test_cache_add_entry_appends_to_parent(self):
+        fs = ExtendedGcsFileSystem(token="anon", skip_instance_cache=True)
+        parent = f"{TEST_HNS_BUCKET}/p"
+        fs.dircache[parent] = [{"name": f"{parent}/a", "type": "file"}]
+        entry = {"name": f"{parent}/b", "type": "file"}
+
+        fs._cache_add_entry(parent, entry)
+
+        assert entry in fs.dircache[parent]
+
+    def test_cache_add_entry_noop_when_parent_uncached(self):
+        fs = ExtendedGcsFileSystem(token="anon", skip_instance_cache=True)
+        parent = f"{TEST_HNS_BUCKET}/p"
+
+        fs._cache_add_entry(parent, {"name": f"{parent}/b", "type": "file"})
+
+        assert parent not in fs.dircache
 
 
 class TestExtendedGcsFileSystemMkdir:

--- a/gcsfs/tests/test_extended_hns_gcsfs.py
+++ b/gcsfs/tests/test_extended_hns_gcsfs.py
@@ -897,10 +897,13 @@ class TestExtendedGcsFileSystemWriteFileCacheUpdate:
     shared by put_file, pipe_file, and cp_file."""
 
     @pytest.mark.asyncio
-    async def test_write_file_cache_update_hns_pops_only_immediate_parent(self):
-        """For HNS buckets, creating a file invalidates only the immediate
-        parent's listing; ancestor directory caches are left intact because in
-        HNS the ancestors' listings are unaffected by adding a file."""
+    async def test_write_file_cache_update_cached_parent_pops_only_immediate_parent(
+        self,
+    ):
+        """When the immediate parent is cached (known to exist), creating a file
+        invalidates only that parent's listing; ancestor directory caches are
+        left intact because adding a file cannot create a new directory in an
+        ancestor's listing. This shortcut is bucket-type-agnostic."""
         fs = ExtendedGcsFileSystem(token="anon", skip_instance_cache=True)
         grandparent = f"{TEST_HNS_BUCKET}/gp"
         parent = f"{grandparent}/p"
@@ -910,35 +913,13 @@ class TestExtendedGcsFileSystemWriteFileCacheUpdate:
         fs.dircache[grandparent] = [{"name": parent, "type": "directory"}]
         fs.dircache[TEST_HNS_BUCKET] = [{"name": grandparent, "type": "directory"}]
 
-        with mock.patch.object(fs, "_is_bucket_hns_enabled", return_value=True):
-            await fs._write_file_cache_update(path)
+        await fs._write_file_cache_update(path)
 
         # Only the immediate parent is invalidated.
         assert parent not in fs.dircache
         # Ancestors are left intact (no walk to the root).
         assert grandparent in fs.dircache
         assert TEST_HNS_BUCKET in fs.dircache
-
-    @pytest.mark.asyncio
-    async def test_write_file_cache_update_non_hns_broad_invalidate(self):
-        """For non-HNS buckets, the write-path cache update falls back to the
-        base broad invalidation of the parent and all of its ancestors."""
-        fs = ExtendedGcsFileSystem(token="anon", skip_instance_cache=True)
-        grandparent = f"{TEST_HNS_BUCKET}/gp"
-        parent = f"{grandparent}/p"
-        path = f"{parent}/new.txt"
-
-        fs.dircache[parent] = [{"name": f"{parent}/existing.txt", "type": "file"}]
-        fs.dircache[grandparent] = [{"name": parent, "type": "directory"}]
-        fs.dircache[TEST_HNS_BUCKET] = [{"name": grandparent, "type": "directory"}]
-
-        with mock.patch.object(fs, "_is_bucket_hns_enabled", return_value=False):
-            await fs._write_file_cache_update(path)
-
-        # The base behavior invalidates the parent and walks up to the root.
-        assert parent not in fs.dircache
-        assert grandparent not in fs.dircache
-        assert TEST_HNS_BUCKET not in fs.dircache
 
     @pytest.mark.asyncio
     async def test_cp_file_hns_invalidates_only_immediate_parent(self):
@@ -975,14 +956,15 @@ class TestExtendedGcsFileSystemWriteFileCacheUpdate:
         assert src_parent in fs.dircache
 
     @pytest.mark.asyncio
-    async def test_write_file_cache_update_hns_uncached_parent_falls_back_to_broad(
+    async def test_write_file_cache_update_uncached_parent_falls_back_to_broad(
         self,
     ):
         """When the immediate parent is not cached, the write may have created
-        it (HNS auto-creates missing parent folders on object write), so a
-        cached ancestor must be invalidated rather than left to hide the new
-        directory. The single-level shortcut only applies to an already-cached
-        (known to exist) parent."""
+        it (flat buckets simulate directories from object prefixes; HNS
+        auto-creates missing parent folders on object write), so a cached
+        ancestor must be invalidated rather than left to hide the new directory.
+        The single-level shortcut only applies to an already-cached (known to
+        exist) parent."""
         fs = ExtendedGcsFileSystem(token="anon", skip_instance_cache=True)
         grandparent = f"{TEST_HNS_BUCKET}/gp"
         parent = f"{grandparent}/p"
@@ -992,8 +974,7 @@ class TestExtendedGcsFileSystemWriteFileCacheUpdate:
         fs.dircache[grandparent] = [{"name": parent, "type": "directory"}]
         fs.dircache[TEST_HNS_BUCKET] = [{"name": grandparent, "type": "directory"}]
 
-        with mock.patch.object(fs, "_is_bucket_hns_enabled", return_value=True):
-            await fs._write_file_cache_update(path)
+        await fs._write_file_cache_update(path)
 
         # Broad invalidation: cached ancestors are popped so a re-list picks up
         # any directory the write implicitly created.
@@ -1134,6 +1115,31 @@ class TestExtendedGcsFileSystemCacheHelpers:
         assert dst not in fs.dircache
         assert dst_child not in fs.dircache
         assert [e["name"] for e in fs.dircache[TEST_HNS_BUCKET]] == [dst]
+
+    def test_update_dircache_after_rename_strips_protocol(self):
+        """Protocol-qualified paths (``gs://...``) must mutate the same cache
+        keys/entries as stripped paths, since the dircache stores names without
+        the protocol. Without stripping, the pop/startswith matching no-ops."""
+        fs = ExtendedGcsFileSystem(token="anon", skip_instance_cache=True)
+        src = f"{TEST_HNS_BUCKET}/src"
+        dst = f"{TEST_HNS_BUCKET}/dst"
+
+        fs.dircache[TEST_HNS_BUCKET] = [{"name": src, "type": "directory"}]
+        fs.dircache[src] = [{"name": f"{src}/new.txt", "type": "file"}]
+        fs.dircache[f"{src}/nested"] = [
+            {"name": f"{src}/nested/new.txt", "type": "file"}
+        ]
+
+        # Callers such as _mv pass the raw (protocol-qualified) paths through.
+        fs._update_dircache_after_rename(f"gs://{src}", f"gs://{dst}")
+
+        # Source and its descendants are dropped from the cache.
+        assert src not in fs.dircache
+        assert f"{src}/nested" not in fs.dircache
+        # The source entry is removed from, and the stripped destination entry
+        # added to, the parent listing.
+        names = [e["name"] for e in fs.dircache[TEST_HNS_BUCKET]]
+        assert names == [dst]
 
 
 class TestExtendedGcsFileSystemMkdir:

--- a/gcsfs/tests/test_extended_hns_gcsfs.py
+++ b/gcsfs/tests/test_extended_hns_gcsfs.py
@@ -986,6 +986,7 @@ class TestExtendedGcsFileSystemWriteFileCacheUpdate:
         assert grandparent not in fs.dircache
         assert TEST_HNS_BUCKET not in fs.dircache
 
+
 class TestExtendedGcsFileSystemCacheHelpers:
     """Unit tests for the shared low-level dircache primitives."""
 

--- a/gcsfs/tests/test_extended_hns_gcsfs.py
+++ b/gcsfs/tests/test_extended_hns_gcsfs.py
@@ -700,6 +700,32 @@ class TestExtendedGcsFileSystemMvFile:
         assert dest_grandparent not in fs.dircache
         assert TEST_HNS_BUCKET not in fs.dircache
 
+    @pytest.mark.asyncio
+    async def test_mv_file_hns_replaces_cached_destination_entry(self):
+        """Moving a file over an already-cached destination must not leave
+        duplicate or stale destination entries in the parent listing."""
+        fs = ExtendedGcsFileSystem(token="anon", skip_instance_cache=True)
+        parent = f"{TEST_HNS_BUCKET}/parent"
+        src = f"{parent}/src.txt"
+        dst = f"{parent}/dst.txt"
+
+        fs.dircache[parent] = [
+            {"name": src, "type": "file", "size": 1},
+            {"name": dst, "type": "file", "size": 10},
+            {"name": f"{parent}/keep.txt", "type": "file", "size": 20},
+        ]
+
+        response = {"bucket": TEST_HNS_BUCKET, "name": "parent/dst.txt", "size": 1}
+        with mock.patch.object(fs, "_is_bucket_hns_enabled", return_value=True):
+            await fs._mv_file_cache_update(src, dst, response)
+
+        entries = fs.dircache[parent]
+        names = [e["name"] for e in entries]
+        assert src not in names
+        assert names.count(dst) == 1
+        assert any(e["name"] == dst and e["size"] == 1 for e in entries)
+        assert f"{parent}/keep.txt" in names
+
 
 class TestExtendedGcsFileSystemRmFile:
     """Unit tests for the _rm_file cache update in ExtendedGcsFileSystem."""
@@ -708,7 +734,7 @@ class TestExtendedGcsFileSystemRmFile:
     async def test_rm_file_hns_cache_update(self):
         """For HNS buckets, _rm_file removes only the deleted entry from the
         immediate parent's listing and leaves ancestor directory caches intact."""
-        fs = ExtendedGcsFileSystem(token="anon")
+        fs = ExtendedGcsFileSystem(token="anon", skip_instance_cache=True)
         grandparent = f"{TEST_HNS_BUCKET}/grandparent"
         parent = f"{grandparent}/parent"
         path = f"{parent}/file1.txt"
@@ -743,7 +769,7 @@ class TestExtendedGcsFileSystemRmFile:
     async def test_rm_file_cache_update_non_hns_fallback(self):
         """For non-HNS buckets, _rm_file_cache_update falls back to the base
         behavior which invalidates the parent and all of its ancestors."""
-        fs = ExtendedGcsFileSystem(token="anon")
+        fs = ExtendedGcsFileSystem(token="anon", skip_instance_cache=True)
         grandparent = f"{TEST_HNS_BUCKET}/grandparent"
         parent = f"{grandparent}/parent"
         path = f"{parent}/file1.txt"
@@ -764,7 +790,7 @@ class TestExtendedGcsFileSystemRmFile:
     async def test_rm_files_hns_cache_update(self):
         """For HNS buckets, batch delete removes only the deleted entries from
         their immediate parents' listings and leaves ancestor caches intact."""
-        fs = ExtendedGcsFileSystem(token="anon")
+        fs = ExtendedGcsFileSystem(token="anon", skip_instance_cache=True)
         grandparent = f"{TEST_HNS_BUCKET}/grandparent"
         parent = f"{grandparent}/parent"
         path1 = f"{parent}/file1.txt"
@@ -796,7 +822,7 @@ class TestExtendedGcsFileSystemRmFile:
     async def test_rm_files_cache_update_non_hns_fallback(self):
         """For non-HNS buckets, the batch cache update falls back to the base
         behavior which invalidates the parents and all of their ancestors."""
-        fs = ExtendedGcsFileSystem(token="anon")
+        fs = ExtendedGcsFileSystem(token="anon", skip_instance_cache=True)
         grandparent = f"{TEST_HNS_BUCKET}/grandparent"
         parent = f"{grandparent}/parent"
         path = f"{parent}/file1.txt"
@@ -817,7 +843,7 @@ class TestExtendedGcsFileSystemRmFile:
         """A failed delete in a batch must not be removed from the parent's
         cached listing: the object still exists in GCS, so the targeted HNS
         cache update must only see the objects that were actually deleted."""
-        fs = ExtendedGcsFileSystem(token="anon")
+        fs = ExtendedGcsFileSystem(token="anon", skip_instance_cache=True)
         parent = f"{TEST_HNS_BUCKET}/parent"
         ok_path = f"{parent}/ok.txt"
         bad_path = f"{parent}/bad.txt"
@@ -875,7 +901,7 @@ class TestExtendedGcsFileSystemWriteFileCacheUpdate:
         """For HNS buckets, creating a file invalidates only the immediate
         parent's listing; ancestor directory caches are left intact because in
         HNS the ancestors' listings are unaffected by adding a file."""
-        fs = ExtendedGcsFileSystem(token="anon")
+        fs = ExtendedGcsFileSystem(token="anon", skip_instance_cache=True)
         grandparent = f"{TEST_HNS_BUCKET}/gp"
         parent = f"{grandparent}/p"
         path = f"{parent}/new.txt"
@@ -897,7 +923,7 @@ class TestExtendedGcsFileSystemWriteFileCacheUpdate:
     async def test_write_file_cache_update_non_hns_broad_invalidate(self):
         """For non-HNS buckets, the write-path cache update falls back to the
         base broad invalidation of the parent and all of its ancestors."""
-        fs = ExtendedGcsFileSystem(token="anon")
+        fs = ExtendedGcsFileSystem(token="anon", skip_instance_cache=True)
         grandparent = f"{TEST_HNS_BUCKET}/gp"
         parent = f"{grandparent}/p"
         path = f"{parent}/new.txt"
@@ -919,7 +945,7 @@ class TestExtendedGcsFileSystemWriteFileCacheUpdate:
         """A standard-bucket cp on an HNS bucket invalidates only the
         destination's immediate parent, leaving the destination's ancestors and
         the source's parent untouched."""
-        fs = ExtendedGcsFileSystem(token="anon")
+        fs = ExtendedGcsFileSystem(token="anon", skip_instance_cache=True)
         grandparent = f"{TEST_HNS_BUCKET}/gp"
         dest_parent = f"{grandparent}/p"
         dst = f"{dest_parent}/new.txt"
@@ -1083,6 +1109,31 @@ class TestExtendedGcsFileSystemCacheHelpers:
         fs._cache_add_entry(parent, {"name": f"{parent}/b", "type": "file"})
 
         assert parent not in fs.dircache
+
+    def test_update_dircache_after_rename_clears_destination_descendants(self):
+        fs = ExtendedGcsFileSystem(token="anon", skip_instance_cache=True)
+        src = f"{TEST_HNS_BUCKET}/src"
+        dst = f"{TEST_HNS_BUCKET}/dst"
+        dst_child = f"{dst}/child"
+
+        fs.dircache[TEST_HNS_BUCKET] = [
+            {"name": src, "type": "directory"},
+            {"name": dst, "type": "directory"},
+        ]
+        fs.dircache[src] = [{"name": f"{src}/new.txt", "type": "file"}]
+        fs.dircache[f"{src}/nested"] = [
+            {"name": f"{src}/nested/new.txt", "type": "file"}
+        ]
+        fs.dircache[dst] = [{"name": f"{dst}/old.txt", "type": "file"}]
+        fs.dircache[dst_child] = [{"name": f"{dst_child}/old.txt", "type": "file"}]
+
+        fs._update_dircache_after_rename(src, dst)
+
+        assert src not in fs.dircache
+        assert f"{src}/nested" not in fs.dircache
+        assert dst not in fs.dircache
+        assert dst_child not in fs.dircache
+        assert [e["name"] for e in fs.dircache[TEST_HNS_BUCKET]] == [dst]
 
 
 class TestExtendedGcsFileSystemMkdir:

--- a/gcsfs/tests/test_extended_hns_gcsfs.py
+++ b/gcsfs/tests/test_extended_hns_gcsfs.py
@@ -672,6 +672,171 @@ class TestExtendedGcsFileSystemMvFile:
                 mock_super_update.assert_awaited_once_with(path3, path4, None)
 
 
+class TestExtendedGcsFileSystemRmFile:
+    """Unit tests for the _rm_file cache update in ExtendedGcsFileSystem."""
+
+    @pytest.mark.asyncio
+    async def test_rm_file_hns_cache_update(self):
+        """For HNS buckets, _rm_file removes only the deleted entry from the
+        immediate parent's listing and leaves ancestor directory caches intact."""
+        fs = ExtendedGcsFileSystem(token="anon")
+        grandparent = f"{TEST_HNS_BUCKET}/grandparent"
+        parent = f"{grandparent}/parent"
+        path = f"{parent}/file1.txt"
+
+        # Pre-populate the cache with the immediate parent and its ancestors.
+        fs.dircache[parent] = [
+            {"name": path, "type": "file"},
+            {"name": f"{parent}/other.txt", "type": "file"},
+        ]
+        fs.dircache[grandparent] = [{"name": parent, "type": "directory"}]
+        fs.dircache[TEST_HNS_BUCKET] = [{"name": grandparent, "type": "directory"}]
+
+        with (
+            mock.patch.object(fs, "_is_bucket_hns_enabled", return_value=True),
+            mock.patch.object(fs, "_call", new_callable=mock.AsyncMock),
+        ):
+            await fs._rm_file(path)
+
+        # The immediate parent's listing is updated, not cleared.
+        assert parent in fs.dircache
+        names = [e["name"] for e in fs.dircache[parent]]
+        assert path not in names
+        assert f"{parent}/other.txt" in names
+
+        # Ancestor directory caches are left intact: HNS directories are
+        # first-class objects, so the redundant invalidation up to the root
+        # is avoided.
+        assert grandparent in fs.dircache
+        assert TEST_HNS_BUCKET in fs.dircache
+
+    @pytest.mark.asyncio
+    async def test_rm_file_cache_update_non_hns_fallback(self):
+        """For non-HNS buckets, _rm_file_cache_update falls back to the base
+        behavior which invalidates the parent and all of its ancestors."""
+        fs = ExtendedGcsFileSystem(token="anon")
+        grandparent = f"{TEST_HNS_BUCKET}/grandparent"
+        parent = f"{grandparent}/parent"
+        path = f"{parent}/file1.txt"
+
+        fs.dircache[parent] = [{"name": path, "type": "file"}]
+        fs.dircache[grandparent] = [{"name": parent, "type": "directory"}]
+        fs.dircache[TEST_HNS_BUCKET] = [{"name": grandparent, "type": "directory"}]
+
+        with mock.patch.object(fs, "_is_bucket_hns_enabled", return_value=False):
+            await fs._rm_file_cache_update(path)
+
+        # The base behavior invalidates the parent and walks up to the root.
+        assert parent not in fs.dircache
+        assert grandparent not in fs.dircache
+        assert TEST_HNS_BUCKET not in fs.dircache
+
+    @pytest.mark.asyncio
+    async def test_rm_files_hns_cache_update(self):
+        """For HNS buckets, batch delete removes only the deleted entries from
+        their immediate parents' listings and leaves ancestor caches intact."""
+        fs = ExtendedGcsFileSystem(token="anon")
+        grandparent = f"{TEST_HNS_BUCKET}/grandparent"
+        parent = f"{grandparent}/parent"
+        path1 = f"{parent}/file1.txt"
+        path2 = f"{parent}/file2.txt"
+
+        fs.dircache[parent] = [
+            {"name": path1, "type": "file"},
+            {"name": path2, "type": "file"},
+            {"name": f"{parent}/keep.txt", "type": "file"},
+        ]
+        fs.dircache[grandparent] = [{"name": parent, "type": "directory"}]
+        fs.dircache[TEST_HNS_BUCKET] = [{"name": grandparent, "type": "directory"}]
+
+        with mock.patch.object(fs, "_is_bucket_hns_enabled", return_value=True):
+            await fs._rm_files_cache_update([path1, path2])
+
+        # The shared parent's listing keeps its surviving entry.
+        assert parent in fs.dircache
+        names = [e["name"] for e in fs.dircache[parent]]
+        assert path1 not in names
+        assert path2 not in names
+        assert f"{parent}/keep.txt" in names
+
+        # Ancestor directory caches are left intact.
+        assert grandparent in fs.dircache
+        assert TEST_HNS_BUCKET in fs.dircache
+
+    @pytest.mark.asyncio
+    async def test_rm_files_cache_update_non_hns_fallback(self):
+        """For non-HNS buckets, the batch cache update falls back to the base
+        behavior which invalidates the parents and all of their ancestors."""
+        fs = ExtendedGcsFileSystem(token="anon")
+        grandparent = f"{TEST_HNS_BUCKET}/grandparent"
+        parent = f"{grandparent}/parent"
+        path = f"{parent}/file1.txt"
+
+        fs.dircache[parent] = [{"name": path, "type": "file"}]
+        fs.dircache[grandparent] = [{"name": parent, "type": "directory"}]
+        fs.dircache[TEST_HNS_BUCKET] = [{"name": grandparent, "type": "directory"}]
+
+        with mock.patch.object(fs, "_is_bucket_hns_enabled", return_value=False):
+            await fs._rm_files_cache_update([path])
+
+        assert parent not in fs.dircache
+        assert grandparent not in fs.dircache
+        assert TEST_HNS_BUCKET not in fs.dircache
+
+    @pytest.mark.asyncio
+    async def test_rm_files_failed_delete_does_not_evict_from_cache(self):
+        """A failed delete in a batch must not be removed from the parent's
+        cached listing: the object still exists in GCS, so the targeted HNS
+        cache update must only see the objects that were actually deleted."""
+        fs = ExtendedGcsFileSystem(token="anon")
+        parent = f"{TEST_HNS_BUCKET}/parent"
+        ok_path = f"{parent}/ok.txt"
+        bad_path = f"{parent}/bad.txt"
+
+        fs.dircache[parent] = [
+            {"name": ok_path, "type": "file"},
+            {"name": bad_path, "type": "file"},
+        ]
+
+        # Batch response: ok.txt is deleted (204), bad.txt fails permanently
+        # (400, which is not retriable).
+        boundary = "==========7330845974216740156=="
+        mock_response_content = (
+            f"\n--{boundary}\n"
+            "Content-Type: application/http\n"
+            "\n"
+            "HTTP/1.1 204 No Content\n"
+            "\n"
+            f"\n--{boundary}\n"
+            "Content-Type: application/http\n"
+            "\n"
+            "HTTP/1.1 400 Bad Request\n"
+            "Content-Type: text/plain\n"
+            "\n"
+            "Error without braces\n"
+            f"--{boundary}--\n"
+        ).encode()
+        mock_headers = {"Content-Type": f"multipart/mixed; boundary={boundary}"}
+
+        with (
+            mock.patch.object(fs, "_is_bucket_hns_enabled", return_value=True),
+            mock.patch.object(fs, "_call", new_callable=mock.AsyncMock) as mock_call,
+        ):
+            mock_call.return_value = (mock_headers, mock_response_content)
+            out = await fs._rm_files([ok_path, bad_path])
+
+        # The failed delete is surfaced to the caller ...
+        assert ok_path in out
+        assert any(isinstance(o, OSError) for o in out)
+
+        # ... and the parent listing keeps the still-present object while
+        # dropping only the one that was actually deleted.
+        assert parent in fs.dircache
+        names = [e["name"] for e in fs.dircache[parent]]
+        assert ok_path not in names
+        assert bad_path in names
+
+
 class TestExtendedGcsFileSystemMkdir:
     """Tests for the mkdir method in ExtendedGcsFileSystem."""
 
@@ -1904,7 +2069,10 @@ class TestExtendedGcsFileSystemRmdir:
             gcsfs.rmdir(folder_path)
 
             assert not gcsfs.exists(folder_path)
-            mocks["async_lookup_bucket_type"].assert_called_once_with(TEST_HNS_BUCKET)
+            # The bucket type is looked up both for the rmdir itself and for the
+            # targeted cache update when the placeholder object is deleted via
+            # _rm_file. The lookup is cached, so this is not an extra API call.
+            mocks["async_lookup_bucket_type"].assert_any_call(TEST_HNS_BUCKET)
             expected_request = self._get_delete_folder_request(folder_path)
             mocks["control_client"].delete_folder.assert_called_once_with(
                 request=expected_request, retry=mock.ANY, timeout=mock.ANY

--- a/gcsfs/tests/test_extended_hns_gcsfs.py
+++ b/gcsfs/tests/test_extended_hns_gcsfs.py
@@ -4,6 +4,11 @@ Hierarchical Namespace (HNS) enabled features.
 
 These tests are designed to run with mocked GCS backends to isolate and verify
 the logic within the filesystem extension without making real API calls.
+
+Test placement: keep HNS-specific ExtendedGcsFileSystem tests here. Standard
+filesystem behavior belongs in test_core.py, pure dircache strategy tests belong
+in test_dircache.py, and zonal-specific filesystem routing belongs in
+test_zonal_file.py.
 """
 
 import contextlib
@@ -18,8 +23,8 @@ from google.cloud import storage_control_v2
 from gcsfs.extended_gcsfs import BucketType, ExtendedGcsFileSystem
 from gcsfs.retry import DEFAULT_RETRY_CONFIG, HttpError
 from gcsfs.tests.conftest import requires_hns
-from gcsfs.tests.settings import TEST_HNS_BUCKET, TEST_ZONAL_BUCKET
-from gcsfs.tests.utils import is_real_gcs, tmpfile
+from gcsfs.tests.settings import TEST_HNS_BUCKET
+from gcsfs.tests.utils import is_real_gcs
 
 pytestmark = [requires_hns]
 
@@ -980,73 +985,6 @@ class TestExtendedGcsFileSystemWriteFileCacheUpdate:
         # any directory the write implicitly created.
         assert grandparent not in fs.dircache
         assert TEST_HNS_BUCKET not in fs.dircache
-
-    @pytest.mark.asyncio
-    async def test_pipe_file_zonal_routes_through_write_cache_update(self):
-        """The zonal pipe_file path routes its cache update through
-        _write_file_cache_update so the HNS single-level invalidation applies."""
-        fs = ExtendedGcsFileSystem(token="anon", skip_instance_cache=True)
-        fs._grpc_client = mock.MagicMock()
-        path = f"{TEST_ZONAL_BUCKET}/dir/file.txt"
-
-        writer = mock.MagicMock()
-        writer.append = mock.AsyncMock()
-
-        with (
-            mock.patch.object(fs, "_is_zonal_bucket", return_value=True),
-            mock.patch.object(fs, "_get_grpc_client", new_callable=mock.AsyncMock),
-            mock.patch(
-                "gcsfs.extended_gcsfs.zb_hns_utils.init_aaow",
-                new_callable=mock.AsyncMock,
-                return_value=writer,
-            ),
-            mock.patch(
-                "gcsfs.extended_gcsfs.zb_hns_utils.close_aaow",
-                new_callable=mock.AsyncMock,
-            ),
-            mock.patch.object(
-                fs, "_write_file_cache_update", new_callable=mock.AsyncMock
-            ) as mock_update,
-        ):
-            await fs._pipe_file(path, b"some-data")
-
-        mock_update.assert_awaited_once_with(path)
-
-    @pytest.mark.asyncio
-    async def test_put_file_zonal_routes_through_write_cache_update(self):
-        """The zonal put_file path routes its cache update through
-        _write_file_cache_update so the HNS single-level invalidation applies."""
-        fs = ExtendedGcsFileSystem(token="anon", skip_instance_cache=True)
-        fs._grpc_client = mock.MagicMock()
-        rpath = f"{TEST_ZONAL_BUCKET}/dir/file.txt"
-
-        writer = mock.MagicMock()
-        writer.append_from_file = mock.AsyncMock()
-
-        with tmpfile() as lpath:
-            with open(lpath, "wb") as f:
-                f.write(b"some-data")
-
-            with (
-                mock.patch.object(fs, "_is_zonal_bucket", return_value=True),
-                mock.patch.object(fs, "_get_grpc_client", new_callable=mock.AsyncMock),
-                mock.patch(
-                    "gcsfs.extended_gcsfs.zb_hns_utils.init_aaow",
-                    new_callable=mock.AsyncMock,
-                    return_value=writer,
-                ),
-                mock.patch(
-                    "gcsfs.extended_gcsfs.zb_hns_utils.close_aaow",
-                    new_callable=mock.AsyncMock,
-                ),
-                mock.patch.object(
-                    fs, "_write_file_cache_update", new_callable=mock.AsyncMock
-                ) as mock_update,
-            ):
-                await fs._put_file(lpath, rpath)
-
-        mock_update.assert_awaited_once_with(rpath)
-
 
 class TestExtendedGcsFileSystemCacheHelpers:
     """Unit tests for the shared low-level dircache primitives."""

--- a/gcsfs/tests/test_zonal_file.py
+++ b/gcsfs/tests/test_zonal_file.py
@@ -1,4 +1,10 @@
-"""Tests for ZonalFile write operations."""
+"""Tests for zonal write operations.
+
+Test placement: keep zonal-specific write behavior here, including ZonalFile
+tests and ExtendedGcsFileSystem zonal write routing tests. Standard filesystem
+behavior belongs in test_core.py; HNS-specific behavior belongs in
+test_extended_hns_gcsfs.py or integration/test_extended_hns.py.
+"""
 
 import asyncio
 import os
@@ -9,6 +15,7 @@ from google.cloud.storage.asyncio.async_appendable_object_writer import (
     _DEFAULT_FLUSH_INTERVAL_BYTES,
 )
 
+from gcsfs.extended_gcsfs import ExtendedGcsFileSystem
 from gcsfs.tests.conftest import requires_rapid
 from gcsfs.tests.settings import TEST_ZONAL_BUCKET
 from gcsfs.tests.utils import is_real_gcs, tempdir, tmpfile
@@ -17,6 +24,72 @@ from gcsfs.zonal_file import ZonalFile
 test_data = b"hello world"
 
 pytestmark = [requires_rapid]
+
+
+class TestZonalGcsFileSystemWriteFileCacheUpdate:
+    @pytest.mark.asyncio
+    async def test_pipe_file_zonal_routes_through_write_cache_update(self):
+        """The zonal pipe_file path routes through the shared cache updater."""
+        fs = ExtendedGcsFileSystem(token="anon", skip_instance_cache=True)
+        fs._grpc_client = mock.MagicMock()
+        path = f"{TEST_ZONAL_BUCKET}/dir/file.txt"
+
+        writer = mock.MagicMock()
+        writer.append = mock.AsyncMock()
+
+        with (
+            mock.patch.object(fs, "_is_zonal_bucket", return_value=True),
+            mock.patch.object(fs, "_get_grpc_client", new_callable=mock.AsyncMock),
+            mock.patch(
+                "gcsfs.extended_gcsfs.zb_hns_utils.init_aaow",
+                new_callable=mock.AsyncMock,
+                return_value=writer,
+            ),
+            mock.patch(
+                "gcsfs.extended_gcsfs.zb_hns_utils.close_aaow",
+                new_callable=mock.AsyncMock,
+            ),
+            mock.patch.object(
+                fs, "_write_file_cache_update", new_callable=mock.AsyncMock
+            ) as mock_update,
+        ):
+            await fs._pipe_file(path, b"some-data")
+
+        mock_update.assert_awaited_once_with(path)
+
+    @pytest.mark.asyncio
+    async def test_put_file_zonal_routes_through_write_cache_update(self):
+        """The zonal put_file path routes through the shared cache updater."""
+        fs = ExtendedGcsFileSystem(token="anon", skip_instance_cache=True)
+        fs._grpc_client = mock.MagicMock()
+        rpath = f"{TEST_ZONAL_BUCKET}/dir/file.txt"
+
+        writer = mock.MagicMock()
+        writer.append_from_file = mock.AsyncMock()
+
+        with tmpfile() as lpath:
+            with open(lpath, "wb") as f:
+                f.write(b"some-data")
+
+            with (
+                mock.patch.object(fs, "_is_zonal_bucket", return_value=True),
+                mock.patch.object(fs, "_get_grpc_client", new_callable=mock.AsyncMock),
+                mock.patch(
+                    "gcsfs.extended_gcsfs.zb_hns_utils.init_aaow",
+                    new_callable=mock.AsyncMock,
+                    return_value=writer,
+                ),
+                mock.patch(
+                    "gcsfs.extended_gcsfs.zb_hns_utils.close_aaow",
+                    new_callable=mock.AsyncMock,
+                ),
+                mock.patch.object(
+                    fs, "_write_file_cache_update", new_callable=mock.AsyncMock
+                ) as mock_update,
+            ):
+                await fs._put_file(lpath, rpath)
+
+        mock_update.assert_awaited_once_with(rpath)
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR refactors the directory cache (`dircache`) update logic in `gcsfs` to centralize caching strategies and optimizes cache invalidation.

### Motivation and Context
Previously, cache invalidation logic was interleaved with I/O operations in `gcsfs/core.py` and `gcsfs/extended_gcsfs.py`, leading to code duplication. Additionally, the default behavior of invalidating all ancestor directories up to the bucket root is redundant for HNS-enabled buckets (where directories are first-class persistent objects) and can be optimized for write operations on all buckets.

This PR addresses these issues by:
1. Centralizing cache update logic into a new module `gcsfs/_dircache.py`.
2. Optimizing cache updates for write operations across all bucket types (standard and HNS) to avoid broad ancestor invalidation when the parent is already cached.
3. Optimizing HNS cache updates for deletion and move operations to perform targeted in-place mutations instead of broad ancestor invalidations.
4. Fixing batch deletion (`_rm_files`) to only update the cache for successfully deleted or confirmed absent files, preventing eviction of failed deletes.

### Detailed Changes

#### 1. Centralized Cache Update Strategies (`gcsfs/_dircache.py`)
- **`DirCacheUpdater`**: The base strategy (used by `GCSFileSystem`).
  - **Writes**: Invalidates only the immediate parent listing if it is already cached (since we know the parent exists, adding a file cannot implicitly create new intermediate directories that would be hidden by a stale ancestor cache). If the parent is not cached, it falls back to broad ancestor invalidation.
  - **Deletes**: Broadly invalidates the affected parent and all of its ancestors.
  - **Moves**: Broadly invalidates the affected parent and all of its ancestors for both source and destination.
- **`HnsDirCacheUpdater`** (subclass of `DirCacheUpdater` used by `ExtendedGcsFileSystem`): A targeted strategy for HNS buckets.
  - **Writes**: Inherits the optimized write behavior from `DirCacheUpdater`.
  - **Deletes**: Mutates parent listings in place by removing deleted entries, avoiding ancestor invalidation entirely. Grouped by parent for efficiency.
  - **Moves**: For intra-bucket moves, removes the source from the parent cache and upserts the destination into the parent cache in place.
  - Non-HNS paths fallback to `DirCacheUpdater` behavior (broad invalidation).

#### 2. Filesystem Refactoring
- **`gcsfs/core.py` (`GCSFileSystem`)**:
  - Inherits from `DirCacheUpdater`.
  - Replaced direct `invalidate_cache` calls in `_mv_file`, `_rm_file`, `_pipe_file`, and `_put_file` with calls to the new cache updater hooks (`_write_file_cache_update`, `_rm_file_cache_update`).
  - Updated `_rm_files` (batch delete) to only update the cache for successfully deleted or confirmed absent (404) files, preventing eviction of failed deletes.
- **`gcsfs/extended_gcsfs.py` (`ExtendedGcsFileSystem`)**:
  - Inherits from `HnsDirCacheUpdater`.
  - Removed overridden `_mv_file_cache_update` and `_update_dircache_after_rename` as they are now handled by `HnsDirCacheUpdater`.
  - Refactored `_mkdir` and `_rmdir` to use low-level cache primitives (`_cache_add_entry`, `_cache_drop_entries`) defined in `HnsDirCacheUpdater`.

#### 3. Testing
- Added comprehensive unit and integration tests to verify:
  - Targeted HNS deletion cache updates (in-place mutation, no ancestor invalidation).
  - Optimized write cache updates (invalidating only immediate parent when cached, falling back to broad invalidation when uncached) for both HNS and standard buckets.
  - Low-level cache helpers (`_cache_drop_entries`, `_cache_add_entry`).
- Updated existing tests to align with the new caching behavior.
