### PR TITLE
Optimize HNS move file cache invalidation logic

### DIFF
--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -735,7 +735,6 @@ class ExtendedGcsFileSystem(GCSFileSystem):
             return True
         return str(entry_generation) in generations
 
-
     async def _mv(self, path1, path2, **kwargs):
         """
         Move a file or directory. Overrides the parent `_mv` to provide an

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -688,17 +688,25 @@ class ExtendedGcsFileSystem(GCSFileSystem):
         For non-HNS buckets or cross-bucket moves, it falls back to the default
         behavior (invalidating the cache for both source and destination parents).
         """
-        src_bucket, _, _ = self.split_path(path1)
+        src_bucket, src_key, src_generation = self.split_path(path1)
         dest_bucket, _, _ = self.split_path(path2)
 
         if await self._is_bucket_hns_enabled(src_bucket) and src_bucket == dest_bucket:
             src_parent = self._parent(path1)
             if src_parent in self.dircache:
-                path1_stripped = self._strip_protocol(path1)
+                # Match the generation-free name stored in the listing (an
+                # explicit source generation, key#generation, is not part of the
+                # cached entry name); when a generation is given, only that
+                # version is removed so other cached versions are left intact.
+                removed = {
+                    f"{src_bucket}/{src_key}": {
+                        None if src_generation is None else str(src_generation)
+                    }
+                }
                 self.dircache[src_parent] = [
                     e
                     for e in self.dircache[src_parent]
-                    if e.get("name") != path1_stripped
+                    if not self._entry_was_deleted(e, removed)
                 ]
             dest_parent = self._parent(path2)
             if dest_parent in self.dircache and response:
@@ -706,6 +714,27 @@ class ExtendedGcsFileSystem(GCSFileSystem):
                 self.dircache[dest_parent].append(new_entry)
         else:
             await super()._mv_file_cache_update(path1, path2, response)
+
+    @staticmethod
+    def _entry_was_deleted(entry, removed):
+        """Whether a cached listing ``entry`` was removed by a delete.
+
+        ``removed`` maps a generation-free name to the set of deleted generations
+        for that name. A ``None`` in the set (a delete with no specific
+        generation), or an entry that carries no generation of its own, matches
+        by name alone; otherwise the entry's generation must be one of the
+        deleted generations, so deleting one version leaves the others cached.
+        """
+        generations = removed.get(entry.get("name"))
+        if generations is None:
+            return False
+        if None in generations:
+            return True
+        entry_generation = entry.get("generation")
+        if entry_generation is None:
+            return True
+        return str(entry_generation) in generations
+
 
     async def _mv(self, path1, path2, **kwargs):
         """

--- a/gcsfs/tests/test_extended_hns_gcsfs.py
+++ b/gcsfs/tests/test_extended_hns_gcsfs.py
@@ -671,6 +671,52 @@ class TestExtendedGcsFileSystemMvFile:
                 await gcsfs._mv_file_cache_update(path3, path4)
                 mock_super_update.assert_awaited_once_with(path3, path4, None)
 
+    @pytest.mark.asyncio
+    async def test_mv_file_hns_cache_update_version_aware(self):
+        """A versioned source path (key#generation) must still match the
+        generation-free name stored in the parent's cached listing."""
+        fs = ExtendedGcsFileSystem(token="anon", version_aware=True)
+        parent = f"{TEST_HNS_BUCKET}/parent"
+        src_name = f"{parent}/file1.txt"
+        path1 = f"{src_name}#123"  # move a specific source generation
+        path2 = f"{parent}/file2.txt"
+
+        fs.dircache[parent] = [
+            {"name": src_name, "type": "file"},
+            {"name": f"{parent}/keep.txt", "type": "file"},
+        ]
+
+        with mock.patch.object(fs, "_is_bucket_hns_enabled", return_value=True):
+            await fs._mv_file_cache_update(path1, path2)
+
+        names = [e["name"] for e in fs.dircache[parent]]
+        assert src_name not in names  # the source generation entry is removed
+        assert f"{parent}/keep.txt" in names
+
+    @pytest.mark.asyncio
+    async def test_mv_file_hns_cache_update_keeps_other_generations(self):
+        """Moving one object generation must not evict the other
+        still-present generations of the same name from the parent's listing."""
+        fs = ExtendedGcsFileSystem(token="anon", version_aware=True)
+        parent = f"{TEST_HNS_BUCKET}/parent"
+        src_name = f"{parent}/file1.txt"
+        path1 = f"{src_name}#123"  # move only generation 123
+        path2 = f"{parent}/file2.txt"
+
+        fs.dircache[parent] = [
+            {"name": src_name, "type": "file", "generation": "123"},
+            {"name": src_name, "type": "file", "generation": "456"},
+            {"name": f"{parent}/keep.txt", "type": "file", "generation": "789"},
+        ]
+
+        with mock.patch.object(fs, "_is_bucket_hns_enabled", return_value=True):
+            await fs._mv_file_cache_update(path1, path2)
+
+        entries = [(e["name"], e.get("generation")) for e in fs.dircache[parent]]
+        assert (src_name, "123") not in entries  # the moved generation is gone
+        assert (src_name, "456") in entries  # the other generation survives
+        assert (f"{parent}/keep.txt", "789") in entries
+
 
 class TestExtendedGcsFileSystemMkdir:
     """Tests for the mkdir method in ExtendedGcsFileSystem."""


### PR DESCRIPTION
This PR optimizes the cache invalidation logic for file move operations in Hierarchical Namespace (HNS) enabled buckets.

### Motivation and Context
For HNS-enabled buckets, directories are first-class persistent objects. When a file is moved within the same HNS bucket, it only affects the contents of the source and destination parent directories. The default behavior in `gcsfs` (designed for flat namespaces) is to recursively invalidate the parent directories and all of their ancestors up to the bucket root. This is redundant and inefficient for HNS buckets.

An optimized HNS-aware `_mv_file_cache_update` was previously introduced, but it was not version-aware. This PR updates it to support version-aware moves.

### Changes
*   **`gcsfs/extended_gcsfs.py`**:
    *   Updated `_mv_file_cache_update` in `ExtendedGcsFileSystem` to be version-aware.
    *   When moving a specific generation of an object (e.g., `path#generation`), only that specific version is removed from the source parent's cached listing, leaving other cached generations of the same object intact.
    *   Introduced a static helper `_entry_was_deleted` to determine if a cached entry matches the moved path and generation.
*   **`gcsfs/tests/test_extended_hns_gcsfs.py`**:
    *   Added two new unit tests under `TestExtendedGcsFileSystemMvFile`:
        *   `test_mv_file_hns_cache_update_version_aware`: Verifies that moving a versioned source path matches the generation-free name in the cache and removes it.
        *   `test_mv_file_hns_cache_update_keeps_other_generations`: Verifies that moving a specific generation of a file leaves other cached generations of the same file in the parent's listing.
