### PR TITLE
Fix MRDPool.close() blocking when pool is exhausted

### DIFF
--- a/gcsfs/tests/test_zb_hns_utils.py
+++ b/gcsfs/tests/test_zb_hns_utils.py
@@ -425,7 +425,7 @@ async def test_mrd_pool_close_with_exceptions(create_mrd_mock, mock_gcsfs):
 
 
 @pytest.mark.asyncio
-async def test_mrd_pool_queue_filled_during_lock_wait(mock_gcsfs):
+async def test_mrd_pool_get_mrd_reuses_free_mrd(mock_gcsfs):
     pool = MRDPool(mock_gcsfs, "bucket", "obj", "123", pool_size=1)
     mrd_mock = mock.AsyncMock()
 
@@ -436,10 +436,8 @@ async def test_mrd_pool_queue_filled_during_lock_wait(mock_gcsfs):
     with mock.patch.object(pool, "_create_mrd", side_effect=fake_create_mrd):
         await pool.initialize()
 
-        side_effects = [True] + [False] * 10
-        with mock.patch.object(pool._free_mrds, "empty", side_effect=side_effects):
-            async with pool.get_mrd() as mrd:
-                assert mrd == mrd_mock
+        async with pool.get_mrd() as mrd:
+            assert mrd == mrd_mock
 
         # We should not have spawned a new MRD
         assert pool._active_count == 1
@@ -864,6 +862,71 @@ async def test_mrd_pool_get_mrd_after_close_raises(mock_cache):
     with pytest.raises(RuntimeError, match="MRDPool is closed"):
         async with mrd_pool.get_mrd():
             pass
+
+
+@pytest.mark.asyncio
+async def test_mrd_pool_close_not_blocked_by_exhausted_pool_waiter(mock_gcsfs):
+    pool = MRDPool(mock_gcsfs, "bucket", "obj", "123", pool_size=1)
+    mrd = mock.AsyncMock()
+
+    with mock.patch.object(pool, "_create_mrd", return_value=mrd):
+        await pool.initialize()
+
+    holder_cm = pool.get_mrd()
+    held_mrd = await holder_cm.__aenter__()
+    assert held_mrd is mrd
+
+    async def waiting_get():
+        async with pool.get_mrd():
+            return "acquired"
+
+    waiter_task = asyncio.create_task(waiting_get())
+    await asyncio.sleep(0)
+    assert not waiter_task.done()
+
+    close_task = asyncio.create_task(pool.close())
+    done, _ = await asyncio.wait({close_task}, timeout=0.1)
+    if close_task not in done:
+        await holder_cm.__aexit__(None, None, None)
+        await asyncio.gather(close_task, waiter_task)
+        pytest.fail("close() waited for an exhausted-pool get_mrd() waiter")
+
+    await close_task
+    with pytest.raises(RuntimeError, match="MRDPool is closed"):
+        await asyncio.wait_for(waiter_task, timeout=0.1)
+
+    await holder_cm.__aexit__(None, None, None)
+    mrd.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_mrd_pool_close_wakes_all_exhausted_pool_waiters(mock_gcsfs):
+    pool = MRDPool(mock_gcsfs, "bucket", "obj", "123", pool_size=1)
+    mrd = mock.AsyncMock()
+
+    with mock.patch.object(pool, "_create_mrd", return_value=mrd):
+        await pool.initialize()
+
+    holder_cm = pool.get_mrd()
+    await holder_cm.__aenter__()
+
+    async def waiting_get():
+        async with pool.get_mrd():
+            return "acquired"
+
+    waiter_tasks = [asyncio.create_task(waiting_get()) for _ in range(10)]
+    await asyncio.sleep(0)
+    assert all(not task.done() for task in waiter_tasks)
+
+    await asyncio.wait_for(pool.close(), timeout=0.1)
+    results = await asyncio.gather(*waiter_tasks, return_exceptions=True)
+    assert all(
+        isinstance(result, RuntimeError) and str(result) == "MRDPool is closed."
+        for result in results
+    )
+
+    await holder_cm.__aexit__(None, None, None)
+    mrd.close.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/gcsfs/tests/test_zb_hns_utils.py
+++ b/gcsfs/tests/test_zb_hns_utils.py
@@ -866,6 +866,14 @@ async def test_mrd_pool_get_mrd_after_close_raises(mock_cache):
 
 @pytest.mark.asyncio
 async def test_mrd_pool_close_not_blocked_by_exhausted_pool_waiter(mock_gcsfs):
+    """
+    Test that MRDPool.close() does not deadlock when there is a task blocked
+    on get_mrd() because the pool is exhausted.
+
+    This verifies that the get_mrd() waiter releases its lock while waiting on the
+    asyncio.Condition variable, allowing the close() call to acquire the lock,
+    mark the pool as closed, and trigger cleanup.
+    """
     pool = MRDPool(mock_gcsfs, "bucket", "obj", "123", pool_size=1)
     mrd = mock.AsyncMock()
 
@@ -901,6 +909,13 @@ async def test_mrd_pool_close_not_blocked_by_exhausted_pool_waiter(mock_gcsfs):
 
 @pytest.mark.asyncio
 async def test_mrd_pool_close_wakes_all_exhausted_pool_waiters(mock_gcsfs):
+    """
+    Test that MRDPool.close() notifies and wakes up all tasks currently waiting
+    for an MRD to become available.
+
+    Each waiter should immediately wake up, detect that the pool has been closed,
+    and raise a RuntimeError("MRDPool is closed.") instead of hanging indefinitely.
+    """
     pool = MRDPool(mock_gcsfs, "bucket", "obj", "123", pool_size=1)
     mrd = mock.AsyncMock()
 

--- a/gcsfs/zb_hns_utils.py
+++ b/gcsfs/zb_hns_utils.py
@@ -478,6 +478,7 @@ class MRDPool:
         self._free_mrds = asyncio.Queue(maxsize=pool_size)
         self._active_count = 0
         self._lock = asyncio.Lock()
+        self._mrd_available = asyncio.Condition(self._lock)
         self.persisted_size = None
         self._initialized = False
         self._closed = False
@@ -503,9 +504,8 @@ class MRDPool:
         """Drop one holder of `mrd`; return True iff this was the LAST holder
         (so the caller must now requeue or close it).
 
-        Both helpers only do synchronous dict mutations with no `await`, so they
-        are atomic under asyncio even though get_mrd's finally runs WITHOUT
-        self._lock."""
+        Both helpers only do synchronous dict mutations with no `await`. They
+        are called while self._lock is held."""
         count = self._inflight.get(mrd, 0) - 1
         if count > 0:
             self._inflight[mrd] = count
@@ -565,47 +565,50 @@ class MRDPool:
         mrd = None
 
         async with self._lock:
-            if self._closed:
-                raise RuntimeError("MRDPool is closed.")
+            while mrd is None:
+                if self._closed:
+                    raise RuntimeError("MRDPool is closed.")
 
-            if self._free_mrds.empty():
-                if self._active_count < self.pool_size:
-                    self._active_count += 1
-                    try:
-                        mrd = await self._get_or_create_mrd()
-                    except BaseException as e:
-                        self._active_count -= 1
-                        raise e
-                elif self.mrd_supports_multi_request and self._all_mrds:
-                    # Pool is full and the queue is empty: share a busy MRD in
-                    # round-robin fashion. The MRD now has multiple holders;
-                    # refcounting ensures it is requeued/closed only once the
-                    # LAST holder is done with it.
-                    mrd = self._all_mrds[self._rr_index]
-                    self._rr_index = (self._rr_index + 1) % len(self._all_mrds)
-
-            if mrd is None:
-                # If the queue was non-empty, this gets an MRD immediately without blocking.
-                # If the queue was empty (pool is full and sharing is disabled), this blocks
-                # until a holder returns an MRD.
-                # NOTE: the lock is intentionally held across this await -- get_mrd's finally
-                # returns MRDs via put_nowait WITHOUT the lock, so a waiter blocked
-                # here is still unblocked by a concurrent release (no deadlock).
-                mrd = await self._free_mrds.get()
+                try:
+                    mrd = self._free_mrds.get_nowait()
+                except asyncio.QueueEmpty:
+                    if self._active_count < self.pool_size:
+                        self._active_count += 1
+                        try:
+                            mrd = await self._get_or_create_mrd()
+                        except BaseException as e:
+                            self._active_count -= 1
+                            self._mrd_available.notify()
+                            raise e
+                    elif self.mrd_supports_multi_request and self._all_mrds:
+                        # Pool is full and the queue is empty: share a busy MRD in
+                        # round-robin fashion. The MRD now has multiple holders;
+                        # refcounting ensures it is requeued/closed only once the
+                        # LAST holder is done with it.
+                        mrd = self._all_mrds[self._rr_index]
+                        self._rr_index = (self._rr_index + 1) % len(self._all_mrds)
+                    else:
+                        await self._mrd_available.wait()
 
             self._mark_inflight(mrd)
 
         try:
             yield mrd
         finally:
-            # Intentionally lock-free (see note above). Only the holder that
-            # releases the MRD last requeues or closes it, so a round-robin
-            # sharer is never torn down by a peer or by close().
-            if self._release_inflight(mrd):
-                if self._closed:
-                    await close_mrd(mrd)
-                else:
-                    self._free_mrds.put_nowait(mrd)
+            close_after_release = False
+            async with self._lock:
+                # Only the holder that releases the MRD last requeues or closes
+                # it, so a round-robin sharer is never torn down by a peer or by
+                # close().
+                if self._release_inflight(mrd):
+                    if self._closed:
+                        close_after_release = True
+                    else:
+                        self._free_mrds.put_nowait(mrd)
+                        self._mrd_available.notify()
+
+            if close_after_release:
+                await close_mrd(mrd)
 
     async def close(self):
         """
@@ -625,13 +628,13 @@ class MRDPool:
             while not self._free_mrds.empty():
                 free_mrds.append(self._free_mrds.get_nowait())
 
-            try:
-                if self._cache is not None:
-                    await self._cache.release(self._key, free_mrds)
-                else:
-                    await _close_mrds(free_mrds, raise_exception=True)
-            finally:
-                self._all_mrds.clear()
+            self._all_mrds.clear()
+            self._mrd_available.notify_all()
+
+        if self._cache is not None:
+            await self._cache.release(self._key, free_mrds)
+        else:
+            await _close_mrds(free_mrds, raise_exception=True)
 
 
 def _drain_queue(q):


### PR DESCRIPTION
Fix MRDPool.close() blocking when pool is exhausted

This PR fixes a bug where `MRDPool.close()` could block indefinitely if there are tasks waiting for a Multi-Request Device (MRD) to become available in an exhausted pool.

### Cause of the bug
Previously, `MRDPool.get_mrd()` would block on `await self._free_mrds.get()` while holding the pool's lock (`self._lock`). Because the lock was held during the await, any call to `MRDPool.close()` (which also requires the lock) would block waiting for the lock to be released. If no active MRDs were released to unblock the waiter, `close()` would hang.

### Solution
We replaced the blocking `asyncio.Queue.get()` call with a condition variable (`asyncio.Condition`).
1.  Waiters now wait on `self._mrd_available.wait()` when the pool is exhausted. This releases the lock while waiting, allowing other tasks (like `close()`) to acquire the lock.
2.  `MRDPool.close()` now acquires the lock, sets `self._closed = True`, clears `_all_mrds`, and notifies all waiters using `self._mrd_available.notify_all()`.
3.  Woken waiters check if the pool has been closed and raise a `RuntimeError("MRDPool is closed.")` instead of hanging.

### Diagrams

#### Before
```mermaid
sequenceDiagram
    participant Waiter as Task 1 (Waiter)
    participant Lock as MRDPool._lock
    participant Queue as MRDPool._free_mrds
    participant Closer as Task 2 (Closer)

    Waiter->>Lock: Acquire Lock
    Note over Waiter, Lock: Lock Held
    Waiter->>Queue: get() (Blocks, Queue Empty)
    Note over Waiter: Blocked inside Lock
    Closer->>Lock: Acquire Lock (Blocks)
    Note over Closer: Blocked waiting for Lock
```

#### After
```mermaid
sequenceDiagram
    participant Waiter as Task 1 (Waiter)
    participant Lock as MRDPool._lock
    participant Cond as MRDPool._mrd_available
    participant Queue as MRDPool._free_mrds
    participant Closer as Task 2 (Closer)

    Waiter->>Lock: Acquire Lock
    Waiter->>Queue: get_nowait() (Empty)
    Waiter->>Cond: wait()
    Note over Waiter, Cond: Releases Lock & Blocks
    Closer->>Lock: Acquire Lock (Success)
    Closer->>Closer: Set _closed = True
    Closer->>Cond: notify_all()
    Closer->>Lock: Release Lock
    Note over Waiter: Wakes up, re-acquires Lock
    Waiter->>Waiter: Checks _closed (True) -> Raises RuntimeError
    Waiter->>Lock: Release Lock
```
