### PR TITLE
Introduce async API in Prefetcher and Integrate it with Disk Reads

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -305,11 +305,6 @@ class GCSFileSystem(asyn.AsyncFileSystem):
     async_impl = True
     MIN_CHUNK_SIZE_FOR_CONCURRENCY = 5 * 1024 * 1024
 
-    # This threshold applies to the standard bucket, whereas the zonal bucket
-    # uses a 5MB threshold. This difference exists because the standard bucket
-    # lacks the `DirectMemmoveBuffer` implementation used in the zonal bucket.
-    THRESOLD_FOR_DISK_READS = 100 * 1024 * 1024
-
     def __init__(
         self,
         project=DEFAULT_PROJECT,
@@ -382,6 +377,9 @@ class GCSFileSystem(asyn.AsyncFileSystem):
     def project(self):
         return self.credentials.project
 
+    # This threshold applies to the standard bucket, whereas the zonal bucket
+    # uses a 5MB threshold. This difference exists because the standard bucket
+    # lacks the `DirectMemmoveBuffer` implementation used in the zonal bucket.
     async def _get_threshold_for_disk_reads(self, bucket):
         return 100 * 1024 * 1024
 

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -10,6 +10,7 @@ import mimetypes
 import os
 import posixpath
 import re
+import sys
 import uuid
 import warnings
 import weakref
@@ -304,6 +305,11 @@ class GCSFileSystem(asyn.AsyncFileSystem):
     async_impl = True
     MIN_CHUNK_SIZE_FOR_CONCURRENCY = 5 * 1024 * 1024
 
+    # This threshold applies to the standard bucket, whereas the zonal bucket
+    # uses a 5MB threshold. This difference exists because the standard bucket
+    # lacks the `DirectMemmoveBuffer` implementation used in the zonal bucket.
+    THRESOLD_FOR_DISK_READS = 100 * 1024 * 1024
+
     def __init__(
         self,
         project=DEFAULT_PROJECT,
@@ -375,6 +381,9 @@ class GCSFileSystem(asyn.AsyncFileSystem):
     @property
     def project(self):
         return self.credentials.project
+
+    async def _get_threshold_for_disk_reads(self, bucket):
+        return 100 * 1024 * 1024
 
     # Clean up the aiohttp session
     #
@@ -1905,6 +1914,7 @@ class GCSFileSystem(asyn.AsyncFileSystem):
     async def _get_file_request(
         self, rpath, lpath, *args, headers=None, callback=None, **kwargs
     ):
+        rpath = self.url(rpath)
         consistency = kwargs.pop("consistency", self.consistency)
         await self._set_session()
         async with self.session.get(
@@ -1936,12 +1946,208 @@ class GCSFileSystem(asyn.AsyncFileSystem):
             checker.validate_http_response(r)  # validate file consistency
             return r.status, r.headers, r.request_info, data
 
+    def _init_local_file(self, lpath, total_size):
+        """Creates the target directory and pre-allocates the file size."""
+        os.makedirs(os.path.dirname(lpath) or os.curdir, exist_ok=True)
+        if total_size == 0:
+            with open(lpath, "wb"):
+                pass
+        else:
+            with open(lpath, "wb") as f:
+                f.truncate(total_size)
+
+    @retry_request(retries=retries)
+    async def _get_file_concurrent(
+        self,
+        rpath,
+        lpath,
+        concurrency,
+        chunk_size,
+        max_prefetch_size,
+        headers=None,
+        callback=None,
+        **kwargs,
+    ):
+        """Main orchestrator for concurrent file downloads utilizing BackgroundPrefetcher."""
+        details = await self._info(rpath, **kwargs)
+        total_size = details.get("size", 0)
+
+        # Concurrency typically improves performance for RAM downloads exceeding 5MB.
+        # However, for disk-backed reads in the standard bucket, _cat_file uses
+        # b"".join, which creates an additional data copy of chunks. Additionally,
+        # prefetching is ineffective for reads under 100MB because it only activates
+        # from the third read onward and scales linearly. These factors often make
+        # concurrent processing slower than writing data as it arrives.
+        #
+        #
+        # Note that the number is 5MB for zonal buckets, Thanks to our in-house, zero-copy
+        # DirectMemmoveBuffer, we didn't integrated it initially with standard bucket, because
+        # we first want to stabilise that in zonal bucket (lower traffic compared to standard)
+        #
+        # Promoting DirectMemmoveBuffer (currently used in the Zonal bucket)
+        # to the standard bucket will enable in-place assembly and lower this
+        # threshold. Until then, the concurrent path for standard is enabled only for disk
+        # reads of 100MB or more.
+        bucket, _, _ = self.split_path(rpath)
+        threshold = await self._get_threshold_for_disk_reads(bucket)
+        if total_size <= max(self.MIN_CHUNK_SIZE_FOR_CONCURRENCY, threshold):
+            concurrency = 1
+
+        if concurrency == 1:
+            return await self._get_file_request(
+                rpath, lpath, headers=headers, callback=callback, **kwargs
+            )
+
+        consistency = kwargs.pop("consistency", self.consistency)
+        check_consistency = consistency not in ("none", None)
+
+        # Prevent silent corruption by pinning the exact object generation
+        generation = details.get("generation")
+        if generation and "generation" not in kwargs:
+            kwargs["generation"] = generation
+
+        callback = callback or NoOpCallback()
+        callback.set_size(total_size)
+
+        # pre-allocate the file, it is required so multiple file descriptors can seek/write safely.
+        self._init_local_file(lpath, total_size)
+        checker = get_consistency_checker(consistency)
+
+        async def fetcher(start, size, split_factor=1):
+            # No need to worry about MRDPool creation in _cat_file.
+            # Thanks to our in-house MRDPoolCache.
+            return await self._cat_file(
+                rpath,
+                start=start,
+                end=start + size,
+                concurrency=split_factor,
+                headers=headers,
+                **kwargs,
+            )
+
+        from .prefetcher import BackgroundPrefetcher
+
+        prefetcher = BackgroundPrefetcher(
+            fetcher=fetcher,
+            size=total_size,
+            concurrency=concurrency,
+            max_prefetch_size=max_prefetch_size,
+        )
+
+        fd = None
+
+        def write_chunk(offset, chunk):
+            if fd is not None:
+                written = 0
+                chunk_view = memoryview(chunk)
+                while written < len(chunk):
+                    written += os.pwrite(fd, chunk_view[written:], offset + written)
+            else:
+                # Thread-safe fallback for older Windows versions (Python < 3.12)
+                with open(lpath, "rb+") as f:
+                    f.seek(offset)
+                    f.write(chunk)
+
+        pending_writes = set()
+        try:
+            if hasattr(os, "pwrite"):
+                fd = os.open(lpath, os.O_WRONLY | getattr(os, "O_BINARY", 0))
+
+            async with prefetcher:
+                offset = 0
+                while offset < total_size:
+                    read_size = min(chunk_size, total_size - offset)
+
+                    data = await prefetcher.afetch(offset, offset + read_size)
+
+                    if not data:
+                        break
+
+                    if check_consistency:
+                        checker.update(data)
+
+                    callback.relative_update(len(data))
+
+                    task = asyncio.create_task(
+                        asyncio.to_thread(write_chunk, offset, data)
+                    )
+                    pending_writes.add(task)
+
+                    if len(pending_writes) >= concurrency:
+                        done, pending_writes = await asyncio.wait(
+                            pending_writes, return_when=asyncio.FIRST_COMPLETED
+                        )
+
+                        exceptions = []
+                        for t in done:
+                            exc = t.exception()
+                            if exc:
+                                exceptions.append(exc)
+
+                        if exceptions:
+                            raise exceptions[0]
+
+                    offset += len(data)
+        finally:
+            all_done = set()
+            was_cancelled = False
+            if pending_writes:
+                while pending_writes:
+                    try:
+                        done_wait, pending_writes = await asyncio.wait(pending_writes)
+                        all_done.update(done_wait)
+                    except asyncio.CancelledError:
+                        was_cancelled = True
+                        pass
+
+            if fd is not None:
+                os.close(fd)
+
+            exceptions = []
+            for t in all_done:
+                exc = t.exception()
+                if exc:
+                    exceptions.append(exc)
+
+            if was_cancelled:
+                raise asyncio.CancelledError()
+
+            if exceptions and sys.exc_info()[1] is None:
+                raise exceptions[0]
+
+        if check_consistency:
+            checker.validate_json_response(details)
+
     async def _get_file(self, rpath, lpath, callback=None, **kwargs):
-        u2 = self.url(rpath)
         if os.path.isdir(lpath):
             return
+
         callback = callback or NoOpCallback()
-        await self._get_file_request(u2, lpath, callback=callback, **kwargs)
+
+        concurrency = kwargs.pop("concurrency", DEFAULT_CONCURRENCY)
+        chunk_size = kwargs.pop("chunk_size", 16 * 1024 * 1024)
+        max_prefetch_size = kwargs.pop(
+            "max_prefetch_size", 2 * concurrency * chunk_size
+        )
+
+        try:
+            # The concurrent path uses `_cat_file` to interact with gcsfs which doesn't take headers as argument.
+            if concurrency > 1 and "headers" not in kwargs:
+                await self._get_file_concurrent(
+                    rpath,
+                    lpath,
+                    concurrency,
+                    callback=callback,
+                    chunk_size=chunk_size,
+                    max_prefetch_size=max_prefetch_size,
+                    **kwargs,
+                )
+            else:
+                await self._get_file_request(rpath, lpath, callback=callback, **kwargs)
+        except BaseException:
+            if os.path.exists(lpath):
+                os.remove(lpath)
+            raise
 
     def _open(
         self,

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -2030,6 +2030,7 @@ class GCSFileSystem(asyn.AsyncFileSystem):
             size=total_size,
             concurrency=concurrency,
             max_prefetch_size=max_prefetch_size,
+            loop=self.loop,
         )
 
         fd = None
@@ -2086,6 +2087,11 @@ class GCSFileSystem(asyn.AsyncFileSystem):
                             raise exceptions[0]
 
                     offset += len(data)
+
+                if offset != total_size:
+                    raise aiohttp.client_exceptions.ClientError(
+                        f"Expected {total_size} bytes, but only received {offset} bytes"
+                    )
         finally:
             all_done = set()
             was_cancelled = False
@@ -2384,6 +2390,7 @@ class GCSFile(fsspec.spec.AbstractBufferedFile):
                 self.size,
                 max_prefetch_size=max_prefetch_size,
                 concurrency=self.concurrency,
+                loop=self.gcsfs.loop,
             )
         else:
             self._prefetch_engine = None

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -2366,7 +2366,7 @@ class GCSFile(fsspec.spec.AbstractBufferedFile):
         """
         try:
             if hasattr(self, "_prefetch_engine") and self._prefetch_engine:
-                return self._prefetch_engine._fetch(start=start, end=end)
+                return self._prefetch_engine.fetch(start=start, end=end)
             return self.fs.cat_file(
                 self.path, start=start, end=end, concurrency=self.concurrency
             )

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1964,6 +1964,7 @@ class GCSFileSystem(asyn.AsyncFileSystem):
         max_prefetch_size,
         headers=None,
         callback=None,
+        fetcher_fn=None,
         **kwargs,
     ):
         """Main orchestrator for concurrent file downloads utilizing BackgroundPrefetcher."""
@@ -2011,22 +2012,24 @@ class GCSFileSystem(asyn.AsyncFileSystem):
         self._init_local_file(lpath, total_size)
         checker = get_consistency_checker(consistency)
 
-        async def fetcher(start, size, split_factor=1):
-            # No need to worry about MRDPool creation in _cat_file.
-            # Thanks to our in-house MRDPoolCache.
-            return await self._cat_file(
-                rpath,
-                start=start,
-                end=start + size,
-                concurrency=split_factor,
-                headers=headers,
-                **kwargs,
-            )
+        if fetcher_fn is None:
+
+            async def default_fetcher(start, size, split_factor=1):
+                return await self._cat_file(
+                    rpath,
+                    start=start,
+                    end=start + size,
+                    concurrency=split_factor,
+                    headers=headers,
+                    **kwargs,
+                )
+
+            fetcher_fn = default_fetcher
 
         from .prefetcher import BackgroundPrefetcher
 
         prefetcher = BackgroundPrefetcher(
-            fetcher=fetcher,
+            fetcher=fetcher_fn,
             size=total_size,
             concurrency=concurrency,
             max_prefetch_size=max_prefetch_size,

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -1745,6 +1745,69 @@ class ExtendedGcsFileSystem(GCSFileSystem):
         finally:
             await mrd_pool.close()
 
+    async def _get_file_concurrent(
+        self,
+        rpath,
+        lpath,
+        concurrency,
+        chunk_size,
+        max_prefetch_size,
+        headers=None,
+        callback=None,
+        fetcher_fn=None,
+        **kwargs,
+    ):
+        bucket, key, path_generation = self.split_path(rpath)
+
+        # Delegate standard buckets to the original implementation
+        if not await self._is_zonal_bucket(bucket):
+            return await super()._get_file_concurrent(
+                rpath,
+                lpath,
+                concurrency,
+                chunk_size,
+                max_prefetch_size,
+                headers=headers,
+                callback=callback,
+                fetcher_fn=fetcher_fn,
+                **kwargs,
+            )
+
+        generation = path_generation or kwargs.get("generation")
+
+        # Initialize the MRDPool once for this concurrent operation
+        mrd_pool = await self._mrd_pool_cache.get(
+            bucket, key, generation, pool_size=concurrency
+        )
+
+        # Define a custom fetcher that passes the pool to _cat_file
+        async def custom_fetcher(start, size, split_factor=1):
+            return await self._cat_file(
+                rpath,
+                start=start,
+                end=start + size,
+                mrd=mrd_pool,  # Inject the shared pool here
+                concurrency=split_factor,
+                headers=headers,
+                **kwargs,
+            )
+
+        try:
+            return await super()._get_file_concurrent(
+                rpath,
+                lpath,
+                concurrency,
+                chunk_size,
+                max_prefetch_size,
+                headers=headers,
+                callback=callback,
+                fetcher_fn=custom_fetcher,  # Pass our custom fetcher up the chain
+                **kwargs,
+            )
+        finally:
+            # Ensure the pool is closed when the download completes or fails
+            await mrd_pool.close()
+
     async def _do_list_objects(
         self,
         path,

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -149,6 +149,13 @@ class ExtendedGcsFileSystem(GCSFileSystem):
             self._mrd_pool_cache,
         )
 
+    async def _get_threshold_for_disk_reads(self, bucket):
+        if await self._is_zonal_bucket(bucket):
+            return (
+                5 * 1024 * 1024
+            )  # Thanks to our in house, zero copy DirectMemmoveBuffer
+        return await super()._get_threshold_for_disk_reads(bucket)
+
     @staticmethod
     def _finalize_mrd_pool_cache(loop, cache):
         """Tear down the MRDPoolCache when ExtendedGcsFileSystem is garbage collected."""
@@ -1659,7 +1666,9 @@ class ExtendedGcsFileSystem(GCSFileSystem):
 
         self.invalidate_cache(self._parent(path))
 
-    async def _get_file(self, rpath, lpath, callback=None, **kwargs):
+    async def _get_file_request(
+        self, rpath, lpath, *args, headers=None, callback=None, **kwargs
+    ):
         """
         Downloads a file from GCS to a local path.
 
@@ -1678,17 +1687,18 @@ class ExtendedGcsFileSystem(GCSFileSystem):
             For Zonal buckets, `chunksize` bytes (int) can be provided to control
             the download chunk size (default is 128KB).
         """
-        bucket, key, generation = self.split_path(rpath)
+        bucket, key, path_generation = self.split_path(rpath)
+
         if not await self._is_zonal_bucket(bucket):
-            return await super()._get_file(
-                rpath,
-                lpath,
-                callback=callback,
-                **kwargs,
+            return await super()._get_file_request(
+                rpath, lpath, *args, headers=headers, callback=callback, **kwargs
             )
 
         if os.path.isdir(lpath):
             return
+
+        # Coalesce generation: URL parsed vs kwargs
+        generation = path_generation or kwargs.get("generation")
         callback = callback or NoOpCallback()
 
         mrd_pool = await self._mrd_pool_cache.get(bucket, key, generation, pool_size=1)
@@ -1701,7 +1711,8 @@ class ExtendedGcsFileSystem(GCSFileSystem):
                         "Falling back to _info() to get the file size. "
                         "This may result in incorrect behavior for unfinalized objects."
                     )
-                    size = (await self._info(rpath))["size"]
+                    size = (await self._info(rpath, **kwargs)).get("size", 0)
+
                 callback.set_size(size)
 
                 lparent = os.path.dirname(lpath) or os.curdir

--- a/gcsfs/prefetcher.py
+++ b/gcsfs/prefetcher.py
@@ -1,7 +1,6 @@
 import asyncio
 import ctypes
 import logging
-import threading
 import weakref
 from collections import deque
 
@@ -262,6 +261,8 @@ class PrefetchProducer:
                 len(tasks_to_wait),
             )
             await asyncio.gather(*tasks_to_wait, return_exceptions=True)
+
+        self.wakeup_event.clear()
 
     async def restart(self, new_offset: int):
         """Stops current tasks and restarts the background loop at a new byte offset.
@@ -649,37 +650,62 @@ class BackgroundPrefetcher:
             )
 
         self.loop = fsspec.asyn.get_loop()
-        self._lock = threading.Lock()
         self._error = None
         self.is_stopped = False
-        self.queue = asyncio.Queue()
-        self.wakeup_event = asyncio.Event()
         self.user_offset = 0
         self.read_tracker = RunningAverageTracker(maxlen=10)
 
-        self.consumer = PrefetchConsumer(
-            queue=self.queue,
-            wakeup_event=self.wakeup_event,
-            tracker=self.read_tracker,
-            orchestrator=self,
-        )
+        self.queue = None
+        self.wakeup_event = None
+        self._async_lock = None
+        self.consumer = None
+        self.producer = None
 
-        self.producer = PrefetchProducer(
-            fetcher=fetcher,
-            size=self.size,
-            concurrency=self.concurrency,
-            queue=self.queue,
-            wakeup_event=self.wakeup_event,
-            consumer=self.consumer,
-            tracker=self.read_tracker,
-            orchestrator=self,
-            user_max_prefetch_size=max_prefetch_size,
-        )
+        def _start():
+            # Ensures all primitives bind directly to `self.loop`
+            self.queue = asyncio.Queue()
+            self.wakeup_event = asyncio.Event()
+            self._async_lock = asyncio.Lock()
 
-        async def _start():
+            self.consumer = PrefetchConsumer(
+                queue=self.queue,
+                wakeup_event=self.wakeup_event,
+                tracker=self.read_tracker,
+                orchestrator=self,
+            )
+
+            self.producer = PrefetchProducer(
+                fetcher=fetcher,
+                size=self.size,
+                concurrency=self.concurrency,
+                queue=self.queue,
+                wakeup_event=self.wakeup_event,
+                consumer=self.consumer,
+                tracker=self.read_tracker,
+                orchestrator=self,
+                user_max_prefetch_size=max_prefetch_size,
+            )
             self.producer.start()
 
-        fsspec.asyn.sync(self.loop, _start)
+        try:
+            current_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            current_loop = None
+
+        if current_loop is self.loop and current_loop.is_running():
+            _start()
+        elif current_loop is not None and current_loop != self.loop:
+            raise RuntimeError(
+                "Multiple event loops are not supported for this class,"
+                " This is meant for run by either synchronous, or by fsspec event loop."
+            )
+        else:
+
+            async def _start_wrapper():
+                _start()
+
+            fsspec.asyn.sync(self.loop, _start_wrapper)
+
         logger.debug("BackgroundPrefetcher initialization complete.")
 
     def __enter__(self):
@@ -690,13 +716,17 @@ class BackgroundPrefetcher:
         """Context manager exit point. Ensures the prefetcher is cleanly closed."""
         self.close()
 
+    async def __aenter__(self):
+        """Async context manager entry point."""
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Async context manager exit point. Ensures the prefetcher is cleanly closed."""
+        await self.aclose()
+
     def set_error(self, e: Exception):
         logger.error("Global error state set in BackgroundPrefetcher: %s", e)
         self._error = e
-
-        # Stop the producer loop.
-        if self.producer and not self.producer.is_stopped:
-            asyncio.run_coroutine_threadsafe(self.producer.stop(), self.loop)
 
     async def _restart_producer(self, new_offset: int):
         logger.debug(
@@ -708,44 +738,78 @@ class BackgroundPrefetcher:
         self.read_tracker.clear()
 
     async def _async_fetch(self, start, end):
-        logger.debug("Executing _async_fetch for range %d - %d.", start, end)
+        """Core internal async fetching logic, protected safely by the async lock."""
+        async with self._async_lock:
+            try:
+                if self.is_stopped:
+                    raise RuntimeError("The file instance has been closed.")
 
-        # If the prefetcher is in error state, let's do a hard seek to start offset.
-        if self._error:
-            logger.info(
-                "Recovering from error state. Restarting producer at offset: %d", start
-            )
-            self.user_offset = start
-            await self._restart_producer(start)
-        elif start != self.user_offset:
-            if self.user_offset < start <= self.producer.current_offset:
-                logger.debug(
-                    "Soft seek detected. Skipping ahead from %d to %d.",
-                    self.user_offset,
-                    start,
+                logger.debug("Executing _async_fetch for range %d - %d.", start, end)
+
+                # If the prefetcher is in error state, let's do a hard seek to start offset.
+                if self._error:
+                    logger.info(
+                        "Recovering from error state. Restarting producer at offset: %d",
+                        start,
+                    )
+                    self.user_offset = start
+                    await self._restart_producer(start)
+                elif start != self.user_offset:
+                    if self.user_offset < start <= self.producer.current_offset:
+                        logger.debug(
+                            "Soft seek detected. Skipping ahead from %d to %d.",
+                            self.user_offset,
+                            start,
+                        )
+                        skip_amount = start - self.user_offset
+                        await self.consumer.skip(skip_amount)
+                        self.user_offset = start
+                    else:
+                        logger.debug(
+                            "Hard seek detected. Moving user offset from %d to %d.",
+                            self.user_offset,
+                            start,
+                        )
+                        self.user_offset = start
+                        await self._restart_producer(start)
+
+                requested_size = end - start
+                self.read_tracker.add(requested_size)
+
+                chunk = await self.consumer.consume(requested_size)
+                self.user_offset += len(chunk)
+
+                logger.debug("Completed _async_fetch. Returned %d bytes.", len(chunk))
+                return chunk
+            except asyncio.CancelledError as e:
+                self._error = e
+                raise
+            except Exception as e:
+                logger.error(
+                    "Exception raised during asynchronous fetch: %s", e, exc_info=True
                 )
-                skip_amount = start - self.user_offset
-                await self.consumer.skip(skip_amount)
-                self.user_offset = start
-            else:
-                logger.debug(
-                    "Hard seek detected. Moving user offset from %d to %d.",
-                    self.user_offset,
-                    start,
-                )
-                self.user_offset = start
-                await self._restart_producer(start)
+                self._error = e
+                if self.producer and not self.producer.is_stopped:
+                    await self.producer.stop()
+                raise
 
-        requested_size = end - start
-        self.read_tracker.add(requested_size)
+    async def _async_close(self):
+        """Asynchronous teardown logic protected by the async lock."""
+        async with self._async_lock:
+            if self.is_stopped:
+                return
 
-        chunk = await self.consumer.consume(requested_size)
-        self.user_offset += len(chunk)
+            self.is_stopped = True
+            logger.debug("Acquired async lock. Tearing down producer and buffers.")
 
-        logger.debug("Completed _async_fetch. Returned %d bytes.", len(chunk))
-        return chunk
+            if self.producer:
+                await self.producer.stop()
 
-    def _fetch(self, start: int | None, end: int | None) -> bytes:
+            self.consumer.clear_buffer()
+            logger.debug("BackgroundPrefetcher closed successfully.")
+
+    async def afetch(self, start: int | None, end: int | None) -> bytes:
+        """Asynchronous API counterpart to `_fetch`."""
         if start is None:
             start = 0
         if end is None:
@@ -753,63 +817,32 @@ class BackgroundPrefetcher:
 
         end = min(end, self.size)
         logger.debug(
-            "Synchronous _fetch called for bounds start=%s, end=%s.", start, end
+            "Asynchronous afetch called for bounds start=%s, end=%s.", start, end
         )
 
         if start >= self.size or start >= end:
-            logger.warning(
-                "Invalid bounds or EOF reached in _fetch. Start: %d, End: %d, Size: %d",
-                start,
-                end,
-                self.size,
-            )
             return b""
 
-        with self._lock:
-            if self.is_stopped:
-                logger.error(
-                    "Cannot fetch data: BackgroundPrefetcher is stopped or closed."
-                )
-                raise RuntimeError(
-                    "The file instance has been closed. This can occur if a close operation "
-                    "is executed concurrently while a read operation is still in progress."
-                )
+        if self.is_stopped:
+            logger.error(
+                "Cannot fetch data: BackgroundPrefetcher is stopped or closed."
+            )
+            raise RuntimeError(
+                "The file instance has been closed. This can occur if a close operation "
+                "is executed concurrently while a read operation is still in progress."
+            )
 
-            try:
-                result = fsspec.asyn.sync(self.loop, self._async_fetch, start, end)
-            except Exception as e:
-                logger.error(
-                    "Exception raised during synchronous fetch: %s", e, exc_info=True
-                )
-                self._error = e
-                if self.producer and not self.producer.is_stopped:
-                    asyncio.run_coroutine_threadsafe(self.producer.stop(), self.loop)
-                raise
+        return await self._async_fetch(start, end)
 
-            if self.is_stopped:
-                logger.error("Instance was stopped mid-fetch operation.")
-                raise RuntimeError(
-                    "The file instance has been closed. This can occur if a close operation "
-                    "is executed concurrently while a read operation is still in progress."
-                )
+    def fetch(self, start: int | None, end: int | None) -> bytes:
+        """Synchronous API wrapper delegating to `afetch`."""
+        # Delegates all boundaries, checking, and fetching to the async event loop perfectly
+        return fsspec.asyn.sync(self.loop, self.afetch, start, end)
 
-            return result
+    async def aclose(self):
+        """Safely shuts down the prefetcher from an asynchronous context."""
+        await self._async_close()
 
     def close(self):
-        """Safely shuts down the prefetcher.
-
-        This cancels all background network tasks and blocks until everything
-        is completely cleaned up. It also clears the internal consumer buffer.
-        """
-        logger.debug("Closing BackgroundPrefetcher and cleaning up resources.")
-        if self.is_stopped:
-            logger.debug(
-                "BackgroundPrefetcher is already stopped. Skipping close operation."
-            )
-            return
-
-        self.is_stopped = True
-        with self._lock:
-            fsspec.asyn.sync(self.loop, self.producer.stop)
-            self.consumer.clear_buffer()
-        logger.debug("BackgroundPrefetcher closed successfully.")
+        """Safely shuts down the prefetcher from a synchronous context."""
+        fsspec.asyn.sync(self.loop, self._async_close)

--- a/gcsfs/prefetcher.py
+++ b/gcsfs/prefetcher.py
@@ -621,7 +621,9 @@ class BackgroundPrefetcher:
 
     producer = None
 
-    def __init__(self, fetcher, size: int, concurrency: int, max_prefetch_size=None):
+    def __init__(
+        self, fetcher, size: int, concurrency: int, max_prefetch_size=None, loop=None
+    ):
         """Initializes the background prefetcher.
 
         Args:
@@ -629,6 +631,10 @@ class BackgroundPrefetcher:
             size (int): Total byte size of the file being read.
             concurrency (int): Number of concurrent network requests to use for large chunks.
             max_prefetch_size (int, optional): Maximum bytes to prefetch ahead of the current user offset.
+            loop (asyncio.AbstractEventLoop, optional): The event loop to attach the prefetcher to.
+                If executing synchronously, this should be the fsspec background loop. If executing
+                asynchronously (asynchronous=True), this should be None so it can automatically
+                inherit the user's currently running event loop.
 
         Raises:
             ValueError: If max_prefetch_size is provided but is not a positive integer.
@@ -649,7 +655,7 @@ class BackgroundPrefetcher:
                 "max_prefetch_size should be a positive integer to use adaptive prefetching!"
             )
 
-        self.loop = fsspec.asyn.get_loop()
+        self.loop = loop
         self._error = None
         self.is_stopped = False
         self.user_offset = 0
@@ -692,19 +698,22 @@ class BackgroundPrefetcher:
         except RuntimeError:
             current_loop = None
 
-        if current_loop is self.loop and current_loop.is_running():
+        if current_loop is self.loop and self.loop is not None:
+            # We are already safely running inside the fsspec background loop
             _start()
-        elif current_loop is not None and current_loop != self.loop:
-            raise RuntimeError(
-                "Multiple event loops are not supported for this class,"
-                " This is meant for run by either synchronous, or by fsspec event loop."
-            )
-        else:
-
+        elif self.loop is not None:
+            # We are on the main thread; schedule setup on the fsspec background loop
             async def _start_wrapper():
                 _start()
 
             fsspec.asyn.sync(self.loop, _start_wrapper)
+        elif current_loop is not None:
+            # asynchronous=True: use the user's active event loop
+            self.loop = current_loop
+            _start()
+        else:
+            # asynchronous=True but called completely outside of an async context
+            raise RuntimeError("No event loop found")
 
         logger.debug("BackgroundPrefetcher initialization complete.")
 

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -11,6 +11,7 @@ from unittest import mock
 from urllib.parse import parse_qs, unquote, urlparse
 from uuid import uuid4
 
+import aiohttp
 import fsspec.asyn
 import fsspec.core
 import pytest
@@ -3210,9 +3211,9 @@ def test_get_file_concurrent_no_pwrite(gcs):
 
 
 def test_get_file_concurrent_early_eof(gcs):
-    """Coverage: `if not data: break` mid-stream"""
+    """Coverage: integrity check raises ClientError after retries."""
     fn = f"{TEST_BUCKET}/early_eof.txt"
-    data = b"1234567890" * 1024 * 1024  # ~10MB (larger than 5MB default)
+    data = b"1234567890" * 1024 * 1024  # ~10MB
     gcs.pipe(fn, data)
 
     with tempdir() as dn:
@@ -3230,15 +3231,21 @@ def test_get_file_concurrent_early_eof(gcs):
                 new_callable=mock.AsyncMock,
             ) as mock_afetch,
         ):
+            # Define a function to simulate consistent truncation across retries
+            async def mock_afetch_truncated(start, end):
+                if start == 0:
+                    return b"12345"  # Only return the first 5 bytes
+                return b""  # Return EOF for any subsequent range
 
-            # 1st call gives data, 2nd call returns empty b"" forcing an early break
-            mock_afetch.side_effect = [b"12345", b""]
-            gcs.get_file(fn, lpath, concurrency=2, chunk_size=5)
+            mock_afetch.side_effect = mock_afetch_truncated
 
-        # The file was pre-allocated to size ~10MB, but early EOF stopped writing at 5
-        assert os.path.getsize(lpath) == len(data)
-        with open(lpath, "rb") as f:
-            assert f.read(5) == b"12345"
+            # The function will retry several times, but always fail the integrity check.
+            # We assert that it eventually raises the ClientError.
+            with pytest.raises(
+                aiohttp.ClientError,
+                match="Expected 10485760 bytes, but only received 5 bytes",
+            ):
+                gcs.get_file(fn, lpath, concurrency=2, chunk_size=5)
 
 
 def test_get_file_concurrent_write_exception_in_loop(gcs):

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -1,3 +1,5 @@
+import asyncio
+import builtins
 import concurrent.futures
 import io
 import os
@@ -3031,3 +3033,295 @@ async def test_info_parallel_dir_first(gcs):
 
         assert mock_get_object.call_count == 1
         assert mock_get_dir.call_count == 1
+
+
+def test_get_file_routing_and_thresholds(gcs):
+    """Test that get_file correctly routes to sequential or concurrent paths based on size thresholds."""
+    fn = f"{TEST_BUCKET}/get_routing.txt"
+    # Create an 8MB file
+    data = os.urandom(8 * 1024 * 1024)
+    gcs.pipe(fn, data)
+
+    with tempdir() as dn:
+        lpath = os.path.join(dn, "out.txt")
+
+        with (
+            mock.patch.object(
+                gcs, "_get_file_request", wraps=gcs._get_file_request
+            ) as mock_req,
+            mock.patch.object(
+                gcs, "_get_file_concurrent", wraps=gcs._get_file_concurrent
+            ) as mock_conc,
+        ):
+
+            # 1. Concurrency = 1 (Should route directly to sequential)
+            gcs.get_file(fn, lpath, concurrency=1)
+            assert open(lpath, "rb").read() == data
+            assert mock_req.call_count == 1
+            assert mock_conc.call_count == 0
+
+            mock_req.reset_mock()
+            mock_conc.reset_mock()
+            os.remove(lpath)
+
+            # 2. Standard Bucket (100MB threshold)
+            # 8MB is < 100MB, so it should gracefully fall back to sequential internally
+            with mock.patch.object(
+                gcs,
+                "_get_threshold_for_disk_reads",
+                new_callable=mock.AsyncMock,
+                return_value=100 * 1024 * 1024,
+            ):
+                gcs.get_file(fn, lpath, concurrency=4)
+                assert open(lpath, "rb").read() == data
+                assert mock_conc.call_count == 1
+                assert mock_req.call_count == 1
+
+            mock_req.reset_mock()
+            mock_conc.reset_mock()
+            os.remove(lpath)
+
+            # 3. Zonal Bucket (5MB threshold)
+            # 8MB is >= 5MB, so it should fully execute via the concurrent prefetcher logic
+            with mock.patch.object(
+                gcs,
+                "_get_threshold_for_disk_reads",
+                new_callable=mock.AsyncMock,
+                return_value=5 * 1024 * 1024,
+            ):
+                gcs.get_file(fn, lpath, concurrency=4)
+                assert open(lpath, "rb").read() == data
+                assert mock_conc.call_count == 1
+                assert mock_req.call_count == 0
+
+
+def test_get_file_concurrent_data_integrity(gcs):
+    """Test that the concurrent file fetch stitches blocks together correctly."""
+    fn = f"{TEST_BUCKET}/get_integrity.txt"
+    file_size = 20 * 1024 * 1024  # 20MB (larger than 5MB default)
+    data = os.urandom(file_size)
+    gcs.pipe(fn, data)
+
+    with tempdir() as dn:
+        lpath = os.path.join(dn, "out_integrity.txt")
+
+        # Lower threshold to force true concurrency (no longer modifying MIN_CHUNK_SIZE_FOR_CONCURRENCY)
+        with mock.patch.object(
+            gcs,
+            "_get_threshold_for_disk_reads",
+            new_callable=mock.AsyncMock,
+            return_value=5 * 1024 * 1024,
+        ):
+            gcs.get_file(fn, lpath, concurrency=4, chunk_size=5 * 1024 * 1024)
+
+        assert os.path.getsize(lpath) == file_size
+        with open(lpath, "rb") as f:
+            assert f.read() == data
+
+
+def test_get_file_concurrent_exception_cancellation(gcs):
+    """Ensure that if a chunk fails during concurrent download, the exception is raised and file is cleaned up."""
+    fn = f"{TEST_BUCKET}/get_exception.txt"
+    file_size = 10 * 1024 * 1024  # 10MB (larger than 5MB default)
+    data = os.urandom(file_size)
+    gcs.pipe(fn, data)
+
+    with tempdir() as dn:
+        lpath = os.path.join(dn, "out_exception.txt")
+        original_cat = gcs._cat_file
+
+        async def mock_fail_cat(path, start, end, **kwargs):
+            if (
+                start > 0
+            ):  # Force failure on subsequent chunks, allowing the first chunk to write
+                raise OSError("Simulated Download Error")
+            return await original_cat(path, start, end, **kwargs)
+
+        with mock.patch.object(
+            gcs,
+            "_get_threshold_for_disk_reads",
+            new_callable=mock.AsyncMock,
+            return_value=2 * 1024 * 1024,
+        ):
+            with mock.patch.object(gcs, "_cat_file", side_effect=mock_fail_cat):
+                with pytest.raises(OSError, match="Simulated Download Error"):
+                    gcs.get_file(fn, lpath, concurrency=4, chunk_size=2 * 1024 * 1024)
+
+        # File should be removed by the clean-up block in _get_file
+        assert not os.path.exists(lpath)
+
+
+def test_get_file_concurrent_consistency(gcs):
+    """Ensure concurrent path appropriately invokes the file consistency checker."""
+    fn = f"{TEST_BUCKET}/get_consistency.txt"
+    data = b"consistency test data" * 300000  # ~6.3MB (larger than 5MB default)
+    gcs.pipe(fn, data)
+
+    with tempdir() as dn:
+        lpath = os.path.join(dn, "out_consistency.txt")
+
+        # Mock the dynamic threshold lookup to 1 byte so it stays concurrent
+        with mock.patch.object(
+            gcs,
+            "_get_threshold_for_disk_reads",
+            new_callable=mock.AsyncMock,
+            return_value=1,
+        ):
+
+            # Mock the internal validate method of the checker
+            with mock.patch(
+                "gcsfs.checkers.MD5Checker.validate_json_response"
+            ) as mock_validate:
+                gcs.get_file(fn, lpath, concurrency=2, consistency="md5")
+                mock_validate.assert_called_once()
+
+
+def test_get_file_concurrent_no_pwrite(gcs):
+    """Coverage: `with open(lpath, "rb+") as f: f.seek(offset); f.write(chunk)`"""
+    fn = f"{TEST_BUCKET}/no_pwrite.txt"
+    data = b"fallback_test_data" * (1024 * 1024)  # ~18MB (larger than 5MB default)
+    gcs.pipe(fn, data)
+
+    with tempdir() as dn:
+        lpath = os.path.join(dn, "out_no_pwrite.txt")
+
+        # Safely mock `hasattr(os, 'pwrite')` returning False
+        orig_hasattr = builtins.hasattr
+
+        def mock_hasattr(obj, name):
+            if obj is os and name == "pwrite":
+                return False
+            return orig_hasattr(obj, name)
+
+        with (
+            mock.patch.object(
+                gcs,
+                "_get_threshold_for_disk_reads",
+                new_callable=mock.AsyncMock,
+                return_value=-1,
+            ),
+            mock.patch("builtins.hasattr", side_effect=mock_hasattr),
+        ):
+
+            gcs.get_file(fn, lpath, concurrency=2, chunk_size=10 * 1024 * 1024)
+
+        with open(lpath, "rb") as f:
+            assert f.read() == data
+
+
+def test_get_file_concurrent_early_eof(gcs):
+    """Coverage: `if not data: break` mid-stream"""
+    fn = f"{TEST_BUCKET}/early_eof.txt"
+    data = b"1234567890" * 1024 * 1024  # ~10MB (larger than 5MB default)
+    gcs.pipe(fn, data)
+
+    with tempdir() as dn:
+        lpath = os.path.join(dn, "out_early_eof.txt")
+
+        with (
+            mock.patch.object(
+                gcs,
+                "_get_threshold_for_disk_reads",
+                new_callable=mock.AsyncMock,
+                return_value=-1,
+            ),
+            mock.patch(
+                "gcsfs.prefetcher.BackgroundPrefetcher.afetch",
+                new_callable=mock.AsyncMock,
+            ) as mock_afetch,
+        ):
+
+            # 1st call gives data, 2nd call returns empty b"" forcing an early break
+            mock_afetch.side_effect = [b"12345", b""]
+            gcs.get_file(fn, lpath, concurrency=2, chunk_size=5)
+
+        # The file was pre-allocated to size ~10MB, but early EOF stopped writing at 5
+        assert os.path.getsize(lpath) == len(data)
+        with open(lpath, "rb") as f:
+            assert f.read(5) == b"12345"
+
+
+def test_get_file_concurrent_write_exception_in_loop(gcs):
+    """Coverage: `if exceptions: raise exceptions[0]` (Inside the pending loop)"""
+    fn = f"{TEST_BUCKET}/write_exc_loop.txt"
+    data = b"1234567890" * 1024 * 1024  # ~10MB (larger than 5MB default)
+    gcs.pipe(fn, data)
+
+    with tempdir() as dn:
+        lpath = os.path.join(dn, "out_write_exc_loop.txt")
+
+        with (
+            mock.patch.object(
+                gcs,
+                "_get_threshold_for_disk_reads",
+                new_callable=mock.AsyncMock,
+                return_value=-1,
+            ),
+            mock.patch("os.pwrite", side_effect=OSError("Disk Full Loop")),
+        ):
+            with pytest.raises(OSError, match="Disk Full Loop"):
+                # Chunk size small to produce many pending_writes and trigger the loop check
+                gcs.get_file(fn, lpath, concurrency=2, chunk_size=5 * 1024 * 1024)
+
+
+def test_get_file_concurrent_write_exception_in_finally(gcs):
+    """Coverage: `if exc: exceptions.append(exc)` (Inside the finally clean-up block)"""
+    fn = f"{TEST_BUCKET}/write_exc_finally.txt"
+    data = b"1234567890" * 1024 * 1024  # ~10MB (larger than 5MB default)
+    gcs.pipe(fn, data)
+
+    with tempdir() as dn:
+        lpath = os.path.join(dn, "out_write_exc_finally.txt")
+
+        with (
+            mock.patch.object(
+                gcs,
+                "_get_threshold_for_disk_reads",
+                new_callable=mock.AsyncMock,
+                return_value=-1,
+            ),
+            mock.patch("os.pwrite", side_effect=OSError("Disk Full Finally")),
+        ):
+            with pytest.raises(OSError, match="Disk Full Finally"):
+                gcs.get_file(fn, lpath, concurrency=3, chunk_size=20 * 1024 * 1024)
+
+
+def test_get_file_concurrent_cancelled_error(gcs):
+    """Coverage: `except asyncio.CancelledError: break/pass` inside the finally block"""
+    fn = f"{TEST_BUCKET}/cancelled.txt"
+    data = b"1234567890" * 1024 * 1024  # ~10MB (larger than 5MB default)
+    gcs.pipe(fn, data)
+
+    with tempdir() as dn:
+        lpath = os.path.join(dn, "out_cancelled.txt")
+
+        # Create a mock that forces the exact exception we are trying to cover
+        async def mock_wait(*args, **kwargs):
+            raise asyncio.CancelledError()
+
+        with (
+            mock.patch.object(
+                gcs,
+                "_get_threshold_for_disk_reads",
+                new_callable=mock.AsyncMock,
+                return_value=-1,
+            ),
+            mock.patch("gcsfs.core.asyncio.wait", side_effect=mock_wait),
+        ):
+            gcs.get_file(fn, lpath, concurrency=2, chunk_size=20 * 1024 * 1024)
+
+
+def test_init_local_file(gcs):
+    """Coverage: `if total_size == 0:` inside `_init_local_file`"""
+    with tempdir() as dn:
+        # Cover normal pre-allocation
+        lpath = os.path.join(dn, "prealloc.txt")
+        gcs._init_local_file(lpath, 1024)
+        assert os.path.exists(lpath)
+        assert os.path.getsize(lpath) == 1024
+
+        # Cover zero-size pre-allocation
+        lpath_zero = os.path.join(dn, "zero.txt")
+        gcs._init_local_file(lpath_zero, 0)
+        assert os.path.exists(lpath_zero)
+        assert os.path.getsize(lpath_zero) == 0

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -3325,6 +3325,8 @@ def test_init_local_file(gcs):
         gcs._init_local_file(lpath_zero, 0)
         assert os.path.exists(lpath_zero)
         assert os.path.getsize(lpath_zero) == 0
+
+
 def test_open_generation_forwarded():
     fs = gcsfs.core.GCSFileSystem()
     with mock.patch("gcsfs.core.GCSFile") as mock_gcs_file:

--- a/gcsfs/tests/test_prefetcher.py
+++ b/gcsfs/tests/test_prefetcher.py
@@ -12,6 +12,9 @@ def prefetcher_factory():
     prefetchers = []
 
     def _make_prefetcher(**kwargs):
+        if "loop" not in kwargs:
+            kwargs["loop"] = fsspec.asyn.get_loop()
+
         bp = BackgroundPrefetcher(**kwargs)
         prefetchers.append(bp)
         return bp
@@ -621,3 +624,47 @@ def test_async_context_manager_and_afetch(prefetcher_factory):
         assert bp.consumer._current_block == b""  # Buffer cleanly cleared on async exit
 
     fsspec.asyn.sync(bp.loop, run_async)
+
+
+def test_init_with_explicit_loop(prefetcher_factory):
+    """Verify that passing an explicit loop assigns it correctly."""
+    loop = fsspec.asyn.get_loop()
+    bp = prefetcher_factory(
+        fetcher=MockFetcher(b"X"), size=100, concurrency=1, loop=loop
+    )
+    assert bp.loop is loop
+
+
+@pytest.mark.asyncio
+async def test_init_with_running_loop():
+    """Verify asynchronous=True behavior where it inherits the user's running loop."""
+    current = asyncio.get_running_loop()
+    # explicitly passing loop=None simulates asynchronous=True behavior
+    bp = BackgroundPrefetcher(
+        fetcher=MockFetcher(b"X"), size=100, concurrency=1, loop=None
+    )
+    assert bp.loop is current
+    await bp.aclose()
+
+
+def test_init_within_fsspec_loop(prefetcher_factory):
+    """Verify the edge case where the prefetcher is initialized while already running inside the target loop."""
+    loop = fsspec.asyn.get_loop()
+
+    async def init_inside_loop():
+        bp = BackgroundPrefetcher(
+            fetcher=MockFetcher(b"X"), size=100, concurrency=1, loop=loop
+        )
+        assert bp.loop is loop
+        await bp.aclose()
+
+    # Submit the initialization directly onto the background thread
+    fsspec.asyn.sync(loop, init_inside_loop)
+
+
+def test_init_no_loop_raises_error():
+    """Verify synchronous execution strictly fails if no explicit loop or active loop is found."""
+    with pytest.raises(RuntimeError, match="No event loop found"):
+        BackgroundPrefetcher(
+            fetcher=MockFetcher(b"X"), size=100, concurrency=1, loop=None
+        )

--- a/gcsfs/tests/test_prefetcher.py
+++ b/gcsfs/tests/test_prefetcher.py
@@ -84,24 +84,24 @@ def test_sequential_read_spanning_blocks(prefetcher_factory):
     bp = prefetcher_factory(fetcher=fetcher, size=300, concurrency=4)
     bp.read_tracker.add(100)  # Seed the adaptive tracker
 
-    assert bp._fetch(0, 100) == b"A" * 100
-    assert bp._fetch(100, 150) == b"B" * 50
+    assert bp.fetch(0, 100) == b"A" * 100
+    assert bp.fetch(100, 150) == b"B" * 50
     assert bp.consumer._current_block_idx == 50
-    assert bp._fetch(150, 250) == b"B" * 50 + b"C" * 50
-    assert bp._fetch(250, 300) == b"C" * 50
-    assert bp._fetch(300, 310) == b""
+    assert bp.fetch(150, 250) == b"B" * 50 + b"C" * 50
+    assert bp.fetch(250, 300) == b"C" * 50
+    assert bp.fetch(300, 310) == b""
 
 
 def test_fetch_default_args_and_out_of_bounds(prefetcher_factory):
     fetcher = MockFetcher(b"12345")
     bp = prefetcher_factory(fetcher=fetcher, size=5, concurrency=4)
 
-    assert bp._fetch(None, None) == b"12345"
-    assert bp._fetch(None, 2) == b"12"
-    assert bp._fetch(5, 10) == b""
-    assert bp._fetch(10, 20) == b""
-    assert bp._fetch(2, 2) == b""
-    assert bp._fetch(4, 2) == b""
+    assert bp.fetch(None, None) == b"12345"
+    assert bp.fetch(None, 2) == b"12"
+    assert bp.fetch(5, 10) == b""
+    assert bp.fetch(10, 20) == b""
+    assert bp.fetch(2, 2) == b""
+    assert bp.fetch(4, 2) == b""
 
 
 def test_seek_logic(prefetcher_factory):
@@ -109,12 +109,12 @@ def test_seek_logic(prefetcher_factory):
     fetcher = MockFetcher(data)
     bp = prefetcher_factory(fetcher=fetcher, size=100, concurrency=4)
 
-    assert bp._fetch(0, 10) == data[0:10]
-    assert bp._fetch(10, 20) == data[10:20]
+    assert bp.fetch(0, 10) == data[0:10]
+    assert bp.fetch(10, 20) == data[10:20]
     assert bp.user_offset == 20
-    assert bp._fetch(50, 60) == data[50:60]
+    assert bp.fetch(50, 60) == data[50:60]
     assert bp.user_offset == 60
-    assert bp._fetch(10, 20) == data[10:20]
+    assert bp.fetch(10, 20) == data[10:20]
     assert bp.user_offset == 20
 
 
@@ -127,7 +127,7 @@ def test_exception_placed_in_queue(prefetcher_factory):
     fsspec.asyn.sync(bp.loop, inject_error)
 
     with pytest.raises(ValueError, match="Injected Producer Error"):
-        bp._fetch(0, 50)
+        bp.fetch(0, 50)
 
     assert isinstance(bp._error, ValueError)
 
@@ -147,7 +147,7 @@ def test_producer_concurrency_streak_and_min_chunk(prefetcher_factory):
     # Update these values as BackgroundPrefetcher constant changes.
     target_streak = bp.producer.MIN_STREAKS_FOR_PREFETCHING + 3
     for i in range(target_streak):
-        bp._fetch(i * 50, (i + 1) * 50)
+        bp.fetch(i * 50, (i + 1) * 50)
 
     fsspec.asyn.sync(bp.loop, asyncio.sleep, 0.1)
 
@@ -169,7 +169,7 @@ def test_producer_loop_space_constraints(prefetcher_factory):
     original_min_chunk = bp.producer.MIN_CHUNK_SIZE
     bp.producer.MIN_CHUNK_SIZE = 200
 
-    assert bp._fetch(0, 10) == b"Y" * 10
+    assert bp.fetch(0, 10) == b"Y" * 10
 
     fsspec.asyn.sync(bp.loop, asyncio.sleep, 0.1)
     sizes = [call["size"] for call in fetcher.calls]
@@ -183,11 +183,11 @@ def test_producer_error_propagation_and_recovery(prefetcher_factory):
     bp = prefetcher_factory(fetcher=fetcher, size=2000, concurrency=4)
 
     for i in range(2):
-        bp._fetch(i * 100, (i + 1) * 100)
+        bp.fetch(i * 100, (i + 1) * 100)
 
     # 3rd read triggers the network timeout
     with pytest.raises(OSError, match="Simulated Network Timeout"):
-        bp._fetch(400, 500)
+        bp.fetch(400, 500)
 
     # The prefetcher is now in an error state
     assert isinstance(bp._error, OSError)
@@ -196,7 +196,7 @@ def test_producer_error_propagation_and_recovery(prefetcher_factory):
     fetcher.fail_at_call = None
 
     # The next fetch should seamlessly recover, wiping the error and returning data
-    data = bp._fetch(400, 500)
+    data = bp.fetch(400, 500)
     assert data == b"A" * 100
     assert bp._error is None
 
@@ -207,7 +207,7 @@ def test_read_after_close(prefetcher_factory):
 
     assert bp.is_stopped is True
     with pytest.raises(RuntimeError, match="The file instance has been closed"):
-        bp._fetch(0, 10)
+        bp.fetch(0, 10)
 
 
 def test_read_recovers_after_error(prefetcher_factory):
@@ -217,7 +217,7 @@ def test_read_recovers_after_error(prefetcher_factory):
     bp._error = ValueError("Pre-existing error")
 
     # The new error-recovery logic allows a subsequent read to clear the error and succeed
-    assert bp._fetch(0, 10) == b"X" * 10
+    assert bp.fetch(0, 10) == b"X" * 10
     assert bp._error is None
 
 
@@ -226,7 +226,7 @@ def test_empty_queue_when_stopped(prefetcher_factory):
     bp.is_stopped = True
 
     with pytest.raises(RuntimeError, match="The file instance has been closed"):
-        bp._fetch(0, 100)
+        bp.fetch(0, 100)
 
 
 def test_cancel_all_tasks_cleans_queue_with_exceptions(prefetcher_factory):
@@ -287,22 +287,23 @@ def test_read_task_cancellation(prefetcher_factory):
 def test_async_fetch_exception_trapping(prefetcher_factory):
     bp = prefetcher_factory(fetcher=MockFetcher(b"X" * 100), size=100, concurrency=4)
 
-    def bad_sync(*args, **kwargs):
-        raise RuntimeError("Simulated sync crash")
+    async def bad_consume(*args, **kwargs):
+        raise RuntimeError("Simulated async crash")
 
-    with mock.patch("fsspec.asyn.sync", side_effect=bad_sync):
-        with pytest.raises(RuntimeError, match="Simulated sync crash"):
-            bp._fetch(0, 10)
+    bp.consumer.consume = bad_consume
 
-    # Orchestrator is no longer permanently stopped on standard exceptions
-    assert bp.is_stopped is False
+    with pytest.raises(RuntimeError, match="Simulated async crash"):
+        bp.fetch(0, 10)
+
+    # Orchestrator should capture the error internally and halt producer processing correctly
     assert isinstance(bp._error, RuntimeError)
+    assert bp.producer.is_stopped is True
 
 
 def test_read_past_eof_internal(prefetcher_factory):
     bp = prefetcher_factory(fetcher=MockFetcher(b"X" * 50), size=50, concurrency=4)
     bp.user_offset = 50
-    res = bp._fetch(50, 60)
+    res = bp.fetch(50, 60)
     assert res == b""
 
 
@@ -311,9 +312,9 @@ def test_fetch_with_exact_block_matches(prefetcher_factory):
     bp = prefetcher_factory(fetcher=MockFetcher(data), size=100, concurrency=4)
     bp.read_tracker.add(50)
 
-    assert bp._fetch(0, 50) == b"X" * 50
+    assert bp.fetch(0, 50) == b"X" * 50
     assert bp.consumer._current_block_idx == 50
-    assert bp._fetch(50, 100) == b"X" * 50
+    assert bp.fetch(50, 100) == b"X" * 50
 
 
 def test_queue_empty_race_condition(prefetcher_factory):
@@ -334,7 +335,7 @@ def test_producer_space_remaining_break(prefetcher_factory):
         concurrency=4,
         max_prefetch_size=150,
     )
-    bp._fetch(0, 10)
+    bp.fetch(0, 10)
     fsspec.asyn.sync(bp.loop, asyncio.sleep, 0.1)
 
 
@@ -368,7 +369,7 @@ def test_producer_loop_exception(prefetcher_factory):
     ) as mocked_avg:
         mocked_avg.side_effect = error_object
         with pytest.raises(ValueError, match="Producer crash"):
-            bp._fetch(0, 10)
+            bp.fetch(0, 10)
 
     assert bp.is_stopped is False
     assert bp._error == error_object
@@ -376,32 +377,20 @@ def test_producer_loop_exception(prefetcher_factory):
 
 def test_seek_same_offset(prefetcher_factory):
     bp = prefetcher_factory(fetcher=MockFetcher(b""), size=100, concurrency=4)
-    fsspec.asyn.sync(bp.loop, bp._async_fetch, 0, 10)
+    bp.fetch(0, 10)
 
 
 def test_read_history_maxlen(prefetcher_factory):
     bp = prefetcher_factory(fetcher=MockFetcher(b"X" * 2000), size=2000, concurrency=4)
     for i in range(12):
-        bp._fetch(i * 10, (i + 1) * 10)
+        bp.fetch(i * 10, (i + 1) * 10)
     assert len(bp.read_tracker._history) == 10
 
 
 def test_fast_slice_branch(prefetcher_factory):
     bp = prefetcher_factory(fetcher=MockFetcher(b"X" * 200), size=200, concurrency=4)
-    assert bp._fetch(0, 10) == b"X" * 10
-    assert bp._fetch(10, 20) == b"X" * 10
-
-
-def test_fetch_stopped_during_execution(prefetcher_factory):
-    bp = prefetcher_factory(fetcher=MockFetcher(b"X" * 100), size=100, concurrency=4)
-
-    async def fake_async_fetch(start, end):
-        bp.is_stopped = True
-        return b"fake"
-
-    with mock.patch.object(bp, "_async_fetch", new=fake_async_fetch):
-        with pytest.raises(RuntimeError, match="The file instance has been closed"):
-            bp._fetch(0, 10)
+    assert bp.fetch(0, 10) == b"X" * 10
+    assert bp.fetch(10, 20) == b"X" * 10
 
 
 def test_async_fetch_not_block_break(prefetcher_factory):
@@ -413,7 +402,7 @@ def test_async_fetch_not_block_break(prefetcher_factory):
     bp.consumer.consume = fake_consume
     bp.user_offset = 0
 
-    res = fsspec.asyn.sync(bp.loop, bp._async_fetch, 0, 50)
+    res = bp.fetch(0, 50)
     assert res == b""
 
 
@@ -423,7 +412,7 @@ def test_fetch_stopped_before_execution(prefetcher_factory):
     bp._error = None
 
     with pytest.raises(RuntimeError, match="The file instance has been closed"):
-        bp._fetch(0, 10)
+        bp.fetch(0, 10)
 
 
 def test_async_fetch_zero_copy_remainder(prefetcher_factory):
@@ -431,7 +420,7 @@ def test_async_fetch_zero_copy_remainder(prefetcher_factory):
     bp.consumer._current_block = b"ABCDE"
     bp.consumer._current_block_idx = 0
     bp.user_offset = 0
-    res = fsspec.asyn.sync(bp.loop, bp._async_fetch, 0, 5)
+    res = bp.fetch(0, 5)
     assert res == b"ABCDE"
     assert bp.consumer._current_block_idx == 5
 
@@ -540,7 +529,7 @@ def test_massive_read_disables_proactive_prefetching(prefetcher_factory):
     # Do enough reads to build a sequential streak and trigger large averages
     # Reading 60 bytes at a time. Average = 60. Threshold = 50.
     for i in range(4):
-        bp._fetch(i * 60, (i + 1) * 60)
+        bp.fetch(i * 60, (i + 1) * 60)
 
     fsspec.asyn.sync(bp.loop, asyncio.sleep, 0.1)
 
@@ -560,7 +549,7 @@ def test_normal_read_allows_proactive_prefetching(prefetcher_factory):
 
     # Reading 60 bytes at a time. Average = 60. Threshold = 100.
     for i in range(4):
-        bp._fetch(i * 60, (i + 1) * 60)
+        bp.fetch(i * 60, (i + 1) * 60)
 
     fsspec.asyn.sync(bp.loop, asyncio.sleep, 0.1)
 
@@ -577,7 +566,7 @@ def test_target_offset_expands_prefetch(prefetcher_factory):
     bp.read_tracker.add(10)
 
     # The consumer requests a massive chunk (500 bytes), far exceeding normal prefetch windows
-    bp._fetch(0, 500)
+    bp.fetch(0, 500)
 
     fsspec.asyn.sync(bp.loop, asyncio.sleep, 0.1)
 
@@ -615,3 +604,20 @@ def test_producer_min_chunk_inner_empty_queue_shrink(prefetcher_factory):
     assert fetcher.call_count > 0
 
     bp.producer.MIN_CHUNK_SIZE = original_min_chunk
+
+
+def test_async_context_manager_and_afetch(prefetcher_factory):
+    bp = prefetcher_factory(fetcher=MockFetcher(b"X" * 100), size=100, concurrency=4)
+
+    async def run_async():
+        async with bp as ctx:
+            res = await ctx.afetch(0, 10)
+            assert res == b"X" * 10
+            # Test default bounds -> (0, 100). Validates a backwards hard seek internally.
+            res_all = await ctx.afetch(None, None)
+            assert len(res_all) == 100
+
+        assert bp.is_stopped is True
+        assert bp.consumer._current_block == b""  # Buffer cleanly cleared on async exit
+
+    fsspec.asyn.sync(bp.loop, run_async)

--- a/gcsfs/tests/test_zonal_file.py
+++ b/gcsfs/tests/test_zonal_file.py
@@ -603,20 +603,20 @@ def test_zonal_file_fetch_range_with_prefetch_engine(mock_sync, mock_gcsfs):
     mock_engine = mock.Mock()
     zf._prefetch_engine = mock_engine
 
-    mock_engine._fetch.return_value = b"all_data"
+    mock_engine.fetch.return_value = b"all_data"
     result = zf._fetch_range(start=0, end=10)
     assert result == b"all_data"
-    mock_engine._fetch.assert_called_once_with(0, 10)
+    mock_engine.fetch.assert_called_once_with(0, 10)
 
     mock_engine.reset_mock()
-    mock_engine._fetch.side_effect = [b"chunk1", b"chunk2"]
+    mock_engine.fetch.side_effect = [b"chunk1", b"chunk2"]
     result = zf._fetch_range(start=0, chunk_lengths=[6, 6])
     assert result == [b"chunk1", b"chunk2"]
-    mock_engine._fetch.assert_has_calls([mock.call(0, 6), mock.call(6, 12)])
+    mock_engine.fetch.assert_has_calls([mock.call(0, 6), mock.call(6, 12)])
 
     mock_engine.reset_mock()
-    mock_engine._fetch.side_effect = None
-    mock_engine._fetch.return_value = b"short"
+    mock_engine.fetch.side_effect = None
+    mock_engine.fetch.return_value = b"short"
 
     result = zf._fetch_range(start=0, chunk_lengths=[10])
     assert result == [b""]
@@ -685,7 +685,7 @@ def test_zonal_file_fetch_range_unhandled_runtime_error(mock_sync, mock_gcsfs):
     zf = ZonalFile(gcsfs=mock_gcsfs, path="gs://test-bucket/test-key", mode="rb")
     mock_engine = mock.Mock()
     zf._prefetch_engine = mock_engine
-    mock_engine._fetch.side_effect = RuntimeError(
+    mock_engine.fetch.side_effect = RuntimeError(
         "A completely different error occurred"
     )
 

--- a/gcsfs/zonal_file.py
+++ b/gcsfs/zonal_file.py
@@ -203,7 +203,7 @@ class ZonalFile(GCSFile):
                 results = []
                 current_offset = start if start is not None else 0
                 for length in chunk_lengths:
-                    data = self._prefetch_engine._fetch(
+                    data = self._prefetch_engine.fetch(
                         current_offset, current_offset + length
                     )
                     results.append(data)

--- a/gcsfs/zonal_file.py
+++ b/gcsfs/zonal_file.py
@@ -193,7 +193,7 @@ class ZonalFile(GCSFile):
 
             try:
                 if chunk_lengths is None:
-                    return self._prefetch_engine._fetch(start, end)
+                    return self._prefetch_engine.fetch(start, end)
 
                 # Fetch chunks sequentially through the prefetch engine
                 # Spawning concurrent task is worst here, because that would act as seek for prefetcher.


### PR DESCRIPTION
## Description

**Introduce async API in Prefetcher and Integration with Disk Reads**

- This PR refactors the `BackgroundPrefetcher` to natively support asynchronous operations. 
- This PR integrates those asynchronous API of prefetcher to _get_file in Zonal and Standard Buckets.

### Benchmarks on Disk Backed Reads

## Zonal (Concurrency Enabled for > 5MB)

| Payload | Before Avg Throughput | After Avg Throughput | Before Memory Peak | After Memory Peak | Mem Delta |
|---------|-----------------------|----------------------|--------------------|-------------------|-----------|
| 64KB    | 0.69                  | 0.31                 | 103.7              | 103.9             | +0.2      |
| 1MB     | 11.53                 | 5.46                 | 108.5              | 109.1             | +0.6      |
| 10MB    | 39.94                 | 75.94                | 140.2              | 150.9             | +10.7     |
| 50MB    | 65.09                 | 334.74               | 189.2              | 216.6             | +27.4     |
| 100MB   | 73.12                 | 522.81               | 266.0              | 278.5             | +12.5     |
| 150MB   | 89.88                 | 613.78               | 329.3              | 346.4             | +17.0     |
| 1GB     | 67.89                 | 1346.88              | 419.5              | 533.1             | +113.5    |
| 5GB     | 62.88                 | 1885.74              | 564.1              | 635.0             | +70.9     |
| 10GB    | 75.92                 | 1884.96              | 584.3              | 644.9             | +60.6     |

## Regional (Concurrency Enabled for > 100MB)

| Payload | Before Avg Throughput | After Avg Throughput | Before Memory Peak | After Memory Peak | Mem Delta |
|---------|-----------------------|----------------------|--------------------|-------------------|-----------|
| 64KB    | 1.61                  | 1.10                 | 87.2               | 87.2              | +0.0      |
| 1MB     | 19.67                 | 15.26                | 87.6               | 87.6              | +0.1      |
| 10MB    | 142.04                | 102.54               | 87.7               | 87.7              | +0.0      |
| 50MB    | 225.54                | 200.85               | 88.4               | 88.6              | +0.2      |
| 100MB   | 235.33                | 268.08               | 89.3               | 89.3              | +0.0      |
| 150MB   | 256.19                | 254.82               | 164.7              | 209.0             | +44.3     |
| 1GB     | 295.30                | 527.34               | 212.1              | 355.6             | +143.5    |
| 5GB     | 219.51                | 702.02               | 250.3              | 367.9             | +117.6    |
| 10GB    | 252.99                | 784.28               | 262.2              | 374.2             | +112.0    |