### PR TITLE
Fix multiple `_info()` calls in `_process_limits_to_offset_and_length`

### DIFF
--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -362,21 +362,23 @@ class ExtendedGcsFileSystem(GCSFileSystem):
         """
         size = file_size
 
+        async def _get_size():
+            nonlocal size
+            if size is None:
+                size = (await self._info(path))["size"]
+            return size
+
         if start is None:
             offset = 0
         elif start < 0:
-            size = (await self._info(path))["size"] if size is None else size
-            # If start is negative and larger than the file size, we should start from 0.
-            offset = max(0, size + start)
+            offset = max(0, await _get_size() + start)
         else:
             offset = start
 
         if end is None:
-            size = (await self._info(path))["size"] if size is None else size
-            effective_end = size
+            effective_end = await _get_size()
         elif end < 0:
-            size = (await self._info(path))["size"] if size is None else size
-            effective_end = size + end
+            effective_end = await _get_size() + end
         else:
             effective_end = end
 
@@ -385,9 +387,9 @@ class ExtendedGcsFileSystem(GCSFileSystem):
             return offset, 0
         else:
             length = effective_end - offset  # Normal case
-            size = (await self._info(path))["size"] if size is None else size
-            if effective_end > size:
-                length = max(0, size - offset)  # Clamp and ensure non-negative
+            s = await _get_size()
+            if effective_end > s:
+                length = max(0, s - offset)  # Clamp and ensure non-negative
 
         return offset, length
 

--- a/gcsfs/tests/test_extended_gcsfs_unit.py
+++ b/gcsfs/tests/test_extended_gcsfs_unit.py
@@ -696,17 +696,23 @@ async def test_get_all_folders_start_dir_calculation(
 async def test_process_limits_to_offset_and_length_info_calls():
     extended_gcsfs = ExtendedGcsFileSystem(token="anon", skip_instance_cache=True)
     path = "bucket/file"
-    with mock.patch.object(extended_gcsfs, "_info", new_callable=mock.AsyncMock) as mock_info:
+    with mock.patch.object(
+        extended_gcsfs, "_info", new_callable=mock.AsyncMock
+    ) as mock_info:
         mock_info.return_value = {"size": 100}
 
         # Test case where size is fetched
-        await extended_gcsfs._process_limits_to_offset_and_length(path, start=-10, end=-5)
+        await extended_gcsfs._process_limits_to_offset_and_length(
+            path, start=-10, end=-5
+        )
         mock_info.assert_awaited_once_with(path)
 
         mock_info.reset_mock()
 
         # Test case where size is fetched (None, None)
-        await extended_gcsfs._process_limits_to_offset_and_length(path, start=None, end=None)
+        await extended_gcsfs._process_limits_to_offset_and_length(
+            path, start=None, end=None
+        )
         mock_info.assert_awaited_once_with(path)
 
         mock_info.reset_mock()
@@ -720,8 +726,11 @@ async def test_process_limits_to_offset_and_length_info_calls():
         mock_info.reset_mock()
 
         # Test case where size is provided
-        await extended_gcsfs._process_limits_to_offset_and_length(path, start=-10, end=-5, file_size=100)
+        await extended_gcsfs._process_limits_to_offset_and_length(
+            path, start=-10, end=-5, file_size=100
+        )
         mock_info.assert_not_called()
+
 
 def test_extended_gcsfs_constructs_mrd_pool_cache(monkeypatch):
     # Avoid creating real gRPC clients

--- a/gcsfs/tests/test_extended_gcsfs_unit.py
+++ b/gcsfs/tests/test_extended_gcsfs_unit.py
@@ -717,9 +717,8 @@ async def test_process_limits_to_offset_and_length_info_calls():
 
         mock_info.reset_mock()
 
-        # Test case where size is not fetched because start and end are positive and end > size
-        # wait, if end > size, it actually WILL fetch size to clamp length.
-        # But if start=10, end=5, it returns offset, 0 without fetching size
+        # Test case where size is not fetched because start and end are positive and end <= start
+        # When end <= start, the function returns early without needing size.
         await extended_gcsfs._process_limits_to_offset_and_length(path, start=10, end=5)
         mock_info.assert_not_called()
 

--- a/gcsfs/tests/test_extended_gcsfs_unit.py
+++ b/gcsfs/tests/test_extended_gcsfs_unit.py
@@ -692,6 +692,37 @@ async def test_get_all_folders_start_dir_calculation(
         assert request.prefix == expected_start_dir
 
 
+@pytest.mark.asyncio
+async def test_process_limits_to_offset_and_length_info_calls():
+    extended_gcsfs = ExtendedGcsFileSystem(token="anon", skip_instance_cache=True)
+    path = "bucket/file"
+    with mock.patch.object(extended_gcsfs, "_info", new_callable=mock.AsyncMock) as mock_info:
+        mock_info.return_value = {"size": 100}
+
+        # Test case where size is fetched
+        await extended_gcsfs._process_limits_to_offset_and_length(path, start=-10, end=-5)
+        mock_info.assert_awaited_once_with(path)
+
+        mock_info.reset_mock()
+
+        # Test case where size is fetched (None, None)
+        await extended_gcsfs._process_limits_to_offset_and_length(path, start=None, end=None)
+        mock_info.assert_awaited_once_with(path)
+
+        mock_info.reset_mock()
+
+        # Test case where size is not fetched because start and end are positive and end > size
+        # wait, if end > size, it actually WILL fetch size to clamp length.
+        # But if start=10, end=5, it returns offset, 0 without fetching size
+        await extended_gcsfs._process_limits_to_offset_and_length(path, start=10, end=5)
+        mock_info.assert_not_called()
+
+        mock_info.reset_mock()
+
+        # Test case where size is provided
+        await extended_gcsfs._process_limits_to_offset_and_length(path, start=-10, end=-5, file_size=100)
+        mock_info.assert_not_called()
+
 def test_extended_gcsfs_constructs_mrd_pool_cache(monkeypatch):
     # Avoid creating real gRPC clients
     monkeypatch.setattr(


### PR DESCRIPTION
Resolves an issue where `ExtendedGcsFileSystem._process_limits_to_offset_and_length` could issue up to three separate `_info()` requests to GCS when calculating limits for range reads with negative or `None` offsets. It does this by fetching the size lazily via an internal async function and memoizing it.
