### PR TITLE
Fix: Route GCSMap through dynamically resolved GCSFileSystem

### DIFF
--- a/gcsfs/__init__.py
+++ b/gcsfs/__init__.py
@@ -28,6 +28,4 @@ if os.getenv("GCSFS_EXPERIMENTAL_ZB_HNS_SUPPORT", "true").lower() in ("true", "1
         )
         # Fallback to core GCSFileSystem, do not register here
 
-# TODO: GCSMap still refers to the original GCSFileSystem. This will be
-# addressed in a future update.
 __all__ = ["GCSFileSystem", "GCSMap"]

--- a/gcsfs/mapping.py
+++ b/gcsfs/mapping.py
@@ -1,7 +1,6 @@
-from .core import GCSFileSystem
-
-
 def GCSMap(root, gcs=None, check=False, create=False):
     """For backward compatibility"""
-    gcs = gcs or GCSFileSystem.current()
+    import gcsfs
+
+    gcs = gcs or gcsfs.GCSFileSystem.current()
     return gcs.get_mapper(root, check=check, create=create)

--- a/gcsfs/tests/test_mapping.py
+++ b/gcsfs/tests/test_mapping.py
@@ -127,3 +127,25 @@ def test_map_pickle(gcs):
     e = pickle.loads(b)
 
     assert dict(e) == {"x": b"1234567890"}
+
+
+def test_gcsmap_uses_extended_gcsfilesystem(monkeypatch):
+    import importlib
+    import gcsfs
+    from gcsfs.extended_gcsfs import ExtendedGcsFileSystem
+
+    monkeypatch.setenv("GCSFS_EXPERIMENTAL_ZB_HNS_SUPPORT", "true")
+    importlib.reload(gcsfs)
+    importlib.reload(gcsfs.mapping)
+
+    # Invalidate cached current instance if any to ensure a new one is created
+    # based on the mocked environment.
+    gcsfs.GCSFileSystem.clear_instance_cache()
+
+    try:
+        mapper = gcsfs.mapping.GCSMap("test-bucket")
+        assert isinstance(mapper.fs, ExtendedGcsFileSystem)
+    finally:
+        monkeypatch.delenv("GCSFS_EXPERIMENTAL_ZB_HNS_SUPPORT", raising=False)
+        importlib.reload(gcsfs)
+        importlib.reload(gcsfs.mapping)

--- a/gcsfs/tests/test_mapping.py
+++ b/gcsfs/tests/test_mapping.py
@@ -131,6 +131,7 @@ def test_map_pickle(gcs):
 
 def test_gcsmap_uses_extended_gcsfilesystem(monkeypatch):
     import importlib
+
     import gcsfs
     from gcsfs.extended_gcsfs import ExtendedGcsFileSystem
 


### PR DESCRIPTION
Fixes `GCSMap` in `gcsfs/mapping.py` to route through the environment-selected `GCSFileSystem` class (e.g. `ExtendedGcsFileSystem` for Zonal/HNS) instead of hardcoding `.core.GCSFileSystem`. This ensures mapping users (such as Dask/Zarr) correctly pick up the experimental features when they are enabled via the environment variable. Also updated mapping tests to verify this behavior dynamically.
