### PR TITLE
Fix generation parameter not forwarded to GCSFile in open()

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1977,6 +1977,7 @@ class GCSFileSystem(asyn.AsyncFileSystem):
             acl=acl,
             autocommit=autocommit,
             fixed_key_metadata=fixed_key_metadata,
+            generation=generation,
             **kwargs,
         )
 

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -3033,7 +3033,6 @@ async def test_info_parallel_dir_first(gcs):
         assert mock_get_dir.call_count == 1
 
 
-
 def test_open_generation_forwarded():
     fs = gcsfs.core.GCSFileSystem()
     with mock.patch("gcsfs.core.GCSFile") as mock_gcs_file:

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -3031,3 +3031,13 @@ async def test_info_parallel_dir_first(gcs):
 
         assert mock_get_object.call_count == 1
         assert mock_get_dir.call_count == 1
+
+
+
+def test_open_generation_forwarded():
+    fs = gcsfs.core.GCSFileSystem()
+    with mock.patch("gcsfs.core.GCSFile") as mock_gcs_file:
+        fs.open("test/key", "rb", generation="123")
+        mock_gcs_file.assert_called_once()
+        _, kwargs = mock_gcs_file.call_args
+        assert kwargs.get("generation") == "123"


### PR DESCRIPTION
In GCSFileSystem._open, the generation parameter was accepted in the method signature but not passed along to the GCSFile constructor. This caused any historical version read requests to silently read the latest object version instead. This commit fixes the bug by explicitly forwarding `generation=generation` to GCSFile and adds a test to verify the fix.
