### PR TITLE
Fix `ResourceMonitor` thread shutdown latency affecting benchmark durations

### DIFF
--- a/gcsfs/tests/perf/microbenchmarks/resource_monitor.py
+++ b/gcsfs/tests/perf/microbenchmarks/resource_monitor.py
@@ -5,8 +5,8 @@ import psutil
 
 
 class ResourceMonitor:
-    def __init__(self):
-        self.interval = 1.0
+    def __init__(self, interval=1.0):
+        self.interval = interval
 
         self.vcpus = psutil.cpu_count() or 1
         self.max_cpu = 0.0
@@ -29,12 +29,12 @@ class ResourceMonitor:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.stop()
         self.duration = time.perf_counter() - self.start_time
         end_net = psutil.net_io_counters()
 
         self.net_sent = end_net.bytes_sent - self.start_net.bytes_sent
         self.net_recv = end_net.bytes_recv - self.start_net.bytes_recv
+        self.stop()
 
     def _monitor(self):
         psutil.cpu_percent(interval=None)
@@ -63,7 +63,7 @@ class ResourceMonitor:
             except psutil.NoSuchProcess:
                 pass
 
-            time.sleep(self.interval)
+            self._stop_event.wait(self.interval)
 
     def start(self):
         self._thread = threading.Thread(target=self._monitor, daemon=True)

--- a/gcsfs/tests/perf/microbenchmarks/test_resource_monitor.py
+++ b/gcsfs/tests/perf/microbenchmarks/test_resource_monitor.py
@@ -1,5 +1,7 @@
 import time
+
 from gcsfs.tests.perf.microbenchmarks.resource_monitor import ResourceMonitor
+
 
 def test_resource_monitor_duration():
     """

--- a/gcsfs/tests/perf/microbenchmarks/test_resource_monitor.py
+++ b/gcsfs/tests/perf/microbenchmarks/test_resource_monitor.py
@@ -1,0 +1,18 @@
+import time
+from gcsfs.tests.perf.microbenchmarks.resource_monitor import ResourceMonitor
+
+def test_resource_monitor_duration():
+    """
+    Test that the resource monitor accurately measures duration of the monitored block,
+    without including thread shutdown latency.
+    """
+    # Use a long interval so that time.sleep inside the monitor thread would have
+    # added significant latency if wait() wasn't used or stop() was called before duration measurement.
+    with ResourceMonitor(interval=1.0) as m:
+        time.sleep(0.05)
+
+    # We slept for 0.05s. Due to Python overhead, let's bound it at 0.2s.
+    # Prior to the fix, this would be ~1.05s because stop() waited for the time.sleep(1.0) to finish
+    # BEFORE duration was recorded.
+    assert m.duration < 0.2
+    assert m.duration >= 0.05


### PR DESCRIPTION
Fixes the bug where ResourceMonitor in the microbenchmarking suite inflated test duration limits due to thread join latency. Duration is correctly calculated prior to waiting on thread termination, and the thread wait allows immediate signalling. Added testing coverage.
