### PR TITLE
Fix ZonalFile generation parameter overwriting

### DIFF
--- a/gcsfs/tests/test_zonal_file.py
+++ b/gcsfs/tests/test_zonal_file.py
@@ -34,29 +34,47 @@ def mock_gcsfs():
     return fs
 
 
-def test_zonal_file_generation_kwarg_handling(mock_gcsfs):
+@mock.patch("gcsfs.zonal_file.asyn.sync")
+def test_zonal_file_generation_kwarg_handling(mock_sync, mock_gcsfs):
     """Test that ZonalFile explicitly provided generation kwarg is not dropped."""
     from gcsfs.zonal_file import ZonalFile
 
     # split_path returns None for generation when it's not in the path
     mock_gcsfs.split_path.return_value = ("test-bucket", "test-key", None)
-    ZonalFile(gcsfs=mock_gcsfs, path="gs://test-bucket/test-key", mode="rb", generation="456")
-
-    mock_gcsfs._mrd_pool_cache.get.assert_called_once_with(
-        "test-bucket", "test-key", "456", mock.ANY
+    zf = ZonalFile(
+        gcsfs=mock_gcsfs, path="gs://test-bucket/test-key", mode="rb", generation="456"
     )
 
+    expected_call = mock.call(
+        mock_gcsfs.loop,
+        mock_gcsfs._mrd_pool_cache.get,
+        "test-bucket",
+        "test-key",
+        "456",
+        mock.ANY,
+    )
+    assert expected_call in mock_sync.call_args_list
+    zf.close()
 
-def test_zonal_file_generation_path_handling(mock_gcsfs):
+
+@mock.patch("gcsfs.zonal_file.asyn.sync")
+def test_zonal_file_generation_path_handling(mock_sync, mock_gcsfs):
     """Test that ZonalFile parses generation from the path when provided."""
     from gcsfs.zonal_file import ZonalFile
 
     mock_gcsfs.split_path.return_value = ("test-bucket", "test-key", "123")
-    ZonalFile(gcsfs=mock_gcsfs, path="gs://test-bucket/test-key#123", mode="rb")
+    zf = ZonalFile(gcsfs=mock_gcsfs, path="gs://test-bucket/test-key#123", mode="rb")
 
-    mock_gcsfs._mrd_pool_cache.get.assert_called_once_with(
-        "test-bucket", "test-key", "123", mock.ANY
+    expected_call = mock.call(
+        mock_gcsfs.loop,
+        mock_gcsfs._mrd_pool_cache.get,
+        "test-bucket",
+        "test-key",
+        "123",
+        mock.ANY,
     )
+    assert expected_call in mock_sync.call_args_list
+    zf.close()
 
 
 @pytest.mark.parametrize(

--- a/gcsfs/tests/test_zonal_file.py
+++ b/gcsfs/tests/test_zonal_file.py
@@ -34,6 +34,31 @@ def mock_gcsfs():
     return fs
 
 
+def test_zonal_file_generation_kwarg_handling(mock_gcsfs):
+    """Test that ZonalFile explicitly provided generation kwarg is not dropped."""
+    from gcsfs.zonal_file import ZonalFile
+
+    # split_path returns None for generation when it's not in the path
+    mock_gcsfs.split_path.return_value = ("test-bucket", "test-key", None)
+    ZonalFile(gcsfs=mock_gcsfs, path="gs://test-bucket/test-key", mode="rb", generation="456")
+
+    mock_gcsfs._mrd_pool_cache.get.assert_called_once_with(
+        "test-bucket", "test-key", "456", mock.ANY
+    )
+
+
+def test_zonal_file_generation_path_handling(mock_gcsfs):
+    """Test that ZonalFile parses generation from the path when provided."""
+    from gcsfs.zonal_file import ZonalFile
+
+    mock_gcsfs.split_path.return_value = ("test-bucket", "test-key", "123")
+    ZonalFile(gcsfs=mock_gcsfs, path="gs://test-bucket/test-key#123", mode="rb")
+
+    mock_gcsfs._mrd_pool_cache.get.assert_called_once_with(
+        "test-bucket", "test-key", "123", mock.ANY
+    )
+
+
 @pytest.mark.parametrize(
     "setup_action, error_match",
     [

--- a/gcsfs/zonal_file.py
+++ b/gcsfs/zonal_file.py
@@ -6,7 +6,7 @@ from google.cloud.storage.asyncio.async_appendable_object_writer import (
 )
 
 from gcsfs import zb_hns_utils
-from gcsfs.core import DEFAULT_BLOCK_SIZE, GCSFile
+from gcsfs.core import DEFAULT_BLOCK_SIZE, GCSFile, _coalesce_generation
 
 from .caching import (  # noqa: F401 Unused import to register GCS-Specific caches, Please do not remove it.
     ReadAheadChunked,
@@ -57,7 +57,8 @@ class ZonalFile(GCSFile):
         of `_MAX_CHUNK_SIZE_BYTES` (2 MiB). Note that this higher default value may
         increase memory usage.
         """
-        bucket, key, generation = gcsfs._split_path(path)
+        bucket, key, path_generation = gcsfs.split_path(path)
+        generation = _coalesce_generation(generation, path_generation)
         if not key:
             raise OSError("Attempt to open a bucket")
         self.aaow = None


### PR DESCRIPTION
The `ZonalFile.__init__` was incorrectly overwriting the explicitly requested `generation` parameter before creating the Multi-Range Downloader (MRD) pool by parsing the path blindly. We fix it by parsing the generation into a `path_generation` variable and merging it correctly using `_coalesce_generation`.
