### PR TITLE
Fix multi-process benchmark child process crash handling

### DIFF
--- a/gcsfs/tests/perf/microbenchmarks/runner.py
+++ b/gcsfs/tests/perf/microbenchmarks/runner.py
@@ -167,6 +167,9 @@ def run_multi_process(
             logging.info(
                 f"Multi-process {benchmark_group} benchmark: Starting round {round_num + 1}/{params.rounds}."
             )
+            for i in range(params.processes):
+                process_data_shared[i] = 0.0
+
             processes = []
 
             affinity_set = False
@@ -195,8 +198,14 @@ def run_multi_process(
                 if affinity_set:
                     os.sched_setaffinity(0, old_affinity)
 
-            for p in processes:
+            for i, p in enumerate(processes):
                 p.join()
+                if p.exitcode != 0:
+                    for remaining_p in processes:
+                        if remaining_p.is_alive():
+                            remaining_p.terminate()
+                            remaining_p.join()
+                    raise RuntimeError(f"Worker process {i} exited with code {p.exitcode}")
 
             if getattr(params, "runtime", None):
                 results.append(int(sum(process_data_shared[:])))

--- a/gcsfs/tests/perf/microbenchmarks/runner.py
+++ b/gcsfs/tests/perf/microbenchmarks/runner.py
@@ -205,7 +205,9 @@ def run_multi_process(
                         if remaining_p.is_alive():
                             remaining_p.terminate()
                             remaining_p.join()
-                    raise RuntimeError(f"Worker process {i} exited with code {p.exitcode}")
+                    raise RuntimeError(
+                        f"Worker process {i} exited with code {p.exitcode}"
+                    )
 
             if getattr(params, "runtime", None):
                 results.append(int(sum(process_data_shared[:])))

--- a/gcsfs/tests/perf/microbenchmarks/test_runner.py
+++ b/gcsfs/tests/perf/microbenchmarks/test_runner.py
@@ -187,11 +187,11 @@ def test_run_multi_process_child_fails(mock_mp, mock_benchmark, mock_monitor):
     mock_mp.get_context.return_value = mock_ctx
 
     mock_process1 = mock.Mock()
-    mock_process1.exitcode = 0
+    mock_process1.exitcode = 1
     mock_process1.is_alive.return_value = False
 
     mock_process2 = mock.Mock()
-    mock_process2.exitcode = 1
+    mock_process2.exitcode = None
     mock_process2.is_alive.return_value = True
 
     mock_ctx.Process.side_effect = [mock_process1, mock_process2]
@@ -208,7 +208,7 @@ def test_run_multi_process_child_fails(mock_mp, mock_benchmark, mock_monitor):
     mock_array = MockArray()
     mock_ctx.Array.return_value = mock_array
 
-    with pytest.raises(RuntimeError, match="Worker process 1 exited with code 1"):
+    with pytest.raises(RuntimeError, match="Worker process 0 exited with code 1"):
         runner.run_multi_process(
             mock_benchmark,
             mock_monitor,
@@ -219,8 +219,10 @@ def test_run_multi_process_child_fails(mock_mp, mock_benchmark, mock_monitor):
             "listing",
         )
 
-    assert mock_process2.terminate.call_count == 1
-    assert mock_process2.join.call_count == 2  # 1 for wait, 1 for after terminate
+    mock_process1.join.assert_called_once()
+    mock_process1.terminate.assert_not_called()
+    mock_process2.terminate.assert_called_once()
+    mock_process2.join.assert_called_once()
 
 
 @mock.patch("gcsfs.tests.perf.microbenchmarks.runner.multiprocessing")
@@ -233,7 +235,6 @@ def test_run_multi_process_resets_shared_data(mock_mp, mock_benchmark, mock_moni
     mock_ctx = mock.Mock()
     mock_mp.get_context.return_value = mock_ctx
     mock_process = mock.Mock()
-    mock_process.exitcode = 0
     mock_process.exitcode = 0
     mock_ctx.Process.return_value = mock_process
 

--- a/gcsfs/tests/perf/microbenchmarks/test_runner.py
+++ b/gcsfs/tests/perf/microbenchmarks/test_runner.py
@@ -139,7 +139,9 @@ def test_run_multi_process(mock_mp, mock_benchmark, mock_monitor):
     # Mock shared array
 
     class MockArray:
-        def __setitem__(self, idx, val): pass
+        def __setitem__(self, idx, val):
+            pass
+
         def __getitem__(self, idx):
             if isinstance(idx, slice):
                 return [1.0, 2.0]
@@ -147,7 +149,6 @@ def test_run_multi_process(mock_mp, mock_benchmark, mock_monitor):
 
     mock_array = MockArray()
     mock_ctx.Array.return_value = mock_array
-
 
     runner.run_multi_process(
         mock_benchmark,
@@ -196,7 +197,9 @@ def test_run_multi_process_child_fails(mock_mp, mock_benchmark, mock_monitor):
     mock_ctx.Process.side_effect = [mock_process1, mock_process2]
 
     class MockArray:
-        def __setitem__(self, idx, val): pass
+        def __setitem__(self, idx, val):
+            pass
+
         def __getitem__(self, idx):
             if isinstance(idx, slice):
                 return [1.0, 2.0]
@@ -217,7 +220,8 @@ def test_run_multi_process_child_fails(mock_mp, mock_benchmark, mock_monitor):
         )
 
     assert mock_process2.terminate.call_count == 1
-    assert mock_process2.join.call_count == 2 # 1 for wait, 1 for after terminate
+    assert mock_process2.join.call_count == 2  # 1 for wait, 1 for after terminate
+
 
 @mock.patch("gcsfs.tests.perf.microbenchmarks.runner.multiprocessing")
 def test_run_multi_process_resets_shared_data(mock_mp, mock_benchmark, mock_monitor):
@@ -235,9 +239,11 @@ def test_run_multi_process_resets_shared_data(mock_mp, mock_benchmark, mock_moni
 
     # Use a real list or dict to simulate the array so we can assert it was reset
     shared_data = {}
+
     class MockArray:
         def __setitem__(self, idx, val):
             shared_data[idx] = val
+
         def __getitem__(self, idx):
             if isinstance(idx, slice):
                 return [shared_data.get(0, 0.0), shared_data.get(1, 0.0)]

--- a/gcsfs/tests/perf/microbenchmarks/test_runner.py
+++ b/gcsfs/tests/perf/microbenchmarks/test_runner.py
@@ -133,13 +133,21 @@ def test_run_multi_process(mock_mp, mock_benchmark, mock_monitor):
     mock_ctx = mock.Mock()
     mock_mp.get_context.return_value = mock_ctx
     mock_process = mock.Mock()
+    mock_process.exitcode = 0
     mock_ctx.Process.return_value = mock_process
 
     # Mock shared array
-    mock_array = mock.Mock()
-    # Simulate durations for 2 processes
-    mock_array.__getitem__ = mock.Mock(return_value=[1.0, 2.0])
+
+    class MockArray:
+        def __setitem__(self, idx, val): pass
+        def __getitem__(self, idx):
+            if isinstance(idx, slice):
+                return [1.0, 2.0]
+            return 1.0
+
+    mock_array = MockArray()
     mock_ctx.Array.return_value = mock_array
+
 
     runner.run_multi_process(
         mock_benchmark,
@@ -165,3 +173,94 @@ def test_run_multi_process(mock_mp, mock_benchmark, mock_monitor):
     # Check runs in extra_info
     assert mock_benchmark.extra_info["runs"] == [2.0, 2.0]
     assert mock_benchmark.extra_info["min_run"] == 2.0
+
+
+@mock.patch("gcsfs.tests.perf.microbenchmarks.runner.multiprocessing")
+def test_run_multi_process_child_fails(mock_mp, mock_benchmark, mock_monitor):
+    params = MockParams(processes=2, rounds=1)
+    extended_gcs_factory = mock.Mock(return_value="gcs_instance")
+    worker_target = mock.Mock()
+    args_builder = mock.Mock(return_value=("arg1",))
+
+    mock_ctx = mock.Mock()
+    mock_mp.get_context.return_value = mock_ctx
+
+    mock_process1 = mock.Mock()
+    mock_process1.exitcode = 0
+    mock_process1.is_alive.return_value = False
+
+    mock_process2 = mock.Mock()
+    mock_process2.exitcode = 1
+    mock_process2.is_alive.return_value = True
+
+    mock_ctx.Process.side_effect = [mock_process1, mock_process2]
+
+    class MockArray:
+        def __setitem__(self, idx, val): pass
+        def __getitem__(self, idx):
+            if isinstance(idx, slice):
+                return [1.0, 2.0]
+            return 1.0
+
+    mock_array = MockArray()
+    mock_ctx.Array.return_value = mock_array
+
+    with pytest.raises(RuntimeError, match="Worker process 1 exited with code 1"):
+        runner.run_multi_process(
+            mock_benchmark,
+            mock_monitor,
+            params,
+            extended_gcs_factory,
+            worker_target,
+            args_builder,
+            "listing",
+        )
+
+    assert mock_process2.terminate.call_count == 1
+    assert mock_process2.join.call_count == 2 # 1 for wait, 1 for after terminate
+
+@mock.patch("gcsfs.tests.perf.microbenchmarks.runner.multiprocessing")
+def test_run_multi_process_resets_shared_data(mock_mp, mock_benchmark, mock_monitor):
+    params = MockParams(processes=2, rounds=2)
+    extended_gcs_factory = mock.Mock(return_value="gcs_instance")
+    worker_target = mock.Mock()
+    args_builder = mock.Mock(return_value=("arg1",))
+
+    mock_ctx = mock.Mock()
+    mock_mp.get_context.return_value = mock_ctx
+    mock_process = mock.Mock()
+    mock_process.exitcode = 0
+    mock_process.exitcode = 0
+    mock_ctx.Process.return_value = mock_process
+
+    # Use a real list or dict to simulate the array so we can assert it was reset
+    shared_data = {}
+    class MockArray:
+        def __setitem__(self, idx, val):
+            shared_data[idx] = val
+        def __getitem__(self, idx):
+            if isinstance(idx, slice):
+                return [shared_data.get(0, 0.0), shared_data.get(1, 0.0)]
+            return shared_data[idx]
+
+    mock_array = MockArray()
+    mock_ctx.Array.return_value = mock_array
+
+    # Set some initial non-zero data
+    shared_data[0] = 10.0
+    shared_data[1] = 20.0
+
+    runner.run_multi_process(
+        mock_benchmark,
+        mock_monitor,
+        params,
+        extended_gcs_factory,
+        worker_target,
+        args_builder,
+        "listing",
+    )
+
+    # If it was reset to 0 at the start of each round, and the worker target is a mock
+    # that doesn't actually run (since we mocked Process), the final results appended
+    # will be 0.0, because the array was reset and never populated by the non-running mock process.
+    assert mock_benchmark.extra_info["runs"] == [0.0, 0.0]


### PR DESCRIPTION
Fixes a critical issue where multi-process benchmarks could silently pass and publish stale or partial results if worker processes crashed.

- Resets the shared data array before each round.
- Inspects process exit codes after joining; terminates remaining processes and raises an error on failure.
- Includes tests in `test_runner.py` for both the failure handling and array reset logic.
