### PR TITLE
Update Codecov config

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,12 +1,15 @@
 ignore:
   - "gcsfs/tests/**/*"
 
+codecov:
+  require_ci_to_pass: true
+
 coverage:
   status:
     project:
       default:
         target: auto
-        threshold: 0%  # Allow 0% drop.
+        threshold: 0.5%  # Allow up to 0.5% drop.
     patch:
       default:
         target: 80%


### PR DESCRIPTION
This commit updates `.github/.codecov.yml` to:
1. Add `require_ci_to_pass: true` so Codecov checks wait for CI to finish and pass.
2. Allow up to a `0.5%` code coverage drop by updating the threshold to `0.5%` instead of `0%` to avoid false positve.
