### PR TITLE
Fix order-independent assertion in test_read_block_zb

### DIFF
--- a/gcsfs/tests/test_extended_gcsfs.py
+++ b/gcsfs/tests/test_extended_gcsfs.py
@@ -1148,9 +1148,11 @@ def test_read_block_zb(extended_gcsfs, gcs_bucket_mocks, subtests):
                             assert (
                                 len(actual_ranges) == expected_chunks
                             ), f"Expected {expected_chunks} chunks (Request + Readahead), got {len(actual_ranges)}"
-                            assert actual_ranges[0][0] == offset
+                            actual_offsets = sorted(range_[0] for range_ in actual_ranges)
+                            expected_offsets = [offset]
                             if len(actual_ranges) == 2:
-                                assert actual_ranges[1][0] == offset + length
+                                expected_offsets.append(offset + length)
+                            assert actual_offsets == expected_offsets
                     else:
                         mocks["downloader"].download_ranges.assert_not_called()
 

--- a/gcsfs/tests/test_extended_gcsfs.py
+++ b/gcsfs/tests/test_extended_gcsfs.py
@@ -1148,7 +1148,9 @@ def test_read_block_zb(extended_gcsfs, gcs_bucket_mocks, subtests):
                             assert (
                                 len(actual_ranges) == expected_chunks
                             ), f"Expected {expected_chunks} chunks (Request + Readahead), got {len(actual_ranges)}"
-                            actual_offsets = sorted(range_[0] for range_ in actual_ranges)
+                            actual_offsets = sorted(
+                                range_[0] for range_ in actual_ranges
+                            )
                             expected_offsets = [offset]
                             if len(actual_ranges) == 2:
                                 expected_offsets.append(offset + length)


### PR DESCRIPTION
Fix a flaky test - This change updates `test_read_block_zb` to sort the actual block ranges before comparing them to `expected_offsets`. This guarantees the test assertion behaves deterministically and does not fail on valid re-ordering of offset returns.
