### PR TITLE
Run e2e-tests in parallel with ci block in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ jobs:
 
   e2e-tests:
     name: Wait for E2E Integration Tests (Cloud Build)
-    needs: ci
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Removes `needs: ci` from the `e2e-tests` block so it can run in parallel with the `ci` block in `.github/workflows/release.yml`. This decreases CI time for release builds as the build block already waits for both CI and e2e-tests to finish.
