### PR TITLE
chore(benchmarks): make create-vm wait for cleanup-leaked-resources

### DIFF
--- a/cloudbuild/benchmarks/benchmarks-cloudbuild.yaml
+++ b/cloudbuild/benchmarks/benchmarks-cloudbuild.yaml
@@ -171,7 +171,7 @@ steps:
             --labels="build-id=$$RUN_ID" \
             --quiet \
             "$${EXTRA_ARGS[@]}"
-    waitFor: ["init-variables"]
+    waitFor: ["cleanup-leaked-resources"]
     allowFailure: true
 
   # 5. Run benchmarks.


### PR DESCRIPTION
This PR updates the benchmarks Cloud Build pipeline to make sure that the `create-vm` step waits for the `cleanup-leaked-resources` step to complete first to make sure that we don't see failures  in microbenchmarks due to infra unavailability.
