### PR TITLE
Remove GCE_METADATA_MTLS_MODE export from e2e pipeline

### DIFF
--- a/cloudbuild/run_tests.sh
+++ b/cloudbuild/run_tests.sh
@@ -2,12 +2,6 @@
 set -e
 source env/bin/activate
 
-# Temporary workaround: Disable mTLS for GCE Metadata Server discovery to avoid
-# transport and SSL verification errors on mTLS-enabled VMs. This ensures
-# stability across all Google SDKs while library-level mTLS fixes are finalized.
-# This is added to support the versioned tests
-export GCE_METADATA_MTLS_MODE=none
-
 # Common Exports
 export STORAGE_EMULATOR_HOST=https://storage.googleapis.com
 export GCSFS_TEST_PROJECT=${PROJECT_ID}


### PR DESCRIPTION
This environment variable was added as a temporary workaround  in #785 due to GCE metadata discovery failure when mTLS is enabled but is no longer needed as the issue is fixed in https://github.com/googleapis/google-cloud-python/issues/16090