### PR TITLE
Implement zero-copy in write path of standard bucket

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1679,8 +1679,9 @@ class GCSFileSystem(DirCacheUpdater, asyn.AsyncFileSystem):
                 mode=mode,
             )
             try:
-                for offset in range(0, len(data), chunksize):
-                    bit = data[offset : offset + chunksize]
+                data_view = memoryview(data)
+                for offset in range(0, size, chunksize):
+                    bit = data_view[offset : offset + chunksize]
                     out = await upload_chunk(
                         self, location, bit, offset, size, content_type
                     )
@@ -2462,9 +2463,9 @@ class GCSFile(fsspec.spec.AbstractBufferedFile):
         """
         while True:
             # shortfall splits blocks bigger than max allowed upload
-            data = self.buffer.getvalue()
+            data_view = self.buffer.getbuffer()
             head = {}
-            l = len(data)
+            l = len(data_view)
 
             if (l < GCS_MIN_BLOCK_SIZE) and (not final or not self.autocommit):
                 # either flush() was called, but we don't have enough to
@@ -2483,7 +2484,7 @@ class GCSFile(fsspec.spec.AbstractBufferedFile):
                 # multiples of 256 KiB:
                 # https://cloud.google.com/storage/docs/performing-resumable-uploads#multiple-chunk-upload
                 chunk_length = (chunk_length // GCS_MIN_BLOCK_SIZE) * GCS_MIN_BLOCK_SIZE
-            chunk = data[:chunk_length]
+            chunk = data_view[:chunk_length]
             if finalizes_upload:
                 if l:
                     # last chunk
@@ -2495,7 +2496,7 @@ class GCSFile(fsspec.spec.AbstractBufferedFile):
                 else:
                     # closing when buffer is empty
                     head["Content-Range"] = "bytes */%i" % self.offset
-                    data = None
+                    chunk = None
             else:
                 head["Content-Range"] = "bytes %i-%i/*" % (
                     self.offset,
@@ -2511,13 +2512,13 @@ class GCSFile(fsspec.spec.AbstractBufferedFile):
                 end = int(headers["Range"].split("-")[1])
                 shortfall = (self.offset + l - 1) - end
                 if shortfall > 0:
-                    self.checker.update(data[:-shortfall])
-                    self.buffer = UnclosableBytesIO(data[-shortfall:])
+                    self.checker.update(data_view[:-shortfall])
+                    self.buffer = UnclosableBytesIO(data_view[-shortfall:])
                     self.buffer.seek(shortfall)
                     self.offset += l - shortfall
                     continue
                 else:
-                    self.checker.update(data)
+                    self.checker.update(data_view)
                 if final and contents:
                     j = json.loads(contents)
                     self.generation = j.get("generation")
@@ -2525,7 +2526,7 @@ class GCSFile(fsspec.spec.AbstractBufferedFile):
                 assert final, "Response looks like upload is over"
                 if l:
                     j = json.loads(contents)
-                    self.checker.update(data)
+                    self.checker.update(data_view)
                     self.checker.validate_json_response(j)
                     self.generation = j.get("generation")
             # Clear buffer and update offset when all is received
@@ -2673,9 +2674,14 @@ async def upload_chunk(fs, location, data, offset, size, content_type):
     range = "bytes %i-%i/%i" % (offset, offset + l - 1, size)
     head["Content-Range"] = range
     head.update({"Content-Type": content_type, "Content-Length": str(l)})
-    headers, txt = await fs._call(
-        "POST", location, headers=head, data=UnclosableBytesIO(data)
+    # aiohttp handles bytes and memoryview natively and zero-copy;
+    # no need to wrap in UnclosableBytesIO.
+    payload = (
+        data
+        if isinstance(data, (bytes, bytearray, memoryview))
+        else UnclosableBytesIO(data)
     )
+    headers, txt = await fs._call("POST", location, headers=head, data=payload)
     if "Range" in headers:
         end = int(headers["Range"].split("-")[1])
         shortfall = (offset + l - 1) - end
@@ -2794,12 +2800,19 @@ async def simple_upload(
     )
 
     data = template.encode() + datain + b"\n--==0==--"
+    # aiohttp handles bytes and memoryview natively and zero-copy;
+    # no need to wrap in UnclosableBytesIO.
+    payload = (
+        data
+        if isinstance(data, (bytes, bytearray, memoryview))
+        else UnclosableBytesIO(data)
+    )
     j = await fs._call(
         "POST",
         path,
         uploadType="multipart",
         headers={"Content-Type": 'multipart/related; boundary="==0=="'},
-        data=UnclosableBytesIO(data),
+        data=payload,
         json_out=True,
         **kw,
     )

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -1465,7 +1465,10 @@ async def test_upload_chunk_shortfall():
     args2, kwargs2 = call_args_list[1]
     assert kwargs2["headers"]["Content-Range"] == "bytes 5-9/10"
 
-    assert kwargs2["data"].getvalue() == b"56789"
+    sent_data = kwargs2["data"]
+    if hasattr(sent_data, "getvalue"):
+        sent_data = sent_data.getvalue()
+    assert sent_data == b"56789"
 
 
 @pytest.mark.parametrize("protocol", ["", "gs://", "gcs://"])


### PR DESCRIPTION
During chunked uploads of standard buckets, GCSFS previously performed multiple memory copies of the data:
1. `self.buffer.getvalue()` created a complete copy of the internal buffer's bytes in memory.
2. `data[:chunk_length]` created another copy (slice) of the chunk to be uploaded.
3. `UnclosableBytesIO(data)` in the module-level `upload_chunk` and `simple_upload` wrapped the chunk in a stream, creating yet another copy of the chunk data.

For large write blocks, these copies caused substantial CPU overhead and transient RAM spikes.

### The Solution
1. **Zero-Copy Buffer Access**: Replaced `self.buffer.getvalue()` with `self.buffer.getbuffer()` to retrieve a zero-copy `memoryview` of the write buffer.
2. **Zero-Copy Slicing**: Slices are now created directly on `memoryview` objects (in `_upload_chunk` and `_pipe_file`), which is a zero-copy operation in Python.
3. **Bypassing Stream Wrappers**: Since `aiohttp` natively supports `bytes` and `memoryview` payloads without requiring stream-seeking or closing, we bypass `UnclosableBytesIO` wrapping entirely for these types, allowing the network socket to stream directly from the original buffer.
4. **Robust Testing**: Updated `test_upload_chunk_shortfall` to correctly assert on raw `bytes` payloads in addition to wrapped streams.

### Performance Impact

Chunk Size | Baseline (Before) | Optimized (After) | Change |
| :--- | :---: | :---: | :---: |
| **16 MiB** | 83.56(MiB/s) | 84.09(MiB/s) | **+0.6%** |
| **32 MiB** | 86.40(MiB/s) | 92.80(MiB/s) | **+7.4%** |