### PR TITLE
fix: force schema recreation for staging external table in ingestion pipeline

### DIFF
--- a/cloudbuild/benchmarks/benchmarks-ingestion-cloudbuild.yaml
+++ b/cloudbuild/benchmarks/benchmarks-ingestion-cloudbuild.yaml
@@ -30,9 +30,11 @@ steps:
         # Inject the dynamically provided bucket name into the JSON schema
         sed -i "s/@INFRA_PREFIX@/${_INFRA_PREFIX}/g" cloudbuild/benchmarks/benchmarks_schema.json
 
+        # Drop the external table if it exists to force a clean recreation and schema update
+        bq rm --project_id=${PROJECT_ID} -f ${_DATASET_NAME}.staging
+
         bq mk --project_id=${PROJECT_ID} \
           --external_table_definition=cloudbuild/benchmarks/benchmarks_schema.json \
-          --force \
           ${_DATASET_NAME}.staging
 
   # Step 2: Perform Token Replacement and run ingestion script

--- a/cloudbuild/benchmarks/benchmarks-ingestion-cloudbuild.yaml
+++ b/cloudbuild/benchmarks/benchmarks-ingestion-cloudbuild.yaml
@@ -31,9 +31,9 @@ steps:
         sed -i "s/@INFRA_PREFIX@/${_INFRA_PREFIX}/g" cloudbuild/benchmarks/benchmarks_schema.json
 
         # Drop the external table if it exists to force a clean recreation and schema update
-        bq rm --project_id=${PROJECT_ID} -f ${_DATASET_NAME}.staging
+        bq --project_id=${PROJECT_ID} rm -f ${_DATASET_NAME}.staging
 
-        bq mk --project_id=${PROJECT_ID} \
+        bq --project_id=${PROJECT_ID} mk \
           --external_table_definition=cloudbuild/benchmarks/benchmarks_schema.json \
           ${_DATASET_NAME}.staging
 


### PR DESCRIPTION
Fixes a schema mismatch error in the micro-benchmarks ingestion pipeline (`run-ingestion` step).

### Cause
In a recent change, new columns (`min_chunk_size`, `max_chunk_size`, `seq_probability`) were added to `benchmarks_schema.json`. However, the pipeline used `bq mk --force` to update the staging external table. In BigQuery, `bq mk --force` on an existing external table silently skips updating its schema metadata, keeping the table on a stale schema. When the ingestion query ran, BigQuery failed because it encountered these new columns in the GCS data files but could not map them to the stale schema.

### Solution
Updated `cloudbuild/benchmarks/benchmarks-ingestion-cloudbuild.yaml` to explicitly drop the external table (`bq rm -f`) before running `bq mk`. This forces BigQuery to cleanly recreate the table and apply the latest schema definition, enabling the ingestion query to run successfully and dynamically update the history table.
