### PR TITLE
feat(macrobench): add GKE orchestration infrastructure and Cloud Build pipeline

### DIFF
--- a/cloudbuild/macrobenchmarks/macrobenchmarks-cloudbuild.yaml
+++ b/cloudbuild/macrobenchmarks/macrobenchmarks-cloudbuild.yaml
@@ -1,0 +1,159 @@
+substitutions:
+  _INFRA_PREFIX: ""
+  _ZONE: ""
+  _GKE_SERVICE_ACCOUNT: ""
+  _WORKLOAD: "hf-pytorch-lightning-cpu"
+  _BUCKET_TYPE: "regional"
+  _NODES: "2"
+  _STEPS: "100"
+  _CHECKPOINT_INTERVAL: "25"
+  _DATASET_PATH: ""
+  _MODEL_ID: "gs://huggingface-model-weights/Llama-3.1-8B"
+  _HF_TOKEN: ""
+  # Optional gs:// checkpoint to resume from, exercising the restore IO path.
+  # Empty (default) = fresh run, no restore. Must point at a checkpoint that
+  # outlives the run (e.g. a seeded bucket), not the per-run ephemeral one.
+  _CHECKPOINT_LOAD_PATH: ""
+  _GCSFS_SOURCE: ""
+  _JOBSET_VERSION: "v0.12.0"
+  _SKIP_CLEANUP: "false"
+
+# Each step's logic lives in scripts/<step>.sh; the step bodies below are just
+# the env wiring (Cloud Build substitutions reach the scripts as environment
+# variables) plus dependency ordering. See scripts/lib.sh.
+steps:
+  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
+    id: "init-variables"
+    entrypoint: "bash"
+    env:
+      - "PROJECT_ID=${PROJECT_ID}"
+      - "BUILD_ID=${BUILD_ID}"
+      - "BRANCH_NAME=${BRANCH_NAME}"
+      - "_INFRA_PREFIX=${_INFRA_PREFIX}"
+      - "_ZONE=${_ZONE}"
+      - "_GKE_SERVICE_ACCOUNT=${_GKE_SERVICE_ACCOUNT}"
+      - "_DATASET_PATH=${_DATASET_PATH}"
+      - "_GCSFS_SOURCE=${_GCSFS_SOURCE}"
+      - "_BUCKET_TYPE=${_BUCKET_TYPE}"
+      - "_NODES=${_NODES}"
+      - "_STEPS=${_STEPS}"
+      - "_CHECKPOINT_INTERVAL=${_CHECKPOINT_INTERVAL}"
+      - "_CHECKPOINT_LOAD_PATH=${_CHECKPOINT_LOAD_PATH}"
+      - "_MODEL_ID=${_MODEL_ID}"
+    args: ["cloudbuild/macrobenchmarks/scripts/init_variables.sh"]
+    waitFor: ["-"]
+
+  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
+    id: "cleanup-leaked-resources"
+    entrypoint: "bash"
+    allowFailure: true
+    env:
+      - "PROJECT_ID=${PROJECT_ID}"
+      - "_INFRA_PREFIX=${_INFRA_PREFIX}"
+    args: ["cloudbuild/macrobenchmarks/scripts/cleanup_leaked_resources.sh"]
+    waitFor: ["init-variables"]
+
+  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
+    id: "create-buckets"
+    entrypoint: "bash"
+    allowFailure: true
+    env:
+      - "PROJECT_ID=${PROJECT_ID}"
+      - "LOCATION=${LOCATION}"
+      - "_BUCKET_TYPE=${_BUCKET_TYPE}"
+      - "_ZONE=${_ZONE}"
+    args: ["cloudbuild/macrobenchmarks/scripts/create_buckets.sh"]
+    waitFor: ["init-variables"]
+
+  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
+    id: "create-cluster"
+    entrypoint: "bash"
+    allowFailure: true
+    env:
+      - "PROJECT_ID=${PROJECT_ID}"
+      - "_ZONE=${_ZONE}"
+      - "_GKE_SERVICE_ACCOUNT=${_GKE_SERVICE_ACCOUNT}"
+      - "_NODES=${_NODES}"
+      - "_JOBSET_VERSION=${_JOBSET_VERSION}"
+    args: ["cloudbuild/macrobenchmarks/scripts/create_cluster.sh"]
+    waitFor: ["create-buckets"]
+
+  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
+    id: "run-workload"
+    entrypoint: "bash"
+    allowFailure: true
+    env:
+      - "PROJECT_ID=${PROJECT_ID}"
+      - "_ZONE=${_ZONE}"
+      - "_WORKLOAD=${_WORKLOAD}"
+      - "_DATASET_PATH=${_DATASET_PATH}"
+      - "_CHECKPOINT_LOAD_PATH=${_CHECKPOINT_LOAD_PATH}"
+      - "_MODEL_ID=${_MODEL_ID}"
+      - "_HF_TOKEN=${_HF_TOKEN}"
+      - "_STEPS=${_STEPS}"
+      - "_CHECKPOINT_INTERVAL=${_CHECKPOINT_INTERVAL}"
+      - "_NODES=${_NODES}"
+      - "_GCSFS_SOURCE=${_GCSFS_SOURCE}"
+    args: ["cloudbuild/macrobenchmarks/scripts/run_workload.sh"]
+    waitFor: ["create-cluster"]
+
+  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
+    id: "scrape-metrics"
+    entrypoint: "bash"
+    allowFailure: true
+    env:
+      - "PROJECT_ID=${PROJECT_ID}"
+      - "_STEPS=${_STEPS}"
+      - "_CHECKPOINT_INTERVAL=${_CHECKPOINT_INTERVAL}"
+      - "_CHECKPOINT_LOAD_PATH=${_CHECKPOINT_LOAD_PATH}"
+      - "_WORKLOAD=${_WORKLOAD}"
+      - "_GCSFS_SOURCE=${_GCSFS_SOURCE}"
+      - "_BUCKET_TYPE=${_BUCKET_TYPE}"
+      - "_ZONE=${_ZONE}"
+      - "_NODES=${_NODES}"
+      - "_DATASET_PATH=${_DATASET_PATH}"
+      - "_MODEL_ID=${_MODEL_ID}"
+    args: ["cloudbuild/macrobenchmarks/scripts/scrape_metrics.sh"]
+    waitFor: ["run-workload"]
+
+  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
+    id: "cleanup-helm"
+    entrypoint: "bash"
+    env:
+      - "PROJECT_ID=${PROJECT_ID}"
+      - "_ZONE=${_ZONE}"
+      - "_SKIP_CLEANUP=${_SKIP_CLEANUP}"
+    args: ["cloudbuild/macrobenchmarks/scripts/cleanup_helm.sh"]
+    waitFor: ["scrape-metrics"]
+
+  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
+    id: "cleanup-cluster"
+    entrypoint: "bash"
+    env:
+      - "PROJECT_ID=${PROJECT_ID}"
+      - "_ZONE=${_ZONE}"
+      - "_SKIP_CLEANUP=${_SKIP_CLEANUP}"
+    args: ["cloudbuild/macrobenchmarks/scripts/cleanup_cluster.sh"]
+    waitFor: ["cleanup-helm"]
+
+  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
+    id: "delete-buckets"
+    entrypoint: "bash"
+    env:
+      - "PROJECT_ID=${PROJECT_ID}"
+      - "_SKIP_CLEANUP=${_SKIP_CLEANUP}"
+    args: ["cloudbuild/macrobenchmarks/scripts/delete_buckets.sh"]
+    waitFor: ["scrape-metrics"]
+
+  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
+    id: "check-failure"
+    entrypoint: "bash"
+    args: ["cloudbuild/macrobenchmarks/scripts/check_failure.sh"]
+    waitFor: ["cleanup-cluster", "delete-buckets"]
+
+timeout: "21600s"
+
+options:
+  logging: CLOUD_LOGGING_ONLY
+  pool:
+    name: "projects/${PROJECT_ID}/locations/${LOCATION}/workerPools/cloud-build-worker-pool"

--- a/cloudbuild/macrobenchmarks/scripts/check_failure.sh
+++ b/cloudbuild/macrobenchmarks/scripts/check_failure.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# check-failure: fail the build if any allowFailure step recorded a failure,
+# listing the culprits.
+source "$(dirname "$0")/lib.sh"
+if [[ -f "${FAILED_FILE}" ]]; then
+  echo "Build failed. Steps that reported failures:"
+  sort -u "${FAILED_FILE}" | sed 's/^/ - /'
+  exit 1
+fi
+echo "Build successful."

--- a/cloudbuild/macrobenchmarks/scripts/cleanup_cluster.sh
+++ b/cloudbuild/macrobenchmarks/scripts/cleanup_cluster.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# cleanup-cluster: tear down the ephemeral GKE cluster (best-effort).
+if [[ "${_SKIP_CLEANUP}" == "true" ]]; then
+  echo "Skipping cleanup-cluster as requested."
+  exit 0
+fi
+source "$(dirname "$0")/lib.sh"
+source "${BUILD_VARS_FILE}"
+gcloud container clusters delete "$CLUSTER_NAME" --zone="${_ZONE}" --project="${PROJECT_ID}" --quiet || true

--- a/cloudbuild/macrobenchmarks/scripts/cleanup_helm.sh
+++ b/cloudbuild/macrobenchmarks/scripts/cleanup_helm.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# cleanup-helm: uninstall the workload release (best-effort).
+if [[ "${_SKIP_CLEANUP}" == "true" ]]; then
+  echo "Skipping cleanup-helm as requested."
+  exit 0
+fi
+source "$(dirname "$0")/lib.sh"
+source "${BUILD_VARS_FILE}"
+curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash || true
+gcloud container clusters get-credentials "$CLUSTER_NAME" --zone="${_ZONE}" --project="${PROJECT_ID}" || true
+helm uninstall "$RUN_ID" || true

--- a/cloudbuild/macrobenchmarks/scripts/cleanup_leaked_resources.sh
+++ b/cloudbuild/macrobenchmarks/scripts/cleanup_leaked_resources.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# cleanup-leaked-resources: reap clusters and checkpoint buckets left behind by
+# builds that have already ended, without touching resources that might belong
+# to a build still in flight.
+
+CURRENT_TIME=$(date +%s)
+# Must be >= the build `timeout` (21600s). A concurrently-running build's
+# cluster/bucket is always younger than that build's own elapsed time (and thus
+# younger than the timeout), so it is never reaped mid-run; only resources from
+# a build that has already ended age past this.
+THRESHOLD=21600
+CLUSTERS=$(gcloud container clusters list --project="${PROJECT_ID}" --filter="name~'${_INFRA_PREFIX}-gke-'" --format="value(name,location,createTime)")
+while read -r name location create_time; do
+  if [ -z "$name" ]; then continue; fi
+  # Skip rather than mis-compute if the create time is empty/unparseable (e.g. a
+  # gcloud field-name change): a bad date would otherwise make AGE garbage.
+  CREATED=$(date -d "$create_time" +%s 2>/dev/null) || continue
+  AGE=$((CURRENT_TIME - CREATED))
+  if [ "$AGE" -gt "$THRESHOLD" ]; then
+    echo "Deleting leaked cluster $name"
+    gcloud container clusters delete "$name" --location="$location" --project="${PROJECT_ID}" --quiet || true
+  fi
+done <<< "$CLUSTERS"
+
+# Clean up leaked checkpoint buckets. Scope the listing to this prefix's
+# ephemeral checkpoint buckets so the shared results bucket is never a
+# candidate; the in-loop anchored match is kept as a second guard.
+BUCKETS=$(gcloud storage buckets list --project="${PROJECT_ID}" --filter="name~'${_INFRA_PREFIX}-macrobench-checkpoint-'" --format="value(name,creation_time)")
+while read -r name creation_time; do
+  if [ -z "$name" ]; then continue; fi
+  if [[ "$name" =~ ^${_INFRA_PREFIX}-macrobench-checkpoint- ]]; then
+    CREATED=$(date -d "$creation_time" +%s 2>/dev/null) || continue
+    AGE=$((CURRENT_TIME - CREATED))
+    if [ "$AGE" -gt "$THRESHOLD" ]; then
+      echo "Deleting leaked bucket gs://$name"
+      gcloud storage rm --recursive "gs://$name" || true
+    fi
+  fi
+done <<< "$BUCKETS"

--- a/cloudbuild/macrobenchmarks/scripts/create_buckets.sh
+++ b/cloudbuild/macrobenchmarks/scripts/create_buckets.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# create-buckets: create the per-run checkpoint bucket (co-located with the
+# cluster's region) and ensure the shared results bucket exists in the
+# worker-pool LOCATION so BigQuery ingestion can read it.
+set -e
+source "$(dirname "$0")/lib.sh"
+trap 'record_failure create-buckets' ERR
+skip_if_failed
+source "${BUILD_VARS_FILE}"
+if [[ "${_BUCKET_TYPE}" == "regional" ]]; then
+  gcloud storage buckets create gs://$CHECKPOINT_BUCKET --project=${PROJECT_ID} --location=$REGION
+elif [[ "${_BUCKET_TYPE}" == "zonal" ]]; then
+  gcloud storage buckets create gs://$CHECKPOINT_BUCKET --project=${PROJECT_ID} --location=$REGION --placement=${_ZONE} --default-storage-class=RAPID --enable-hierarchical-namespace --uniform-bucket-level-access
+elif [[ "${_BUCKET_TYPE}" == "hns" ]]; then
+  gcloud storage buckets create gs://$CHECKPOINT_BUCKET --project=${PROJECT_ID} --location=$REGION --enable-hierarchical-namespace --uniform-bucket-level-access
+fi
+if gcloud storage buckets describe gs://$RESULTS_BUCKET --project=${PROJECT_ID} >/dev/null 2>&1; then
+  # Reuse only if co-located with this build's LOCATION. The ingestion pipeline
+  # builds the BigQuery dataset (and external table) in LOCATION; a results
+  # bucket in another region cannot be read by that dataset, so rows would
+  # silently stop landing. Fail fast.
+  EXISTING_LOC=$(gcloud storage buckets describe gs://$RESULTS_BUCKET --project=${PROJECT_ID} --format="value(location)" | tr 'A-Z' 'a-z')
+  WANT_LOC=$(echo "${LOCATION}" | tr 'A-Z' 'a-z')
+  if [ "$EXISTING_LOC" != "$WANT_LOC" ]; then
+    record_failure create-buckets
+    echo "ERROR: results bucket gs://$RESULTS_BUCKET is in '$EXISTING_LOC' but this build's LOCATION is '$WANT_LOC'; ingestion (dataset in ${LOCATION}) cannot read it. Run from a ${LOCATION} worker pool or use a different _INFRA_PREFIX."
+    exit 1
+  fi
+else
+  gcloud storage buckets create gs://$RESULTS_BUCKET --project=${PROJECT_ID} --location=${LOCATION} --enable-hierarchical-namespace --uniform-bucket-level-access
+fi

--- a/cloudbuild/macrobenchmarks/scripts/create_cluster.sh
+++ b/cloudbuild/macrobenchmarks/scripts/create_cluster.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# create-cluster: create the GKE cluster with a small system pool plus a
+# dedicated c4-standard-192 pool (whose name the workload's nodeSelector keys
+# off), then install the JobSet controller.
+set -e
+source "$(dirname "$0")/lib.sh"
+trap 'record_failure create-cluster' ERR
+skip_if_failed
+source "${BUILD_VARS_FILE}"
+# `gcloud container clusters create` has no --node-pool flag and always names
+# its initial pool "default-pool", which would not match the workload's
+# nodeSelector (cloud.google.com/gke-nodepool=c4-standard-192). Create a small
+# system pool for the cluster, then a dedicated c4-standard-192 pool whose name
+# the GKE node label (and the chart's nodeSelector) keys off of. --enable-gvnic
+# puts the nodes on gVNIC, which C4 requires and which TIER_1 egress (the direct
+# high-bandwidth path) is gated on.
+gcloud container clusters create "$CLUSTER_NAME" \
+  --project="${PROJECT_ID}" --zone="${_ZONE}" \
+  --machine-type="e2-standard-4" --num-nodes="1" \
+  --service-account="${_GKE_SERVICE_ACCOUNT}" \
+  --scopes="https://www.googleapis.com/auth/cloud-platform" \
+  --private-ipv6-google-access-type=outbound-only \
+  --no-enable-autoupgrade --quiet
+gcloud container node-pools create "c4-standard-192" \
+  --cluster="$CLUSTER_NAME" --project="${PROJECT_ID}" --zone="${_ZONE}" \
+  --machine-type="c4-standard-192" --num-nodes="${_NODES}" \
+  --disk-size="200" \
+  --disk-type="hyperdisk-balanced" \
+  --enable-gvnic \
+  --network-performance-configs="total-egress-bandwidth-tier=TIER_1" \
+  --service-account="${_GKE_SERVICE_ACCOUNT}" \
+  --scopes="https://www.googleapis.com/auth/cloud-platform" \
+  --no-enable-autoupgrade --quiet
+gcloud container clusters get-credentials "$CLUSTER_NAME" --zone="${_ZONE}" --project="${PROJECT_ID}"
+kubectl apply --server-side -f "https://github.com/kubernetes-sigs/jobset/releases/download/${_JOBSET_VERSION}/manifests.yaml"
+kubectl rollout status deployment/jobset-controller-manager -n jobset-system --timeout=300s

--- a/cloudbuild/macrobenchmarks/scripts/delete_buckets.sh
+++ b/cloudbuild/macrobenchmarks/scripts/delete_buckets.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# delete-buckets: delete the per-run checkpoint bucket (best-effort). The shared
+# results bucket is intentionally left in place.
+if [[ "${_SKIP_CLEANUP}" == "true" ]]; then
+  echo "Skipping delete-buckets as requested."
+  exit 0
+fi
+source "$(dirname "$0")/lib.sh"
+source "${BUILD_VARS_FILE}"
+gcloud storage rm --recursive --project="${PROJECT_ID}" gs://$CHECKPOINT_BUCKET || true

--- a/cloudbuild/macrobenchmarks/scripts/init_variables.sh
+++ b/cloudbuild/macrobenchmarks/scripts/init_variables.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# init-variables: validate the substitutions and operator-supplied buckets,
+# derive the region and run identifiers, and write them to
+# /workspace/build_vars.env for later steps. Everything here fails fast, before
+# any GKE cluster or bucket is provisioned (and billed).
+source "$(dirname "$0")/lib.sh"
+
+SHORT_BUILD_ID=${BUILD_ID:0:8}
+SAFE_BRANCH=$(echo -n "${BRANCH_NAME:-unknown}" | tr -c 'a-zA-Z0-9_.-' '-')
+if [ "${SAFE_BRANCH}" = "unknown" ]; then
+  echo "ERROR: BRANCH_NAME unset."; exit 1
+fi
+if [ -z "${_INFRA_PREFIX}" ] || [ -z "${_ZONE}" ] || [ -z "${_GKE_SERVICE_ACCOUNT}" ] || [ -z "${_DATASET_PATH}" ] || [ -z "${_GCSFS_SOURCE}" ]; then
+  echo "ERROR: required substitution missing (_INFRA_PREFIX,_ZONE,_GKE_SERVICE_ACCOUNT,_DATASET_PATH,_GCSFS_SOURCE)."; exit 1
+fi
+# Validate config before provisioning anything: an unsupported _BUCKET_TYPE
+# silently skips checkpoint-bucket creation, and a non-positive _CHECKPOINT_INTERVAL
+# divides-by-zero in scrape-metrics. Fail fast here so misconfig never reaches
+# (and bills) GKE.
+case "${_BUCKET_TYPE}" in
+  regional|zonal|hns) ;;
+  *) echo "ERROR: _BUCKET_TYPE must be regional|zonal|hns (got '${_BUCKET_TYPE}')."; exit 1 ;;
+esac
+# Reject malformed zones before anything keys off them.
+if ! echo "${_ZONE}" | grep -Eq '^[a-z]+-[a-z]+[0-9]-[a-z]$'; then
+  echo "ERROR: _ZONE must be a GCP zone like us-central1-a (got '${_ZONE}')."; exit 1
+fi
+# Derive the region from the zone so buckets and cluster co-locate; do NOT use
+# the worker-pool LOCATION, which may differ from _ZONE.
+ZONE="${_ZONE}"
+REGION="${ZONE%-*}"
+for pair in "_NODES=${_NODES}" "_STEPS=${_STEPS}" "_CHECKPOINT_INTERVAL=${_CHECKPOINT_INTERVAL}"; do
+  key=${pair%%=*}; val=${pair#*=}
+  if ! echo "$val" | grep -Eq '^[1-9][0-9]*$'; then
+    echo "ERROR: $key must be a positive integer (got '$val')."; exit 1
+  fi
+done
+# Validate that operator-supplied buckets actually match _BUCKET_TYPE and the
+# run's region/zone. Project-owned buckets are describable by the build SA
+# (storage admin), so these are hard fail-fast (nothing is provisioned yet).
+# Field-name-robust: one JSON describe, then grep the JSON for RAPID / the zone
+# and read location + HNS explicitly.
+validate_bucket() {
+  BPATH="$1"; KIND="$2"
+  BUCKET=$(echo "$BPATH" | sed -E 's#^gs://([^/]+).*#\1#')
+  JSON=$(gcloud storage buckets describe "gs://$BUCKET" --project=${PROJECT_ID} --format=json 2>/dev/null) || {
+    echo "ERROR: cannot describe $KIND bucket gs://$BUCKET (missing or no read access)."; exit 1; }
+  LOC=$(echo "$JSON" | python3 -c "import sys,json;print((json.load(sys.stdin).get('location') or '').lower())")
+  case "$LOC" in
+    $REGION|$REGION-*) : ;;
+    *) echo "ERROR: $KIND bucket gs://$BUCKET is in '$LOC', not region '$REGION'."; exit 1 ;;
+  esac
+  IS_RAPID=no; echo "$JSON" | grep -qiF 'RAPID' && IS_RAPID=yes
+  # gcloud's JSON key for HNS has varied across CLI versions
+  # (hierarchicalNamespace vs hierarchical_namespace); accept either so a real
+  # HNS bucket is never silently read as non-HNS (which would reject hns runs
+  # and, worse, bypass the regional-run "no HNS" guard).
+  HNS=$(echo "$JSON" | python3 -c "import sys,json;d=json.load(sys.stdin);print(bool((d.get('hierarchicalNamespace') or d.get('hierarchical_namespace') or {}).get('enabled')))")
+  case "${_BUCKET_TYPE}" in
+    regional)
+      if [ "$IS_RAPID" = yes ]; then echo "ERROR: regional run but $KIND bucket gs://$BUCKET is RAPID/zonal."; exit 1; fi
+      if [ "$HNS" = "True" ]; then echo "ERROR: regional run but $KIND bucket gs://$BUCKET has HNS enabled."; exit 1; fi ;;
+    zonal)
+      if [ "$IS_RAPID" != yes ]; then echo "ERROR: zonal run requires a RAPID $KIND bucket (gs://$BUCKET)."; exit 1; fi
+      if ! echo "$JSON" | grep -qiF "${_ZONE}"; then echo "ERROR: zonal $KIND bucket gs://$BUCKET is not placed in zone ${_ZONE}."; exit 1; fi ;;
+    hns)
+      if [ "$IS_RAPID" = yes ]; then echo "ERROR: hns run but $KIND bucket gs://$BUCKET is RAPID/zonal."; exit 1; fi
+      if [ "$HNS" != "True" ]; then echo "ERROR: hns run requires an HNS-enabled $KIND bucket (gs://$BUCKET)."; exit 1; fi ;;
+  esac
+  echo "OK: $KIND bucket gs://$BUCKET matches ${_BUCKET_TYPE} in $LOC."
+}
+validate_bucket "${_DATASET_PATH}" dataset
+if [ -n "${_CHECKPOINT_LOAD_PATH}" ]; then validate_bucket "${_CHECKPOINT_LOAD_PATH}" checkpoint-load; fi
+
+# Model-weights bucket is external (read by the node SA, not the build SA), so a
+# build-step describe would false-negative: warn, never exit.
+case "${_MODEL_ID}" in
+  gs://*)
+    MODEL_BUCKET=$(echo "${_MODEL_ID}" | sed -E 's#^gs://([^/]+).*#\1#')
+    gcloud storage buckets describe "gs://$MODEL_BUCKET" --project=${PROJECT_ID} >/dev/null 2>&1 || \
+      echo "WARNING: build SA cannot read model bucket gs://$MODEL_BUCKET; ensure the node SA (${_GKE_SERVICE_ACCOUNT}) has read access." ;;
+esac
+# Machine-type availability is best-effort (container.admin lacks
+# compute.machineTypes.get); the node-pool create fails fast if wrong.
+gcloud compute machine-types describe c4-standard-192 --zone=${_ZONE} --project=${PROJECT_ID} >/dev/null 2>&1 || \
+  echo "WARNING: could not verify c4-standard-192 in ${_ZONE} (may be a permissions gap, not a real problem)."
+echo "export BRANCH_NAME=${SAFE_BRANCH}" >> "${BUILD_VARS_FILE}"
+# Prepend 'buildid-' to ensure RUN_ID starts with a letter, satisfying GKE/K8s
+# DNS-1035 naming restrictions (since Cloud Build UUIDs can start with numbers).
+echo "export RUN_ID=buildid-${BUILD_ID}" >> "${BUILD_VARS_FILE}"
+echo "export CLUSTER_NAME=${_INFRA_PREFIX}-gke-${SHORT_BUILD_ID}" >> "${BUILD_VARS_FILE}"
+echo "export CHECKPOINT_BUCKET=${_INFRA_PREFIX}-macrobench-checkpoint-${SHORT_BUILD_ID}" >> "${BUILD_VARS_FILE}"
+echo "export RESULTS_BUCKET=${_INFRA_PREFIX}-macrobench-results" >> "${BUILD_VARS_FILE}"
+echo "export REGION=${REGION}" >> "${BUILD_VARS_FILE}"

--- a/cloudbuild/macrobenchmarks/scripts/lib.sh
+++ b/cloudbuild/macrobenchmarks/scripts/lib.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Shared helpers for the macrobenchmarks run-pipeline step scripts.
+#
+# Each step of ../macrobenchmarks-cloudbuild.yaml invokes one script in this
+# directory. Cloud Build substitutions reach the scripts as environment
+# variables (wired through each step's `env:` block) because Cloud Build does
+# not substitute ${...} inside a file read from disk -- so the scripts read
+# e.g. ${_ZONE} and ${PROJECT_ID} as ordinary env vars.
+
+# Cross-step state files live on the /workspace volume that Cloud Build shares
+# between steps. The defaults are overridable so the scripts can be exercised
+# outside Cloud Build (e.g. unit tests) without writing to /workspace.
+FAILED_FILE="${FAILED_FILE:-/workspace/FAILED}"
+BUILD_VARS_FILE="${BUILD_VARS_FILE:-/workspace/build_vars.env}"
+
+# Record a step id in the failure ledger. The allowFailure provisioning steps
+# append here on error so the final check-failure step can fail the build with
+# the list of culprits.
+record_failure() {
+  echo "$1" >> "${FAILED_FILE}"
+}
+
+# Short-circuit the rest of a step when an earlier step already failed. Cloud
+# Build keeps running later steps after an allowFailure step fails; this turns
+# them into no-ops instead of compounding the failure.
+skip_if_failed() {
+  if [[ -f "${FAILED_FILE}" ]]; then
+    echo "Skipping: previous step failed"
+    exit 0
+  fi
+}

--- a/cloudbuild/macrobenchmarks/scripts/run_workload.sh
+++ b/cloudbuild/macrobenchmarks/scripts/run_workload.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# run-workload: helm install the workload chart, then poll the JobSet until it
+# completes (recording start/end timestamps for the metric scrape) or fails /
+# times out.
+set -e
+source "$(dirname "$0")/lib.sh"
+trap 'record_failure run-workload' ERR
+skip_if_failed
+source "${BUILD_VARS_FILE}"
+curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+gcloud container clusters get-credentials "$CLUSTER_NAME" --zone="${_ZONE}" --project="${PROJECT_ID}"
+CHART="gcsfs/tests/perf/macrobenchmarks/workloads/${_WORKLOAD}/helm_chart"
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > /workspace/start_time.txt
+helm install "$RUN_ID" "$CHART" -f "$CHART/values_base.yaml" \
+  --set gcsfs.datasetPath="${_DATASET_PATH}" \
+  --set gcsfs.ckptWritePath="gs://$CHECKPOINT_BUCKET/checkpoints" \
+  --set-string gcsfs.ckptLoadPath="${_CHECKPOINT_LOAD_PATH}" \
+  --set workload.modelId="${_MODEL_ID}" \
+  --set workload.hfToken="${_HF_TOKEN}" \
+  --set workload.steps="${_STEPS}" \
+  --set workload.ckptWriterInterval="${_CHECKPOINT_INTERVAL}" \
+  --set workload.nodes="${_NODES}" \
+  --set workload.requirements="${_GCSFS_SOURCE}" \
+  --set serviceAccount=default
+echo "Waiting for JobSet $RUN_ID to complete..."
+WORKLOAD_COMPLETED=false
+for i in $(seq 1 240); do
+  COMPLETE=$(kubectl get jobset "$RUN_ID" -o jsonpath='{.status.conditions[?(@.type=="Completed")].status}' 2>/dev/null || echo "")
+  FAILED=$(kubectl get jobset "$RUN_ID" -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null || echo "")
+  if [ "$COMPLETE" = "True" ]; then WORKLOAD_COMPLETED=true; echo "JobSet completed."; break; fi
+  if [ "$FAILED" = "True" ]; then
+    echo "JobSet failed."
+    kubectl describe jobset "$RUN_ID" || true
+    kubectl get pods -l jobset.sigs.k8s.io/jobset-name="$RUN_ID" -o wide || true
+    record_failure run-workload
+    exit 1
+  fi
+  sleep 30
+done
+if [ "$WORKLOAD_COMPLETED" != "true" ]; then
+  echo "Timed out waiting for JobSet $RUN_ID to complete."
+  kubectl describe jobset "$RUN_ID" || true
+  kubectl get pods -l jobset.sigs.k8s.io/jobset-name="$RUN_ID" -o wide || true
+  record_failure run-workload
+  exit 1
+fi
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > /workspace/end_time.txt

--- a/cloudbuild/macrobenchmarks/scripts/scrape_metrics.sh
+++ b/cloudbuild/macrobenchmarks/scripts/scrape_metrics.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# scrape-metrics: scrape Cloud Logging into raw CSVs and aggregate them into one
+# summary row, retrying for Cloud Logging ingestion lag, then upload the summary
+# to the results bucket. calculate exits non-zero until the required metrics are
+# complete, gating the upload.
+set -e
+source "$(dirname "$0")/lib.sh"
+trap 'record_failure scrape-metrics' ERR
+skip_if_failed
+source "${BUILD_VARS_FILE}"
+pip3 install --break-system-packages --quiet -r cloudbuild/macrobenchmarks/metrics/requirements.txt
+START_TIME=$(cat /workspace/start_time.txt)
+END_TIME=$(cat /workspace/end_time.txt)
+RAW_DIR=/workspace/raw_metrics
+cd cloudbuild/macrobenchmarks
+DATE_DIR=$(date +%Y%m%d)
+TS_DIR=$(date +%Y%m%d-%H%M%S)
+SUMMARY=/workspace/${TS_DIR}.csv
+MIN_WRITE_DATAPOINTS=$((${_STEPS} / ${_CHECKPOINT_INTERVAL}))
+if [ "$MIN_WRITE_DATAPOINTS" -lt 1 ]; then
+  MIN_WRITE_DATAPOINTS=1
+fi
+MIN_RESTORE_DATAPOINTS=0
+RESUME_ARGS=()
+if [ -n "${_CHECKPOINT_LOAD_PATH}" ]; then
+  MIN_RESTORE_DATAPOINTS=1
+  RESUME_ARGS=(--resume-run)
+fi
+# Cloud Logging ingestion lags pod termination by seconds-to-minutes, and the
+# last logs emitted (the final checkpoint write and the profiler summary that
+# carries the data-loading metric) are the most likely to still be in flight
+# when the JobSet reports Completed. Settle once, then re-scrape at a fixed 60s
+# interval until the required metrics validate (or attempts are exhausted).
+# calculate
+# exits non-zero when metrics are incomplete; running it as an `if` condition
+# keeps `set -e`/the ERR trap from aborting the step on a not-yet-complete
+# attempt.
+sleep 60
+SCRAPE_OK=false
+for attempt in $(seq 1 5); do
+  echo "Scrape attempt $attempt of 5..."
+  rm -rf "$RAW_DIR"
+  # The parser hits the Cloud Logging API; a transient API error should fall
+  # through to the backoff like the ingestion-lag case, not abort the step via
+  # set -e / the ERR trap. Guard it in a condition so a failure retries.
+  if ! python3 -m metrics.parsers.hf \
+      --run-id "$RUN_ID" --project "${PROJECT_ID}" \
+      --start-time "$START_TIME" --end-time "$END_TIME" \
+      --checkpoint-location "gs://$CHECKPOINT_BUCKET/checkpoints" \
+      --out-dir "$RAW_DIR"; then
+    echo "Scrape failed (transient?); waiting before retry..."
+    sleep 60
+    continue
+  fi
+  if python3 -m metrics.calculate \
+      --run-id "$RUN_ID" --workload-name "${_WORKLOAD}" \
+      --gcsfs-source "${_GCSFS_SOURCE}" --in-dir "$RAW_DIR" --out-file "$SUMMARY" \
+      --expected-steps "${_STEPS}" \
+      --min-write-datapoints "$MIN_WRITE_DATAPOINTS" \
+      --min-restore-datapoints "$MIN_RESTORE_DATAPOINTS" \
+      "${RESUME_ARGS[@]}" \
+      --require-data-loading-metrics \
+      --bucket-type "${_BUCKET_TYPE}" --zone "${_ZONE}" --region "$REGION" \
+      --nodes "${_NODES}" --steps "${_STEPS}" --checkpoint-interval "${_CHECKPOINT_INTERVAL}" \
+      --dataset-path "${_DATASET_PATH}" --model-id "${_MODEL_ID}"; then
+    SCRAPE_OK=true
+    break
+  fi
+  echo "Required metrics incomplete; waiting for Cloud Logging ingestion..."
+  sleep 60
+done
+if [ "$SCRAPE_OK" != "true" ]; then
+  echo "Metrics still incomplete after retries."
+  # Record explicitly: bash's ERR trap does NOT fire on `exit`, so without this
+  # the allowFailure step leaves the FAILED ledger empty and check-failure would
+  # green a run that uploaded no summary.
+  record_failure scrape-metrics
+  exit 1
+fi
+gcloud storage cp "$SUMMARY" "gs://$RESULTS_BUCKET/branch=$BRANCH_NAME/$DATE_DIR/$RUN_ID/${TS_DIR}.csv"


### PR DESCRIPTION
This PR introduces the GKE orchestration infrastructure and Cloud Build pipeline for running macrobenchmarks. It is based directly on `main` and focuses purely on the orchestration side, independent of specific workloads.

### Key Changes:
*   **Cloud Build Pipeline**: Added `cloudbuild/macrobenchmarks/macrobenchmarks-cloudbuild.yaml` to orchestrate the benchmark run.
*   **Orchestration Scripts**: Added helper scripts under `cloudbuild/macrobenchmarks/scripts/` for:
    *   Creating and cleaning up GKE clusters (`create_cluster.sh`, `cleanup_cluster.sh`, `cleanup_leaked_resources.sh`).
    *   Managing GCS buckets (`create_buckets.sh`, `delete_buckets.sh`).
    *   Running workloads via Helm (`run_workload.sh`, `cleanup_helm.sh`).
    *   Scraping metrics and checking for failures (`scrape_metrics.sh`, `check_failure.sh`).
*   **Workload Reference**: Set the default workload to `hf-pytorch-lightning-cpu` in the pipeline configuration to align with the planned workload name.

*Note: This branch has been rebased onto `main` to exclude the workload implementation (`feat-macrobench-llama-cpu-sim`), allowing the orchestration infrastructure to be reviewed and merged independently.*
