### PR TITLE
feat(macrobench): add BigQuery ingestion pipeline with dynamic schema evolution

### DIFF
--- a/cloudbuild/macrobenchmarks/ingest.sql
+++ b/cloudbuild/macrobenchmarks/ingest.sql
@@ -1,0 +1,58 @@
+BEGIN
+  DECLARE alter_stmt STRING;
+  DECLARE columns_list STRING;
+  DECLARE insert_query STRING;
+
+  CREATE TABLE IF NOT EXISTS `@PROJECT_ID@.@DATASET_NAME@.history`
+  (
+    run_date DATE,
+    build_id STRING,
+    run_timestamp TIMESTAMP,
+    source_uri STRING,
+    branch_name STRING
+  )
+  PARTITION BY run_date;
+
+  SET alter_stmt = (
+    SELECT
+      CONCAT("ALTER TABLE `@PROJECT_ID@.@DATASET_NAME@.history` ",
+             STRING_AGG(CONCAT("ADD COLUMN `", column_name, "` ", data_type), ", "))
+    FROM `@PROJECT_ID@.@DATASET_NAME@.INFORMATION_SCHEMA.COLUMNS`
+    WHERE table_name = 'staging'
+      AND column_name NOT IN (
+        SELECT column_name
+        FROM `@PROJECT_ID@.@DATASET_NAME@.INFORMATION_SCHEMA.COLUMNS`
+        WHERE table_name = 'history'
+      )
+  );
+
+  IF alter_stmt IS NOT NULL THEN
+    EXECUTE IMMEDIATE alter_stmt;
+  END IF;
+
+  -- Exclude the columns history derives from _FILE_NAME (run_date, build_id,
+  -- run_timestamp, source_uri, branch_name). They are inserted explicitly
+  -- below; if a future metric column ever collided with one of these names it
+  -- would otherwise appear twice in the INSERT column list and fail.
+  SET columns_list = (
+    SELECT STRING_AGG(CONCAT("`", column_name, "`"), ", " ORDER BY column_name)
+    FROM `@PROJECT_ID@.@DATASET_NAME@.INFORMATION_SCHEMA.COLUMNS`
+    WHERE table_name = 'staging'
+      AND column_name NOT IN ('run_date', 'build_id', 'run_timestamp',
+                              'source_uri', 'branch_name')
+  );
+
+  SET insert_query = CONCAT(
+    "INSERT INTO `@PROJECT_ID@.@DATASET_NAME@.history` (run_date, build_id, run_timestamp, source_uri, branch_name, ",
+    columns_list,
+    ") SELECT PARSE_DATE('%Y%m%d', REGEXP_EXTRACT(_FILE_NAME, r'/(\\d{8})/')) as run_date, ",
+    "REGEXP_EXTRACT(_FILE_NAME, r'/buildid-([0-9a-fA-F-]{36})/') as build_id, ",
+    "PARSE_TIMESTAMP('%Y%m%d-%H%M%S', REGEXP_EXTRACT(_FILE_NAME, r'/(\\d{8}-\\d{6})\\.csv')) as run_timestamp, ",
+    "_FILE_NAME as source_uri, ",
+    "REGEXP_EXTRACT(_FILE_NAME, r'/branch=([^/]+)/') as branch_name, ",
+    columns_list,
+    " FROM `@PROJECT_ID@.@DATASET_NAME@.staging` WHERE _FILE_NAME NOT IN (SELECT DISTINCT source_uri FROM `@PROJECT_ID@.@DATASET_NAME@.history`)"
+  );
+
+  EXECUTE IMMEDIATE insert_query;
+END;

--- a/cloudbuild/macrobenchmarks/ingest.sql
+++ b/cloudbuild/macrobenchmarks/ingest.sql
@@ -51,7 +51,7 @@ BEGIN
     "_FILE_NAME as source_uri, ",
     "REGEXP_EXTRACT(_FILE_NAME, r'/branch=([^/]+)/') as branch_name, ",
     columns_list,
-    " FROM `@PROJECT_ID@.@DATASET_NAME@.staging` WHERE _FILE_NAME NOT IN (SELECT DISTINCT source_uri FROM `@PROJECT_ID@.@DATASET_NAME@.history`)"
+    " FROM `@PROJECT_ID@.@DATASET_NAME@.staging` s WHERE NOT EXISTS (SELECT 1 FROM `@PROJECT_ID@.@DATASET_NAME@.history` h WHERE h.source_uri = s._FILE_NAME)"
   );
 
   EXECUTE IMMEDIATE insert_query;

--- a/cloudbuild/macrobenchmarks/macrobenchmarks-ingestion-cloudbuild.yaml
+++ b/cloudbuild/macrobenchmarks/macrobenchmarks-ingestion-cloudbuild.yaml
@@ -1,0 +1,89 @@
+substitutions:
+  _DATASET_NAME: ""
+  _INFRA_PREFIX: ""
+
+steps:
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    id: 'ensure-dataset'
+    entrypoint: 'bash'
+    waitFor: ['-']
+    args:
+      - '-c'
+      - |
+        if [ -z "${_DATASET_NAME}" ] || [ -z "${_INFRA_PREFIX}" ]; then
+          echo "ERROR: _DATASET_NAME and _INFRA_PREFIX are required."; exit 1
+        fi
+        # Namespace the dataset by infra prefix so each prefixed results bucket
+        # always lands in its own dataset (stable per-dataset dedup; two prefixes
+        # never clobber one history table). BigQuery dataset names allow only
+        # [A-Za-z0-9_], so collapse the hyphens infra prefixes carry. The $$ is
+        # Cloud Build's escape for a literal $ (this is a shell var, not a
+        # substitution); the leading ${_...} are Cloud Build substitutions.
+        DATASET_NAME=$$(echo "${_INFRA_PREFIX}_${_DATASET_NAME}" | tr '-' '_')
+        bq show ${PROJECT_ID}:$${DATASET_NAME} || \
+        bq mk --dataset --location=${LOCATION} ${PROJECT_ID}:$${DATASET_NAME}
+
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    id: 'update-staging-table'
+    entrypoint: 'bash'
+    waitFor: ['ensure-dataset']
+    args:
+      - '-c'
+      - |
+        set -e
+        # _INFRA_PREFIX selects the results bucket the external table reads
+        # (gs://<_INFRA_PREFIX>-macrobench-results/*.csv); a missing value would
+        # render gs://-macrobench-results and silently read nothing. Require it
+        # here too (not only in ensure-dataset) so this step is safe in isolation.
+        if [ -z "${_INFRA_PREFIX}" ] || [ -z "${_DATASET_NAME}" ]; then
+          echo "ERROR: _INFRA_PREFIX and _DATASET_NAME are required."; exit 1
+        fi
+        # Same namespaced dataset as ensure-dataset (kept self-contained).
+        DATASET_NAME=$$(echo "${_INFRA_PREFIX}_${_DATASET_NAME}" | tr '-' '_')
+        # Render the @INFRA_PREFIX@ placeholder into a /workspace copy rather
+        # than editing the checked-in schema in place (keeps the tracked file
+        # pristine and the build idempotent/re-runnable).
+        sed "s/@INFRA_PREFIX@/${_INFRA_PREFIX}/g" \
+          cloudbuild/macrobenchmarks/macrobenchmarks_schema.json \
+          > /workspace/staging_schema.json
+        # Fail loudly if the placeholder survived (e.g. the value was empty or
+        # the schema drifted) rather than creating a table over a bad URI.
+        if grep -q '@INFRA_PREFIX@' /workspace/staging_schema.json; then
+          echo "ERROR: _INFRA_PREFIX was not applied to the staging schema."; exit 1
+        fi
+        # Drop the external table if it exists to force a clean recreation and schema update
+        bq --project_id=${PROJECT_ID} rm -f $${DATASET_NAME}.staging
+
+        bq --project_id=${PROJECT_ID} mk \
+          --external_table_definition=/workspace/staging_schema.json \
+          $${DATASET_NAME}.staging
+
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    id: 'run-ingestion'
+    entrypoint: 'bash'
+    waitFor: ['update-staging-table']
+    args:
+      - '-c'
+      - |
+        set -e
+        if [ -z "${_INFRA_PREFIX}" ] || [ -z "${_DATASET_NAME}" ]; then
+          echo "ERROR: _INFRA_PREFIX and _DATASET_NAME are required."; exit 1
+        fi
+        # Same namespaced dataset as the prior steps (kept self-contained).
+        DATASET_NAME=$$(echo "${_INFRA_PREFIX}_${_DATASET_NAME}" | tr '-' '_')
+        # Render placeholders into a /workspace copy; BigQuery cannot bind table
+        # identifiers as query parameters, so they are substituted textually,
+        # but never into the tracked source file.
+        sed -e "s/@PROJECT_ID@/${PROJECT_ID}/g" \
+            -e "s/@DATASET_NAME@/$${DATASET_NAME}/g" \
+            cloudbuild/macrobenchmarks/ingest.sql > /workspace/ingest.sql
+        bq query --use_legacy_sql=false \
+                 --project_id=${PROJECT_ID} \
+                 < /workspace/ingest.sql
+
+timeout: "14400s"
+
+options:
+  logging: CLOUD_LOGGING_ONLY
+  pool:
+    name: "projects/${PROJECT_ID}/locations/${LOCATION}/workerPools/cloud-build-worker-pool"


### PR DESCRIPTION
This PR introduces a BigQuery ingestion pipeline for macrobenchmarks, similar to the microbenchmarks pipeline, but with built-in support for dynamic schema evolution (schema cross-check).

### Key Additions & Changes:

1. **Dynamic Ingestion SQL (`cloudbuild/macrobenchmarks/ingest.sql`)**:
   - **Table Initialization**: Automatically creates the partitioned `history` table if it does not exist.
   - **Schema Cross-check & Evolution**: Queries `INFORMATION_SCHEMA.COLUMNS` to identify columns present in the `staging` external table but missing in the `history` table, and executes `ALTER TABLE ... ADD COLUMN` to dynamically evolve the history table's schema.
   - **Deduplicated Ingestion**: Dynamically constructs and executes an `INSERT INTO` statement to load new benchmark runs, parsing metadata (`run_date`, `build_id`, `run_timestamp`, `source_uri`, `branch_name`) from the `_FILE_NAME` pseudo-column and avoiding duplicate ingestion.

2. **Cloud Build Ingestion Pipeline (`cloudbuild/macrobenchmarks/macrobenchmarks-ingestion-cloudbuild.yaml`)**:
   - **`ensure-dataset`**: Namespaces the BigQuery dataset by `_INFRA_PREFIX` (e.g. collapsing hyphens to underscores) and ensures it exists, isolating results across different infra prefixes.
   - **`update-staging-table`**: Substitutes `_INFRA_PREFIX` in the external table schema definition, drops any existing staging table, and recreates it to guarantee a fresh external table mapping.
   - **`run-ingestion`**: Renders project and dataset placeholders into the SQL script and executes it using `bq query`.

### Benefits:
- **Zero-touch schema evolution**: When new macrobenchmark metrics are added as columns in the CSV output, the pipeline automatically updates the BigQuery history schema without manual intervention or data migrations.
- **Environment Isolation**: The `_INFRA_PREFIX` namespacing prevents separate test environments from clobbering each other's history tables.
