### PR TITLE
perf(benchmarks): increase pipe benchmark size and exclude setup overhead from write benchmark

### DIFF
--- a/gcsfs/tests/perf/microbenchmarks/pipe/configs.yaml
+++ b/gcsfs/tests/perf/microbenchmarks/pipe/configs.yaml
@@ -3,7 +3,7 @@ common:
     - "regional"
     - "zonal"
   file_sizes_mb:
-    - 200 # 200 MB
+    - 4096 # 4 GB
   chunk_sizes_mb:
     - 50 # 50 MB Default chunk size
   rounds: 3

--- a/gcsfs/tests/perf/microbenchmarks/pipe/test_pipe.py
+++ b/gcsfs/tests/perf/microbenchmarks/pipe/test_pipe.py
@@ -18,9 +18,7 @@ BENCHMARK_GROUP = "pipe"
 def _pipe_op(gcs, file_path, data_buffer, chunk_size):
     """Pipe data buffer to a single file."""
     try:
-        gcs.pipe(
-            file_path, data_buffer, chunksize=chunk_size, finalize_on_close=True
-        )
+        gcs.pipe(file_path, data_buffer, chunksize=chunk_size, finalize_on_close=True)
     except Exception as e:
         logging.error(f"Error piping to {file_path}: {e}")
         raise

--- a/gcsfs/tests/perf/microbenchmarks/pipe/test_pipe.py
+++ b/gcsfs/tests/perf/microbenchmarks/pipe/test_pipe.py
@@ -18,7 +18,7 @@ BENCHMARK_GROUP = "pipe"
 def _pipe_op(gcs, file_path, data_buffer, chunk_size):
     """Pipe data buffer to a single file."""
     try:
-        gcs.pipe(file_path, data_buffer, chunksize=chunk_size, finalize_on_close=True)
+        gcs.pipe(file_path, data_buffer, chunksize=chunk_size)
     except Exception as e:
         logging.error(f"Error piping to {file_path}: {e}")
         raise

--- a/gcsfs/tests/perf/microbenchmarks/pipe/test_pipe.py
+++ b/gcsfs/tests/perf/microbenchmarks/pipe/test_pipe.py
@@ -18,7 +18,9 @@ BENCHMARK_GROUP = "pipe"
 def _pipe_op(gcs, file_path, data_buffer, chunk_size):
     """Pipe data buffer to a single file."""
     try:
-        gcs.pipe(file_path, data_buffer, chunksize=chunk_size)
+        gcs.pipe(
+            file_path, data_buffer, chunksize=chunk_size, finalize_on_close=True
+        )
     except Exception as e:
         logging.error(f"Error piping to {file_path}: {e}")
         raise

--- a/gcsfs/tests/perf/microbenchmarks/write/test_write.py
+++ b/gcsfs/tests/perf/microbenchmarks/write/test_write.py
@@ -21,12 +21,9 @@ def _write_op_seq_fixed_duration(gcs, file_path, chunk_size, runtime):
 
     # Pre-generate chunk to avoid overhead during write loop
     data_chunk = os.urandom(chunk_size)
-
+    start_time = time.perf_counter()
     try:
         with gcs.open(file_path, "wb", finalize_on_close=True) as f:
-            # Start timing only after setup (data generation and upload
-            # initiation) so the runtime window measures the write loop alone.
-            start_time = time.perf_counter()
             while time.perf_counter() - start_time < runtime:
                 f.write(data_chunk)
                 total_bytes_written += chunk_size

--- a/gcsfs/tests/perf/microbenchmarks/write/test_write.py
+++ b/gcsfs/tests/perf/microbenchmarks/write/test_write.py
@@ -23,7 +23,7 @@ def _write_op_seq_fixed_duration(gcs, file_path, chunk_size, runtime):
     data_chunk = os.urandom(chunk_size)
     start_time = time.perf_counter()
     try:
-        with gcs.open(file_path, "wb", finalize_on_close=True) as f:
+        with gcs.open(file_path, "wb") as f:
             while time.perf_counter() - start_time < runtime:
                 f.write(data_chunk)
                 total_bytes_written += chunk_size

--- a/gcsfs/tests/perf/microbenchmarks/write/test_write.py
+++ b/gcsfs/tests/perf/microbenchmarks/write/test_write.py
@@ -18,13 +18,15 @@ BENCHMARK_GROUP = "write"
 def _write_op_seq_fixed_duration(gcs, file_path, chunk_size, runtime):
     """Write to a single file sequentially for a fixed duration."""
     total_bytes_written = 0
-    start_time = time.perf_counter()
 
     # Pre-generate chunk to avoid overhead during write loop
     data_chunk = os.urandom(chunk_size)
 
     try:
-        with gcs.open(file_path, "wb") as f:
+        with gcs.open(file_path, "wb", finalize_on_close=True) as f:
+            # Start timing only after setup (data generation and upload
+            # initiation) so the runtime window measures the write loop alone.
+            start_time = time.perf_counter()
             while time.perf_counter() - start_time < runtime:
                 f.write(data_chunk)
                 total_bytes_written += chunk_size


### PR DESCRIPTION
This PR updates the microbenchmarks to improve measurement accuracy and coverage:

- **Pipe Benchmark**: Increases the file size from 200 MB to 4 GB in `pipe/configs.yaml` to provide a more robust performance measurement.
- **Write Benchmark**: Adjusts the timing in `test_write.py` by moving `start_time` to after `os.urandom(chunk_size)`. This excludes the overhead of generating random data from the benchmarked write loop duration.