### PR TITLE
Fix HNS _list_objects error swallowing

### DIFF
--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -747,9 +747,6 @@ class ExtendedGcsFileSystem(HnsDirCacheUpdater, GCSFileSystem):
                     return []
                 except FileNotFoundError:
                     pass
-                except Exception as e:
-                    logger.warning(f"Error fetching directory info for {path}: {e}")
-                    raise
             raise
 
     async def _mkdir(

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -747,6 +747,9 @@ class ExtendedGcsFileSystem(HnsDirCacheUpdater, GCSFileSystem):
                     return []
                 except FileNotFoundError:
                     pass
+                except Exception as e:
+                    logger.warning(f"Error fetching directory info for {path}: {e}")
+                    raise
             raise
 
     async def _mkdir(

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -745,8 +745,11 @@ class ExtendedGcsFileSystem(HnsDirCacheUpdater, GCSFileSystem):
                 try:
                     await self._get_directory_info(path, bucket, key, None)
                     return []
-                except (FileNotFoundError, Exception):
+                except FileNotFoundError:
                     pass
+                except Exception as e:
+                    logger.warning(f"Error fetching directory info for {path}: {e}")
+                    raise
             raise
 
     async def _mkdir(

--- a/gcsfs/tests/test_extended_hns_gcsfs.py
+++ b/gcsfs/tests/test_extended_hns_gcsfs.py
@@ -2985,3 +2985,34 @@ class TestExtendedGcsFileSystemBucketType:
                 bucket_type = await fs._get_bucket_type("error-bucket")
                 assert bucket_type == BucketType.UNKNOWN
                 assert "Could not determine bucket type" in caplog.text
+import pytest
+from unittest import mock
+from gcsfs.extended_gcsfs import ExtendedGcsFileSystem
+
+@pytest.mark.asyncio
+async def test_list_objects_file_not_found_hns():
+    fs = ExtendedGcsFileSystem(token="anon")
+    with mock.patch("gcsfs.core.GCSFileSystem._list_objects", new_callable=mock.AsyncMock) as mock_super_list, \
+         mock.patch.object(fs, "split_path", return_value=("bucket", "key", "gen")), \
+         mock.patch.object(fs, "_is_bucket_hns_enabled", return_value=True), \
+         mock.patch.object(fs, "_get_directory_info", new_callable=mock.AsyncMock) as mock_dir_info:
+
+        mock_super_list.side_effect = FileNotFoundError()
+        mock_dir_info.side_effect = FileNotFoundError()
+
+        with pytest.raises(FileNotFoundError):
+            await fs._list_objects("gs://bucket/key")
+
+@pytest.mark.asyncio
+async def test_list_objects_unexpected_exception_hns():
+    fs = ExtendedGcsFileSystem(token="anon")
+    with mock.patch("gcsfs.core.GCSFileSystem._list_objects", new_callable=mock.AsyncMock) as mock_super_list, \
+         mock.patch.object(fs, "split_path", return_value=("bucket", "key", "gen")), \
+         mock.patch.object(fs, "_is_bucket_hns_enabled", return_value=True), \
+         mock.patch.object(fs, "_get_directory_info", new_callable=mock.AsyncMock) as mock_dir_info:
+
+        mock_super_list.side_effect = FileNotFoundError()
+        mock_dir_info.side_effect = Exception("API Error")
+
+        with pytest.raises(Exception, match="API Error"):
+            await fs._list_objects("gs://bucket/key")

--- a/gcsfs/tests/test_extended_hns_gcsfs.py
+++ b/gcsfs/tests/test_extended_hns_gcsfs.py
@@ -2985,17 +2985,28 @@ class TestExtendedGcsFileSystemBucketType:
                 bucket_type = await fs._get_bucket_type("error-bucket")
                 assert bucket_type == BucketType.UNKNOWN
                 assert "Could not determine bucket type" in caplog.text
-import pytest
+
+
 from unittest import mock
+
+import pytest
+
 from gcsfs.extended_gcsfs import ExtendedGcsFileSystem
+
 
 @pytest.mark.asyncio
 async def test_list_objects_file_not_found_hns():
     fs = ExtendedGcsFileSystem(token="anon")
-    with mock.patch("gcsfs.core.GCSFileSystem._list_objects", new_callable=mock.AsyncMock) as mock_super_list, \
-         mock.patch.object(fs, "split_path", return_value=("bucket", "key", "gen")), \
-         mock.patch.object(fs, "_is_bucket_hns_enabled", return_value=True), \
-         mock.patch.object(fs, "_get_directory_info", new_callable=mock.AsyncMock) as mock_dir_info:
+    with (
+        mock.patch(
+            "gcsfs.core.GCSFileSystem._list_objects", new_callable=mock.AsyncMock
+        ) as mock_super_list,
+        mock.patch.object(fs, "split_path", return_value=("bucket", "key", "gen")),
+        mock.patch.object(fs, "_is_bucket_hns_enabled", return_value=True),
+        mock.patch.object(
+            fs, "_get_directory_info", new_callable=mock.AsyncMock
+        ) as mock_dir_info,
+    ):
 
         mock_super_list.side_effect = FileNotFoundError()
         mock_dir_info.side_effect = FileNotFoundError()
@@ -3003,13 +3014,20 @@ async def test_list_objects_file_not_found_hns():
         with pytest.raises(FileNotFoundError):
             await fs._list_objects("gs://bucket/key")
 
+
 @pytest.mark.asyncio
 async def test_list_objects_unexpected_exception_hns():
     fs = ExtendedGcsFileSystem(token="anon")
-    with mock.patch("gcsfs.core.GCSFileSystem._list_objects", new_callable=mock.AsyncMock) as mock_super_list, \
-         mock.patch.object(fs, "split_path", return_value=("bucket", "key", "gen")), \
-         mock.patch.object(fs, "_is_bucket_hns_enabled", return_value=True), \
-         mock.patch.object(fs, "_get_directory_info", new_callable=mock.AsyncMock) as mock_dir_info:
+    with (
+        mock.patch(
+            "gcsfs.core.GCSFileSystem._list_objects", new_callable=mock.AsyncMock
+        ) as mock_super_list,
+        mock.patch.object(fs, "split_path", return_value=("bucket", "key", "gen")),
+        mock.patch.object(fs, "_is_bucket_hns_enabled", return_value=True),
+        mock.patch.object(
+            fs, "_get_directory_info", new_callable=mock.AsyncMock
+        ) as mock_dir_info,
+    ):
 
         mock_super_list.side_effect = FileNotFoundError()
         mock_dir_info.side_effect = Exception("API Error")

--- a/gcsfs/tests/test_extended_hns_gcsfs.py
+++ b/gcsfs/tests/test_extended_hns_gcsfs.py
@@ -2987,13 +2987,6 @@ class TestExtendedGcsFileSystemBucketType:
                 assert "Could not determine bucket type" in caplog.text
 
 
-from unittest import mock
-
-import pytest
-
-from gcsfs.extended_gcsfs import ExtendedGcsFileSystem
-
-
 @pytest.mark.asyncio
 async def test_list_objects_file_not_found_hns():
     fs = ExtendedGcsFileSystem(token="anon")
@@ -3001,7 +2994,6 @@ async def test_list_objects_file_not_found_hns():
         mock.patch(
             "gcsfs.core.GCSFileSystem._list_objects", new_callable=mock.AsyncMock
         ) as mock_super_list,
-        mock.patch.object(fs, "split_path", return_value=("bucket", "key", "gen")),
         mock.patch.object(fs, "_is_bucket_hns_enabled", return_value=True),
         mock.patch.object(
             fs, "_get_directory_info", new_callable=mock.AsyncMock
@@ -3022,7 +3014,6 @@ async def test_list_objects_unexpected_exception_hns():
         mock.patch(
             "gcsfs.core.GCSFileSystem._list_objects", new_callable=mock.AsyncMock
         ) as mock_super_list,
-        mock.patch.object(fs, "split_path", return_value=("bucket", "key", "gen")),
         mock.patch.object(fs, "_is_bucket_hns_enabled", return_value=True),
         mock.patch.object(
             fs, "_get_directory_info", new_callable=mock.AsyncMock


### PR DESCRIPTION
HNS _list_objects swallows all folder-metadata errors. This commit fixes it by catching only FileNotFoundError, logging unexpected exceptions, and re-raising them.
