### PR TITLE
Fix silent truncation on short reads in zonal bucket downloads

### DIFF
--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -1655,7 +1655,7 @@ class ExtendedGcsFileSystem(HnsDirCacheUpdater, GCSFileSystem):
                         callback.relative_update(len(data))
 
                 if offset != size:
-                    raise aiohttp.client_exceptions.ClientError(
+                    raise aiohttp.ClientError(
                         f"Expected {size} bytes, but only received {offset} bytes"
                     )
         except Exception as e:

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -8,6 +8,7 @@ from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 from glob import has_magic
 
+import aiohttp
 import fsspec
 from fsspec import asyn
 from fsspec.callbacks import NoOpCallback
@@ -1652,6 +1653,11 @@ class ExtendedGcsFileSystem(HnsDirCacheUpdater, GCSFileSystem):
                         f2.write(data)
                         offset += len(data)
                         callback.relative_update(len(data))
+
+                if offset != size:
+                    raise aiohttp.client_exceptions.ClientError(
+                        f"Expected {size} bytes, but only received {offset} bytes"
+                    )
         except Exception as e:
             # Clean up the corrupted file before raising error
             if os.path.exists(lpath):

--- a/gcsfs/tests/test_extended_gcsfs_unit.py
+++ b/gcsfs/tests/test_extended_gcsfs_unit.py
@@ -4,6 +4,7 @@ import io
 import logging
 from unittest import mock
 
+import aiohttp
 import pytest
 from google.cloud.storage.asyncio.async_multi_range_downloader import (
     AsyncMultiRangeDownloader,

--- a/gcsfs/tests/test_extended_gcsfs_unit.py
+++ b/gcsfs/tests/test_extended_gcsfs_unit.py
@@ -574,8 +574,17 @@ async def test_get_file_incomplete_download(
         lpath = tmp_path / "output.txt"
 
         # Simulate download_range returning a shorter byte string than expected
+        # by returning some data on first call, then empty bytes (EOF) on subsequent calls.
+        # This ensures the download terminates early and raises ClientError, even if
+        # the expected size happens to be a multiple of the chunk size.
+        download_called = False
+
         async def mock_download_range(*args, **kwargs):
-            return b"short"
+            nonlocal download_called
+            if not download_called:
+                download_called = True
+                return b"short"
+            return b""
 
         with (
             mock.patch(

--- a/gcsfs/tests/test_extended_gcsfs_unit.py
+++ b/gcsfs/tests/test_extended_gcsfs_unit.py
@@ -561,6 +561,45 @@ async def test_get_file_warning_on_missing_persisted_size(
             assert lpath.read_bytes() == json_data
 
 
+import aiohttp
+
+
+@pytest.mark.asyncio
+async def test_get_file_incomplete_download(
+    async_gcs, gcs_bucket_mocks, tmp_path, file_path
+):
+    """
+    Tests that _get_file raises ClientError and correctly removes the local file
+    when the downloaded bytes are less than the expected size.
+    """
+
+    with gcs_bucket_mocks(json_data, bucket_type_val=BucketType.ZONAL_HIERARCHICAL):
+        lpath = tmp_path / "output.txt"
+
+        # Simulate download_range returning a shorter byte string than expected
+        async def mock_download_range(*args, **kwargs):
+            return b"short"
+
+        with (
+            mock.patch(
+                "gcsfs.zb_hns_utils.download_range",
+                side_effect=mock_download_range,
+            ),
+            mock.patch.object(
+                async_gcs, "_info", new_callable=mock.AsyncMock
+            ) as mock_info,
+        ):
+            mock_info.return_value = {"size": len(json_data)}
+            with pytest.raises(
+                aiohttp.client_exceptions.ClientError,
+                match="Expected .* bytes, but only received .* bytes",
+            ):
+                await async_gcs._get_file(file_path, str(lpath))
+
+            # The local file should not exist after the failed download
+            assert not lpath.exists()
+
+
 @pytest.mark.asyncio
 async def test_get_file_exception_cleanup(
     async_gcs, gcs_bucket_mocks, tmp_path, file_path

--- a/gcsfs/tests/test_extended_gcsfs_unit.py
+++ b/gcsfs/tests/test_extended_gcsfs_unit.py
@@ -561,9 +561,6 @@ async def test_get_file_warning_on_missing_persisted_size(
             assert lpath.read_bytes() == json_data
 
 
-import aiohttp
-
-
 @pytest.mark.asyncio
 async def test_get_file_incomplete_download(
     async_gcs, gcs_bucket_mocks, tmp_path, file_path

--- a/gcsfs/tests/test_extended_gcsfs_unit.py
+++ b/gcsfs/tests/test_extended_gcsfs_unit.py
@@ -588,7 +588,7 @@ async def test_get_file_incomplete_download(
         ):
             mock_info.return_value = {"size": len(json_data)}
             with pytest.raises(
-                aiohttp.client_exceptions.ClientError,
+                aiohttp.ClientError,
                 match="Expected .* bytes, but only received .* bytes",
             ):
                 await async_gcs._get_file(file_path, str(lpath))


### PR DESCRIPTION
Fixes a bug where a short read from GCS would silently truncate the target local file and return success. Now, if the amount of bytes written differs from the expected file size, a `ClientError` is raised, stopping the silent truncation and leaving the target local system clean by removing the corrupted partial file.
