### PR TITLE
Fix generation threading in gcsfs url and concurrent fetches

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1173,10 +1173,11 @@ class GCSFileSystem(DirCacheUpdater, asyn.AsyncFileSystem):
         else:
             return [o["name"] for o in out]
 
-    def url(self, path):
+    def url(self, path, generation=None):
         """Get HTTP URL of the given path"""
         u = "{}/download/storage/v1/b/{}/o/{}?alt=media{}"
-        bucket, object, generation = self.split_path(path)
+        bucket, object, path_generation = self.split_path(path)
+        generation = _coalesce_generation(generation, path_generation)
         object = quote(object)
         return u.format(
             self._location,
@@ -1193,7 +1194,7 @@ class GCSFileSystem(DirCacheUpdater, asyn.AsyncFileSystem):
         if start is not None and end is not None and start >= end >= 0:
             return b""
 
-        u2 = self.url(path)
+        u2 = self.url(path, generation=kwargs.get("generation"))
         if start is not None or end is not None:
             head = {"Range": await self._process_limits(path, start, end)}
         else:

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -2452,7 +2452,7 @@ class GCSFile(fsspec.spec.AbstractBufferedFile):
 
     def url(self):
         """HTTP link to this file's data"""
-        return self.fs.url(self.path)
+        return self.fs.url(self.path, generation=self.generation)
 
     def _upload_chunk(self, final=False):
         """Write one part of a multi-block file upload

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -3501,3 +3501,16 @@ async def test_cat_file_generation():
             assert mock_call.call_count == 1
             url = mock_call.call_args[0][1]
             assert "generation=12345" in url
+
+
+def test_file_url_generation():
+    fs = gcsfs.core.GCSFileSystem(token="anon")
+    f = gcsfs.core.GCSFile(fs, "bucket/file", mode="wb")
+    f.generation = "12345"
+
+    try:
+        assert f.url() == fs.url("bucket/file", generation="12345")
+        assert "generation=12345" in f.url()
+    finally:
+        # Avoid flushing the unused write buffer (and a network call) on GC.
+        f.closed = True

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -3481,3 +3481,23 @@ def test_open_generation_forwarded():
         mock_gcs_file.assert_called_once()
         _, kwargs = mock_gcs_file.call_args
         assert kwargs.get("generation") == "123"
+
+
+@pytest.mark.asyncio
+async def test_cat_file_generation():
+    fs = gcsfs.core.GCSFileSystem(token="anon")
+
+    with mock.patch.object(fs, "_call", new_callable=mock.AsyncMock) as mock_call:
+        with mock.patch.object(
+            fs, "_process_limits", new_callable=mock.AsyncMock
+        ) as mock_limits:
+            mock_limits.return_value = "bytes=0-10"
+            mock_call.return_value = ({}, b"data")
+
+            await fs._cat_file_sequential(
+                "bucket/file", start=0, end=10, generation="12345"
+            )
+
+            assert mock_call.call_count == 1
+            url = mock_call.call_args[0][1]
+            assert "generation=12345" in url


### PR DESCRIPTION
This branch updates `url` and `_cat_file_sequential` to properly process and pass `generation` query arguments to ensure concurrent fetches download a consistent object version.
