### PR TITLE
ci: add macrobenchmark infrastructure unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,11 @@ jobs:
         run: |
           pip install -r gcsfs/tests/perf/microbenchmarks/requirements.txt
           pytest gcsfs/tests/perf/microbenchmarks --run-benchmarks-infra
+      - name: Run Macrobenchmark Infrastructure Unit Tests
+        run: |
+          pip install -r cloudbuild/macrobenchmarks/metrics/requirements.txt
+          PYTHONPATH=cloudbuild/macrobenchmarks pytest cloudbuild/macrobenchmarks/metrics/tests
+
       - name: Run all tests (Standard, Zonal & HNS Enabled) with default ON extended feature support
 
         run: |


### PR DESCRIPTION
Adds macrobenchmark infrastructure unit tests to the CI workflow.