### PR TITLE
Optimize concurrent downloads by capping task count based on minimum chunk size

### DIFF
--- a/gcsfs/concurrency.py
+++ b/gcsfs/concurrency.py
@@ -2,6 +2,27 @@ import asyncio
 from contextlib import asynccontextmanager
 
 
+def split_range(size, concurrency, min_chunk_size):
+    """Split a byte range into no more chunks than the configured minimum warrants."""
+    if size <= 0:
+        return []
+
+    min_chunk_size = max(1, min_chunk_size)
+    if concurrency <= 1 or size < min_chunk_size:
+        chunk_count = 1
+    else:
+        chunk_count = min(concurrency, size // min_chunk_size)
+
+    part_size = size // chunk_count
+    return [
+        (
+            i * part_size,
+            part_size if i < chunk_count - 1 else size - (i * part_size),
+        )
+        for i in range(chunk_count)
+    ]
+
+
 @asynccontextmanager
 async def parallel_tasks_first_completed(coros):
     """

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -30,7 +30,7 @@ from fsspec.utils import other_paths, setup_logging, stringify_path
 from . import __version__ as version
 from ._dircache import DirCacheUpdater
 from .checkers import get_consistency_checker
-from .concurrency import parallel_tasks_first_completed
+from .concurrency import parallel_tasks_first_completed, split_range
 from .credentials import GoogleCredentials
 from .inventory_report import InventoryReport
 from .retry import errs, retry_request, validate_response
@@ -1213,22 +1213,20 @@ class GCSFileSystem(DirCacheUpdater, asyn.AsyncFileSystem):
         if start >= end:
             return b""
 
-        if concurrency <= 1 or end - start < self.MIN_CHUNK_SIZE_FOR_CONCURRENCY:
+        ranges = split_range(
+            end - start, concurrency, self.MIN_CHUNK_SIZE_FOR_CONCURRENCY
+        )
+        if len(ranges) == 1:
             return await self._cat_file_sequential(path, start=start, end=end, **kwargs)
 
-        total_size = end - start
-        part_size = total_size // concurrency
         tasks = []
 
-        for i in range(concurrency):
-            offset = start + (i * part_size)
-            actual_size = (
-                part_size if i < concurrency - 1 else total_size - (i * part_size)
-            )
+        for relative_offset, size in ranges:
+            offset = start + relative_offset
             tasks.append(
                 asyncio.create_task(
                     self._cat_file_sequential(
-                        path, start=offset, end=offset + actual_size, **kwargs
+                        path, start=offset, end=offset + size, **kwargs
                     )
                 )
             )

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -27,6 +27,7 @@ from google.cloud.storage.asyncio.async_multi_range_downloader import (
 from gcsfs import __version__ as version
 from gcsfs import zb_hns_utils
 from gcsfs._dircache import HnsDirCacheUpdater
+from gcsfs.concurrency import split_range
 from gcsfs.core import GCSFile, GCSFileSystem
 from gcsfs.retry import DEFAULT_RETRY_CONFIG, get_storage_control_retry_config
 from gcsfs.zb_hns_utils import DirectMemmoveBuffer, MRDPool
@@ -495,10 +496,7 @@ class ExtendedGcsFileSystem(HnsDirCacheUpdater, GCSFileSystem):
 
     async def _concurrent_mrd_fetch(self, offset, length, concurrency, mrd_or_pool):
         """Helper to handle concurrent chunk downloads cleanly."""
-        concurrency = (
-            concurrency if length >= self.MIN_CHUNK_SIZE_FOR_CONCURRENCY else 1
-        )
-        part_size = length // concurrency
+        ranges = split_range(length, concurrency, self.MIN_CHUNK_SIZE_FOR_CONCURRENCY)
 
         tasks = []
         views = []
@@ -516,9 +514,8 @@ class ExtendedGcsFileSystem(HnsDirCacheUpdater, GCSFileSystem):
                     )
                 await m_client.download_ranges([(o, s, view)])
 
-        for i in range(concurrency):
-            part_offset = offset + (i * part_size)
-            actual_size = part_size if i < concurrency - 1 else length - (i * part_size)
+        for relative_offset, actual_size in ranges:
+            part_offset = offset + relative_offset
 
             # Give each task a restricted view of the master buffer
             view = master_buffer.get_view(part_offset - offset, actual_size)
@@ -620,7 +617,7 @@ class ExtendedGcsFileSystem(HnsDirCacheUpdater, GCSFileSystem):
             return await self._concurrent_mrd_fetch(
                 offset,
                 length,
-                concurrency if length >= self.MIN_CHUNK_SIZE_FOR_CONCURRENCY else 1,
+                concurrency,
                 mrd,
             )
 

--- a/gcsfs/tests/test_concurrency.py
+++ b/gcsfs/tests/test_concurrency.py
@@ -2,7 +2,22 @@ import asyncio
 
 import pytest
 
-from gcsfs.concurrency import parallel_tasks_first_completed
+from gcsfs.concurrency import parallel_tasks_first_completed, split_range
+
+
+@pytest.mark.parametrize(
+    "size, concurrency, min_chunk_size, expected",
+    [
+        (0, 4, 5, []),
+        (4, 4, 5, [(0, 4)]),
+        (5, 4, 5, [(0, 5)]),
+        (20, 1000, 5, [(0, 5), (5, 5), (10, 5), (15, 5)]),
+        (21, 4, 5, [(0, 5), (5, 5), (10, 5), (15, 6)]),
+        (21, 1000, 5, [(0, 5), (5, 5), (10, 5), (15, 6)]),
+    ],
+)
+def test_split_range_caps_concurrency(size, concurrency, min_chunk_size, expected):
+    assert split_range(size, concurrency, min_chunk_size) == expected
 
 
 @pytest.mark.asyncio

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -2692,13 +2692,12 @@ def test_mv_file_raises_error_for_specific_generation(gcs):
         gcs.version_aware = original_version_aware
 
 
-def test_cat_file_routing_and_thresholds(gcs):
+def test_cat_file_routing_and_thresholds(gcs, monkeypatch):
+    monkeypatch.setattr(gcs, "MIN_CHUNK_SIZE_FOR_CONCURRENCY", 5)
     fn = f"{TEST_BUCKET}/core_routing.txt"
-    # Create an 8MB file
-    data = os.urandom(8 * 1024 * 1024)
+    data = b"0123456789abcdefghijk"
     gcs.pipe(fn, data)
 
-    # 1. Concurrency = 1 (Should route to sequential)
     with mock.patch.object(
         gcs, "_cat_file_sequential", wraps=gcs._cat_file_sequential
     ) as mock_seq:
@@ -2712,7 +2711,6 @@ def test_cat_file_routing_and_thresholds(gcs):
             assert mock_seq.call_count == 1
             assert mock_conc.call_count == 0
 
-    # 2. Concurrency = 4, but read size (1MB) is < MIN_CHUNK_SIZE_FOR_CONCURRENCY (5MB)
     with mock.patch.object(
         gcs, "_cat_file_sequential", wraps=gcs._cat_file_sequential
     ) as mock_seq:
@@ -2720,23 +2718,24 @@ def test_cat_file_routing_and_thresholds(gcs):
             gcs, "_cat_file_concurrent", wraps=gcs._cat_file_concurrent
         ) as mock_conc:
             res = fsspec.asyn.sync(
-                gcs.loop, gcs._cat_file, fn, start=0, end=1024 * 1024, concurrency=4
+                gcs.loop, gcs._cat_file, fn, start=0, end=4, concurrency=4
             )
-            assert res == data[: 1024 * 1024]
-            # It hits the concurrent wrapper, but bails out to sequential internally
+            assert res == data[:4]
             assert mock_conc.call_count == 1
             assert mock_seq.call_count == 1
 
-    # 3. Concurrency = 4, and read size (8MB) >= MIN_CHUNK_SIZE_FOR_CONCURRENCY (5MB)
     with mock.patch.object(
         gcs, "_cat_file_sequential", wraps=gcs._cat_file_sequential
     ) as mock_seq:
         res = fsspec.asyn.sync(
-            gcs.loop, gcs._cat_file, fn, start=0, end=8 * 1024 * 1024, concurrency=4
+            gcs.loop, gcs._cat_file, fn, start=0, end=len(data), concurrency=4
         )
         assert res == data
-        # Should call sequential 4 times (once for each concurrent chunk)
         assert mock_seq.call_count == 4
+        assert [
+            (call.kwargs["start"], call.kwargs["end"])
+            for call in mock_seq.call_args_list
+        ] == [(0, 5), (5, 10), (10, 15), (15, 21)]
 
 
 def test_cat_file_concurrent_data_integrity(gcs):
@@ -2750,6 +2749,31 @@ def test_cat_file_concurrent_data_integrity(gcs):
     )
     assert len(res) == file_size
     assert res == data
+
+
+def test_cat_file_concurrent_caps_tasks(gcs, monkeypatch):
+    monkeypatch.setattr(gcs, "MIN_CHUNK_SIZE_FOR_CONCURRENCY", 5)
+    fn = f"{TEST_BUCKET}/core_capped_concurrency.txt"
+    data = b"0123456789abcdefghij"
+    gcs.pipe(fn, data)
+
+    with mock.patch.object(
+        gcs, "_cat_file_sequential", wraps=gcs._cat_file_sequential
+    ) as mock_seq:
+        res = fsspec.asyn.sync(
+            gcs.loop,
+            gcs._cat_file_concurrent,
+            fn,
+            start=0,
+            end=len(data),
+            concurrency=1000,
+        )
+        assert res == data
+        assert mock_seq.call_count == 4
+        assert [
+            (call.kwargs["start"], call.kwargs["end"])
+            for call in mock_seq.call_args_list
+        ] == [(0, 5), (5, 10), (10, 15), (15, 20)]
 
 
 def test_cat_file_concurrent_exception_cancellation(gcs):

--- a/gcsfs/tests/test_extended_gcsfs.py
+++ b/gcsfs/tests/test_extended_gcsfs.py
@@ -1184,15 +1184,10 @@ def test_mrd_stream_cleanup(extended_gcsfs, gcs_bucket_mocks):
             mocks["downloader"].close.assert_awaited()
 
 
-@pytest.mark.asyncio
-async def test_concurrent_mrd_fetch_success(extended_gcsfs):
-    """Tests that _concurrent_mrd_fetch successfully downloads and stitches chunks."""
-    # Add spec so isinstance() checks pass
+def _mrd_pool_with_downloads():
     mock_pool = mock.AsyncMock(spec=MRDPool)
     mock_mrd = mock.AsyncMock(spec=AsyncMultiRangeDownloader)
     mock_mrd.object_name = "test_object"
-
-    # Set up the context manager mock return value
     mock_pool.get_mrd.return_value.__aenter__.return_value = mock_mrd
 
     async def fake_download(ranges):
@@ -1200,27 +1195,50 @@ async def test_concurrent_mrd_fetch_success(extended_gcsfs):
             buf.write(b"A" * length)
 
     mock_mrd.download_ranges.side_effect = fake_download
+    return mock_pool, mock_mrd
+
+
+@pytest.mark.asyncio
+async def test_concurrent_mrd_fetch_success(extended_gcsfs, monkeypatch):
+    """Tests that _concurrent_mrd_fetch successfully downloads and stitches chunks."""
+    monkeypatch.setattr(extended_gcsfs, "MIN_CHUNK_SIZE_FOR_CONCURRENCY", 1)
+    mock_pool, mock_mrd = _mrd_pool_with_downloads()
 
     result = await extended_gcsfs._concurrent_mrd_fetch(
-        offset=0, length=5 * 1024 * 1024, concurrency=4, mrd_or_pool=mock_pool
+        offset=0, length=4, concurrency=4, mrd_or_pool=mock_pool
     )
 
-    assert len(result) == 5 * 1024 * 1024
-    assert result == b"A" * 5 * 1024 * 1024
+    assert result == b"A" * 4
     assert mock_mrd.download_ranges.call_count == 4
 
 
 @pytest.mark.asyncio
-async def test_concurrent_mrd_fetch_exception_masking(extended_gcsfs):
+async def test_concurrent_mrd_fetch_caps_tasks(extended_gcsfs, monkeypatch):
+    """Tests that _concurrent_mrd_fetch caps concurrency to the number of chunks."""
+    monkeypatch.setattr(extended_gcsfs, "MIN_CHUNK_SIZE_FOR_CONCURRENCY", 5)
+    mock_pool, mock_mrd = _mrd_pool_with_downloads()
+
+    result = await extended_gcsfs._concurrent_mrd_fetch(
+        offset=0, length=20, concurrency=1000, mrd_or_pool=mock_pool
+    )
+
+    assert result == b"A" * 20
+    assert mock_mrd.download_ranges.call_count == 4
+    assert [
+        call.args[0][0][:2] for call in mock_mrd.download_ranges.call_args_list
+    ] == [(0, 5), (5, 5), (10, 5), (15, 5)]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_mrd_fetch_exception_masking(extended_gcsfs, monkeypatch):
     """
     Tests that original exceptions in concurrent fetches are not masked by BufferErrors.
     """
-    # Add spec so isinstance() checks pass
+    monkeypatch.setattr(extended_gcsfs, "MIN_CHUNK_SIZE_FOR_CONCURRENCY", 1)
     mock_pool = mock.AsyncMock(spec=MRDPool)
     mock_mrd = mock.AsyncMock(spec=AsyncMultiRangeDownloader)
     mock_mrd.object_name = "test_object"
 
-    # Set up the context manager mock return value
     mock_pool.get_mrd.return_value.__aenter__.return_value = mock_mrd
 
     call_count = 0
@@ -1229,7 +1247,6 @@ async def test_concurrent_mrd_fetch_exception_masking(extended_gcsfs):
         nonlocal call_count
         call_count += 1
         if call_count == 2:
-            # Simulate a network drop on the second concurrent chunk
             raise DataCorruption(None, "Simulated Network Drop")
         for offset, length, buf in ranges:
             buf.write(b"A" * length)
@@ -1238,7 +1255,7 @@ async def test_concurrent_mrd_fetch_exception_masking(extended_gcsfs):
 
     with pytest.raises(DataCorruption, match="Simulated Network Drop"):
         await extended_gcsfs._concurrent_mrd_fetch(
-            offset=0, length=5 * 1024 * 1024, concurrency=4, mrd_or_pool=mock_pool
+            offset=0, length=4, concurrency=4, mrd_or_pool=mock_pool
         )
 
 
@@ -1425,10 +1442,11 @@ async def test_cat_file_zero_length_read(extended_gcsfs):
 
 
 @pytest.mark.asyncio
-async def test_cat_file_concurrency_threshold(extended_gcsfs):
-    """Tests that _cat_file passes concurrency=1 to the fetcher if under the chunk size threshold."""
-    # Set a dummy threshold for the test
-    extended_gcsfs.MIN_CHUNK_SIZE_FOR_CONCURRENCY = 1000
+async def test_cat_file_delegates_resolved_range_to_mrd_fetch(
+    extended_gcsfs, monkeypatch
+):
+    """Tests that _cat_file delegates the resolved range to the concurrent fetcher."""
+    monkeypatch.setattr(extended_gcsfs, "MIN_CHUNK_SIZE_FOR_CONCURRENCY", 1000)
     mock_pool = mock.AsyncMock()
     extended_gcsfs._mrd_pool_cache.get = mock.AsyncMock(return_value=mock_pool)
 
@@ -1457,13 +1475,15 @@ async def test_cat_file_concurrency_threshold(extended_gcsfs):
 
         await extended_gcsfs._cat_file("bucket/obj", concurrency=4)
 
-        # Because length (500) < MIN_CHUNK_SIZE_FOR_CONCURRENCY (1000), it should override concurrency to 1
-        mock_concurrent_fetch.assert_awaited_once_with(0, 500, 1, mock_pool)
+        mock_concurrent_fetch.assert_awaited_once_with(0, 500, 4, mock_pool)
 
 
 @pytest.mark.asyncio
-async def test_concurrent_mrd_fetch_base_exception_cancellation(extended_gcsfs):
+async def test_concurrent_mrd_fetch_base_exception_cancellation(
+    extended_gcsfs, monkeypatch
+):
     """Tests that pending tasks are cancelled if a BaseException occurs."""
+    monkeypatch.setattr(extended_gcsfs, "MIN_CHUNK_SIZE_FOR_CONCURRENCY", 1)
     mock_pool = mock.AsyncMock(spec=MRDPool)
 
     # Create fake tasks to track cancellation
@@ -1472,10 +1492,15 @@ async def test_concurrent_mrd_fetch_base_exception_cancellation(extended_gcsfs):
 
     mock_task2 = mock.Mock(spec=asyncio.Task)
     mock_task2.done.return_value = True  # Finished, should NOT be cancelled
+    task_mocks = iter([mock_task1, mock_task2])
+
+    def fake_create_task(coro):
+        coro.close()
+        return next(task_mocks)
 
     with contextlib.ExitStack() as stack:
         stack.enter_context(
-            mock.patch("asyncio.create_task", side_effect=[mock_task1, mock_task2])
+            mock.patch("asyncio.create_task", side_effect=fake_create_task)
         )
         mock_gather = stack.enter_context(
             mock.patch("asyncio.gather", new_callable=mock.AsyncMock)
@@ -1485,7 +1510,7 @@ async def test_concurrent_mrd_fetch_base_exception_cancellation(extended_gcsfs):
 
         with pytest.raises(KeyboardInterrupt):
             await extended_gcsfs._concurrent_mrd_fetch(
-                offset=0, length=1024, concurrency=2, mrd_or_pool=mock_pool
+                offset=0, length=2, concurrency=2, mrd_or_pool=mock_pool
             )
 
         # Assert exactly the logic: if not t.done(): t.cancel()


### PR DESCRIPTION
### Problem
When performing concurrent downloads (`_cat_file_concurrent` in `core.py` and `_concurrent_mrd_fetch` in `extended_gcsfs.py`), the number of concurrent tasks was determined solely by the requested `concurrency` parameter, as long as the total read size exceeded `MIN_CHUNK_SIZE_FOR_CONCURRENCY`.

This led to **over-segmentation** when a high concurrency was requested for relatively small files. For example, if `MIN_CHUNK_SIZE_FOR_CONCURRENCY` is 5MB, and a user tries to read a 6MB file with `concurrency=100`, the file would be split into 100 chunks of 60KB each. Spawning 100 concurrent tasks for such small chunks is highly inefficient due to:
1. High overhead of creating and managing many asyncio tasks.
2. The latency of making many small HTTP requests to GCS, which performs worse than fewer, larger requests.

### Solution
Introduced a helper function `split_range(size, concurrency, min_chunk_size)` that calculates the optimal number of chunks and their ranges. It caps the number of chunks (and thus concurrent tasks) to `ceil(size / min_chunk_size)`. This ensures that we only scale concurrency when the file size warrants it, maintaining a reasonable chunk size per task.

### Changes
1. **`gcsfs/concurrency.py`**: Added the `split_range` utility function to safely partition byte ranges based on concurrency and minimum chunk size.
2. **`gcsfs/core.py`**: Updated `_cat_file_concurrent` to use `split_range`. If the helper determines only one chunk is needed, it cleanly falls back to the sequential download path.
3. **`gcsfs/extended_gcsfs.py`**: Updated `_concurrent_mrd_fetch` to use `split_range` for chunk partitioning, and simplified `_cat_file` by delegating the threshold logic to the fetcher.
4. **Tests**: 
   - Added unit tests for `split_range` covering various edge cases (zero size, small sizes, high concurrency).
   - Updated and added tests in `test_core.py` and `test_extended_gcsfs.py` to verify that concurrent download paths respect the capped concurrency and do not spawn excessive tasks.