### PR TITLE
macrobenchmarks: Parameterize training strategy and simulated step compute; generalize requirements

### DIFF
--- a/cloudbuild/macrobenchmarks/macrobenchmarks-cloudbuild.yaml
+++ b/cloudbuild/macrobenchmarks/macrobenchmarks-cloudbuild.yaml
@@ -14,7 +14,9 @@ substitutions:
   # Empty (default) = fresh run, no restore. Must point at a checkpoint that
   # outlives the run (e.g. a seeded bucket), not the per-run ephemeral one.
   _CHECKPOINT_LOAD_PATH: ""
-  _GCSFS_SOURCE: ""
+  _REQUIREMENTS: ""
+  _TRAINING_STRATEGY: "ddp"
+  _SIMULATED_STEP_COMPUTE_SECONDS: "1.0"
   _JOBSET_VERSION: "v0.12.0"
   _SKIP_CLEANUP: "false"
 
@@ -33,13 +35,15 @@ steps:
       - "_ZONE=${_ZONE}"
       - "_GKE_SERVICE_ACCOUNT=${_GKE_SERVICE_ACCOUNT}"
       - "_DATASET_PATH=${_DATASET_PATH}"
-      - "_GCSFS_SOURCE=${_GCSFS_SOURCE}"
+      - "_REQUIREMENTS=${_REQUIREMENTS}"
       - "_BUCKET_TYPE=${_BUCKET_TYPE}"
       - "_NODES=${_NODES}"
       - "_STEPS=${_STEPS}"
       - "_CHECKPOINT_INTERVAL=${_CHECKPOINT_INTERVAL}"
       - "_CHECKPOINT_LOAD_PATH=${_CHECKPOINT_LOAD_PATH}"
       - "_MODEL_ID=${_MODEL_ID}"
+      - "_TRAINING_STRATEGY=${_TRAINING_STRATEGY}"
+      - "_SIMULATED_STEP_COMPUTE_SECONDS=${_SIMULATED_STEP_COMPUTE_SECONDS}"
     args: ["cloudbuild/macrobenchmarks/scripts/init_variables.sh"]
     waitFor: ["-"]
 
@@ -89,11 +93,13 @@ steps:
       - "_DATASET_PATH=${_DATASET_PATH}"
       - "_CHECKPOINT_LOAD_PATH=${_CHECKPOINT_LOAD_PATH}"
       - "_MODEL_ID=${_MODEL_ID}"
+      - "_TRAINING_STRATEGY=${_TRAINING_STRATEGY}"
+      - "_SIMULATED_STEP_COMPUTE_SECONDS=${_SIMULATED_STEP_COMPUTE_SECONDS}"
       - "_HF_TOKEN=${_HF_TOKEN}"
       - "_STEPS=${_STEPS}"
       - "_CHECKPOINT_INTERVAL=${_CHECKPOINT_INTERVAL}"
       - "_NODES=${_NODES}"
-      - "_GCSFS_SOURCE=${_GCSFS_SOURCE}"
+      - "_REQUIREMENTS=${_REQUIREMENTS}"
     args: ["cloudbuild/macrobenchmarks/scripts/run_workload.sh"]
     waitFor: ["create-cluster"]
 
@@ -107,12 +113,14 @@ steps:
       - "_CHECKPOINT_INTERVAL=${_CHECKPOINT_INTERVAL}"
       - "_CHECKPOINT_LOAD_PATH=${_CHECKPOINT_LOAD_PATH}"
       - "_WORKLOAD=${_WORKLOAD}"
-      - "_GCSFS_SOURCE=${_GCSFS_SOURCE}"
+      - "_REQUIREMENTS=${_REQUIREMENTS}"
       - "_BUCKET_TYPE=${_BUCKET_TYPE}"
       - "_ZONE=${_ZONE}"
       - "_NODES=${_NODES}"
       - "_DATASET_PATH=${_DATASET_PATH}"
       - "_MODEL_ID=${_MODEL_ID}"
+      - "_TRAINING_STRATEGY=${_TRAINING_STRATEGY}"
+      - "_SIMULATED_STEP_COMPUTE_SECONDS=${_SIMULATED_STEP_COMPUTE_SECONDS}"
     args: ["cloudbuild/macrobenchmarks/scripts/scrape_metrics.sh"]
     waitFor: ["run-workload"]
 

--- a/cloudbuild/macrobenchmarks/macrobenchmarks_schema.json
+++ b/cloudbuild/macrobenchmarks/macrobenchmarks_schema.json
@@ -10,7 +10,7 @@
     "fields": [
       {"name": "run_id", "type": "STRING", "description": "Cloud Build run id (prefixed buildid-)."},
       {"name": "workload_name", "type": "STRING", "description": "Benchmark workload name (e.g. hf-pytorch-lightning-cpu)."},
-      {"name": "gcsfs_source", "type": "STRING", "description": "gcsfs under test - a git ref or gcsfs==<version>."},
+      {"name": "requirements", "type": "STRING", "description": "Packages installed/overridden for the run -- git refs and/or pkg==<version> specs (e.g. gcsfs under test, a custom lightning build)."},
       {"name": "bucket_type", "type": "STRING", "description": "Storage tier of the run's buckets: regional, zonal (RAPID), or hns."},
       {"name": "zone", "type": "STRING", "description": "GCP zone the cluster and buckets ran in (e.g. us-central1-a)."},
       {"name": "region", "type": "STRING", "description": "GCP region derived from the zone (e.g. us-central1)."},
@@ -19,6 +19,8 @@
       {"name": "checkpoint_interval", "type": "INTEGER", "description": "Number of training steps between checkpoint writes."},
       {"name": "dataset_path", "type": "STRING", "description": "gs:// path of the training dataset (Parquet)."},
       {"name": "model_id", "type": "STRING", "description": "Model identifier or gs:// path of the model weights."},
+      {"name": "training_strategy", "type": "STRING", "description": "Parallel training strategy used for the run: ddp (fsdp is added by the FSDP branch)."},
+      {"name": "simulated_step_compute_seconds", "type": "FLOAT", "description": "Configured per-step simulated compute time in seconds (the training_step sleep standing in for GPU forward+backward)."},
       {"name": "mean_step_time", "type": "FLOAT", "description": "Mean per-step duration in seconds over all measured steps."},
       {"name": "stable_window_avg_step_time", "type": "FLOAT", "description": "Mean per-step duration in seconds over the stable window (after warmup steps)."},
       {"name": "stable_window_total_step_duration", "type": "FLOAT", "description": "Total wall-clock duration in seconds of the stable window."},

--- a/cloudbuild/macrobenchmarks/metrics/calculate.py
+++ b/cloudbuild/macrobenchmarks/metrics/calculate.py
@@ -172,7 +172,7 @@ def build_summary_row(
     *,
     run_id: str,
     workload_name: str,
-    gcsfs_source: str,
+    requirements: str,
     step_rows: list,
     write_rows: list,
     restore_rows: list,
@@ -183,7 +183,7 @@ def build_summary_row(
     row = {
         "run_id": run_id,
         "workload_name": workload_name,
-        "gcsfs_source": gcsfs_source,
+        "requirements": requirements,
     }
     if dimensions:
         row.update({k: v for k, v in dimensions.items() if v is not None})
@@ -292,7 +292,7 @@ def main(argv=None) -> None:
     )
     parser.add_argument("--run-id", required=True)
     parser.add_argument("--workload-name", required=True)
-    parser.add_argument("--gcsfs-source", required=True)
+    parser.add_argument("--requirements", required=True)
     parser.add_argument("--in-dir", required=True)
     parser.add_argument("--out-file", required=True)
     parser.add_argument("--run-type", default="perf_optimization")
@@ -318,6 +318,8 @@ def main(argv=None) -> None:
     parser.add_argument("--checkpoint-interval", type=int)
     parser.add_argument("--dataset-path")
     parser.add_argument("--model-id")
+    parser.add_argument("--training-strategy")
+    parser.add_argument("--simulated-step-compute-seconds", type=float)
     args = parser.parse_args(argv)
 
     tables = raw_store.read_raw_metrics(args.in_dir, run_type=args.run_type)
@@ -349,11 +351,13 @@ def main(argv=None) -> None:
         "checkpoint_interval": args.checkpoint_interval,
         "dataset_path": args.dataset_path,
         "model_id": args.model_id,
+        "training_strategy": args.training_strategy,
+        "simulated_step_compute_seconds": args.simulated_step_compute_seconds,
     }
     row = build_summary_row(
         run_id=args.run_id,
         workload_name=args.workload_name,
-        gcsfs_source=args.gcsfs_source,
+        requirements=args.requirements,
         step_rows=step_rows,
         write_rows=write_rows,
         restore_rows=restore_rows,

--- a/cloudbuild/macrobenchmarks/metrics/tests/test_calculate_summary.py
+++ b/cloudbuild/macrobenchmarks/metrics/tests/test_calculate_summary.py
@@ -54,7 +54,7 @@ def test_build_summary_row_keys_subset_of_fieldnames():
     row = calculate.build_summary_row(
         run_id="r",
         workload_name="hf-pytorch-lightning-cpu",
-        gcsfs_source="gcsfs==1.0",
+        requirements="gcsfs==1.0",
         step_rows=[{"step": 0, "step_duration": 1.0, "step_end_time": 1.0}],
         write_rows=[],
         restore_rows=[],
@@ -63,7 +63,7 @@ def test_build_summary_row_keys_subset_of_fieldnames():
     )
     assert row["run_id"] == "r"
     assert row["workload_name"] == "hf-pytorch-lightning-cpu"
-    assert row["gcsfs_source"] == "gcsfs==1.0"
+    assert row["requirements"] == "gcsfs==1.0"
     assert set(row).issubset(set(calculate.SUMMARY_FIELDNAMES))
 
 
@@ -82,7 +82,7 @@ def test_main_writes_one_row_summary(tmp_path):
             "r",
             "--workload-name",
             "hf-pytorch-lightning-cpu",
-            "--gcsfs-source",
+            "--requirements",
             "gcsfs==1.0",
             "--in-dir",
             str(in_dir),
@@ -110,7 +110,7 @@ def test_main_fails_when_required_step_metrics_are_missing(tmp_path):
                 "r",
                 "--workload-name",
                 "hf-pytorch-lightning-cpu",
-                "--gcsfs-source",
+                "--requirements",
                 "gcsfs==1.0",
                 "--in-dir",
                 str(tmp_path / "raw"),
@@ -140,7 +140,7 @@ def test_main_fails_when_required_write_metrics_are_missing(tmp_path):
                 "r",
                 "--workload-name",
                 "hf-pytorch-lightning-cpu",
-                "--gcsfs-source",
+                "--requirements",
                 "gcsfs==1.0",
                 "--in-dir",
                 str(in_dir),
@@ -271,7 +271,7 @@ def test_main_fails_when_required_data_loading_metrics_are_missing(tmp_path):
                 "r",
                 "--workload-name",
                 "hf-pytorch-lightning-cpu",
-                "--gcsfs-source",
+                "--requirements",
                 "gcsfs==1.0",
                 "--in-dir",
                 str(in_dir),
@@ -296,7 +296,7 @@ def test_main_fails_when_required_restore_metrics_are_missing(tmp_path):
                 "r",
                 "--workload-name",
                 "hf-pytorch-lightning-cpu",
-                "--gcsfs-source",
+                "--requirements",
                 "gcsfs==1.0",
                 "--in-dir",
                 str(in_dir),
@@ -322,7 +322,7 @@ def test_main_succeeds_when_required_restore_metrics_are_present(tmp_path):
             "r",
             "--workload-name",
             "hf-pytorch-lightning-cpu",
-            "--gcsfs-source",
+            "--requirements",
             "gcsfs==1.0",
             "--in-dir",
             str(in_dir),
@@ -351,7 +351,7 @@ def test_main_fails_when_data_loading_metrics_present_but_null(tmp_path):
                 "r",
                 "--workload-name",
                 "hf-pytorch-lightning-cpu",
-                "--gcsfs-source",
+                "--requirements",
                 "gcsfs==1.0",
                 "--in-dir",
                 str(in_dir),
@@ -375,7 +375,7 @@ def test_main_emits_run_dimension_columns(tmp_path):
             "r",
             "--workload-name",
             "hf-pytorch-lightning-cpu",
-            "--gcsfs-source",
+            "--requirements",
             "gcsfs==1.0",
             "--in-dir",
             str(in_dir),
@@ -412,6 +412,62 @@ def test_main_emits_run_dimension_columns(tmp_path):
     assert rows[0]["model_id"] == "gs://huggingface-model-weights/Llama-3.1-8B"
 
 
+def test_main_emits_training_strategy_column(tmp_path):
+    in_dir = tmp_path / "raw"
+    _write_step_csv(in_dir)
+    _write_data_loading_csv(in_dir)
+    out_file = tmp_path / "summary.csv"
+    calculate.main(
+        [
+            "--run-id",
+            "r",
+            "--workload-name",
+            "hf-pytorch-lightning-cpu",
+            "--requirements",
+            "gcsfs==1.0",
+            "--in-dir",
+            str(in_dir),
+            "--out-file",
+            str(out_file),
+            "--require-data-loading-metrics",
+            "--training-strategy",
+            "ddp",
+        ]
+    )
+    with open(out_file) as f:
+        rows = list(csv.DictReader(f))
+    assert rows[0]["training_strategy"] == "ddp"
+    assert "training_strategy" in calculate.SUMMARY_FIELDNAMES
+
+
+def test_main_emits_simulated_step_compute_seconds_column(tmp_path):
+    in_dir = tmp_path / "raw"
+    _write_step_csv(in_dir)
+    _write_data_loading_csv(in_dir)
+    out_file = tmp_path / "summary.csv"
+    calculate.main(
+        [
+            "--run-id",
+            "r",
+            "--workload-name",
+            "hf-pytorch-lightning-cpu",
+            "--requirements",
+            "gcsfs==1.0",
+            "--in-dir",
+            str(in_dir),
+            "--out-file",
+            str(out_file),
+            "--require-data-loading-metrics",
+            "--simulated-step-compute-seconds",
+            "2.5",
+        ]
+    )
+    with open(out_file) as f:
+        rows = list(csv.DictReader(f))
+    assert rows[0]["simulated_step_compute_seconds"] == "2.5"
+    assert "simulated_step_compute_seconds" in calculate.SUMMARY_FIELDNAMES
+
+
 def test_main_succeeds_with_required_data_loading_metrics(tmp_path):
     in_dir = tmp_path / "raw"
     _write_step_csv(in_dir)
@@ -423,7 +479,7 @@ def test_main_succeeds_with_required_data_loading_metrics(tmp_path):
             "r",
             "--workload-name",
             "hf-pytorch-lightning-cpu",
-            "--gcsfs-source",
+            "--requirements",
             "gcsfs==1.0",
             "--in-dir",
             str(in_dir),

--- a/cloudbuild/macrobenchmarks/scripts/init_variables.sh
+++ b/cloudbuild/macrobenchmarks/scripts/init_variables.sh
@@ -10,8 +10,8 @@ SAFE_BRANCH=$(echo -n "${BRANCH_NAME:-unknown}" | tr -c 'a-zA-Z0-9_.-' '-')
 if [ "${SAFE_BRANCH}" = "unknown" ]; then
   echo "ERROR: BRANCH_NAME unset."; exit 1
 fi
-if [ -z "${_INFRA_PREFIX}" ] || [ -z "${_ZONE}" ] || [ -z "${_GKE_SERVICE_ACCOUNT}" ] || [ -z "${_DATASET_PATH}" ] || [ -z "${_GCSFS_SOURCE}" ]; then
-  echo "ERROR: required substitution missing (_INFRA_PREFIX,_ZONE,_GKE_SERVICE_ACCOUNT,_DATASET_PATH,_GCSFS_SOURCE)."; exit 1
+if [ -z "${_INFRA_PREFIX}" ] || [ -z "${_ZONE}" ] || [ -z "${_GKE_SERVICE_ACCOUNT}" ] || [ -z "${_DATASET_PATH}" ] || [ -z "${_REQUIREMENTS}" ]; then
+  echo "ERROR: required substitution missing (_INFRA_PREFIX,_ZONE,_GKE_SERVICE_ACCOUNT,_DATASET_PATH,_REQUIREMENTS)."; exit 1
 fi
 # Validate config before provisioning anything: an unsupported _BUCKET_TYPE
 # silently skips checkpoint-bucket creation, and a non-positive _CHECKPOINT_INTERVAL
@@ -21,6 +21,15 @@ case "${_BUCKET_TYPE}" in
   regional|zonal|hns) ;;
   *) echo "ERROR: _BUCKET_TYPE must be regional|zonal|hns (got '${_BUCKET_TYPE}')."; exit 1 ;;
 esac
+# Reject an unknown parallel strategy before provisioning anything.
+case "${_TRAINING_STRATEGY:-ddp}" in
+  ddp) ;;
+  *) echo "ERROR: _TRAINING_STRATEGY must be ddp (got '${_TRAINING_STRATEGY}')."; exit 1 ;;
+esac
+# Reject a non-numeric / negative simulated compute time before provisioning.
+if ! echo "${_SIMULATED_STEP_COMPUTE_SECONDS:-1.0}" | grep -Eq '^[0-9]+(\.[0-9]+)?$'; then
+  echo "ERROR: _SIMULATED_STEP_COMPUTE_SECONDS must be a non-negative number (got '${_SIMULATED_STEP_COMPUTE_SECONDS}')."; exit 1
+fi
 # Reject malformed zones before anything keys off them.
 if ! echo "${_ZONE}" | grep -Eq '^[a-z]+-[a-z]+[0-9]-[a-z]$'; then
   echo "ERROR: _ZONE must be a GCP zone like us-central1-a (got '${_ZONE}')."; exit 1

--- a/cloudbuild/macrobenchmarks/scripts/run_workload.sh
+++ b/cloudbuild/macrobenchmarks/scripts/run_workload.sh
@@ -20,7 +20,9 @@ helm install "$RUN_ID" "$CHART" -f "$CHART/values_base.yaml" \
   --set workload.steps="${_STEPS}" \
   --set workload.ckptWriterInterval="${_CHECKPOINT_INTERVAL}" \
   --set workload.nodes="${_NODES}" \
-  --set workload.requirements="${_GCSFS_SOURCE}" \
+  --set workload.requirements="${_REQUIREMENTS}" \
+  --set workload.trainingStrategy="${_TRAINING_STRATEGY}" \
+  --set workload.simulatedStepComputeSeconds="${_SIMULATED_STEP_COMPUTE_SECONDS}" \
   --set serviceAccount=default
 echo "Waiting for JobSet $RUN_ID to complete..."
 WORKLOAD_COMPLETED=false

--- a/cloudbuild/macrobenchmarks/scripts/scrape_metrics.sh
+++ b/cloudbuild/macrobenchmarks/scripts/scrape_metrics.sh
@@ -54,7 +54,7 @@ for attempt in $(seq 1 5); do
   fi
   if python3 -m metrics.calculate \
       --run-id "$RUN_ID" --workload-name "${_WORKLOAD}" \
-      --gcsfs-source "${_GCSFS_SOURCE}" --in-dir "$RAW_DIR" --out-file "$SUMMARY" \
+      --requirements "${_REQUIREMENTS}" --in-dir "$RAW_DIR" --out-file "$SUMMARY" \
       --expected-steps "${_STEPS}" \
       --min-write-datapoints "$MIN_WRITE_DATAPOINTS" \
       --min-restore-datapoints "$MIN_RESTORE_DATAPOINTS" \
@@ -62,7 +62,9 @@ for attempt in $(seq 1 5); do
       --require-data-loading-metrics \
       --bucket-type "${_BUCKET_TYPE}" --zone "${_ZONE}" --region "$REGION" \
       --nodes "${_NODES}" --steps "${_STEPS}" --checkpoint-interval "${_CHECKPOINT_INTERVAL}" \
-      --dataset-path "${_DATASET_PATH}" --model-id "${_MODEL_ID}"; then
+      --dataset-path "${_DATASET_PATH}" --model-id "${_MODEL_ID}" \
+      --training-strategy "${_TRAINING_STRATEGY}" \
+      --simulated-step-compute-seconds "${_SIMULATED_STEP_COMPUTE_SECONDS}"; then
     SCRAPE_OK=true
     break
   fi

--- a/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/launcher.sh
+++ b/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/launcher.sh
@@ -71,9 +71,11 @@ pip3 install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu tor
 pip3 install --no-cache-dir -r /workload/configs/requirements.txt
 
 if [[ -n "${REQUIREMENTS:-}" ]]; then
-  # Optional escape hatch: REQUIREMENTS env var lets a run pull in extra
-  # packages or version overrides without rebuilding the image or editing
-  # requirements.txt. Word-split intentional.
+  # Optional escape hatch: REQUIREMENTS lets a run install/override arbitrary
+  # packages (the gcsfs under test and/or a custom lightning build, etc.)
+  # without rebuilding the image or editing requirements.txt. It runs AFTER
+  # requirements.txt, so a spec here overrides the pinned versions there.
+  # Word-split intentional.
   # shellcheck disable=SC2086
   pip3 install $REQUIREMENTS
 fi
@@ -91,6 +93,9 @@ echo "Launching Torch distributed as node rank $NODE_RANK out of $NNODES nodes"
 # pod regardless of the c4 host's underlying NIC name (ens4/etc.).
 export GLOO_SOCKET_IFNAME=${GLOO_SOCKET_IFNAME:-eth0}
 export TOKENIZERS_PARALLELISM=false
+
+# Parallel training strategy for cpu_sim.py (ddp default).
+export TRAINING_STRATEGY=${TRAINING_STRATEGY:-ddp}
 
 # Training parameters -- same defaults as a4_v1/launcher.sh so step time and
 # checkpoint cadence are directly comparable between the GPU and CPU runs.

--- a/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/llama_3_1_8b_cpu_sim.py
+++ b/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/llama_3_1_8b_cpu_sim.py
@@ -96,9 +96,7 @@ model_id = os.getenv("MODEL_ID", "meta-llama/Llama-3.1-8B")
 # (The ``fsdp`` strategy is added by the fsdp-cpu-macrobench branch.)
 training_strategy = os.getenv("TRAINING_STRATEGY", "ddp").lower()
 if training_strategy not in ("ddp",):
-    raise SystemExit(
-        f"TRAINING_STRATEGY must be 'ddp' (got {training_strategy!r})."
-    )
+    raise SystemExit(f"TRAINING_STRATEGY must be 'ddp' (got {training_strategy!r}).")
 # Parity with the model_id: line -- a single grep-able config marker per knob.
 logging.info("training_strategy: %s", training_strategy)
 

--- a/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/llama_3_1_8b_cpu_sim.py
+++ b/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/llama_3_1_8b_cpu_sim.py
@@ -3,7 +3,7 @@
 Reproduces the GCS IO pattern (N_NODES x 8 ranks x 16 dataloader workers,
 periodic checkpoint writes of the full bf16 8B state dict) without GPUs. The
 real Llama model is loaded and held frozen so checkpoint file sizes match
-production; GPU compute is replaced by ``time.sleep(SIMULATED_STEP_SECONDS)``
+production; GPU compute is replaced by ``time.sleep(SIMULATED_STEP_COMPUTE_SECONDS)``
 in ``training_step``.
 
 Single-node launch (smoke test):
@@ -71,8 +71,13 @@ logging.basicConfig(
 )
 
 # ---- Simulated compute ----------------------------------------------------
-# Hardcoded per design: replaces GPU forward+backward in training_step.
-SIMULATED_STEP_SECONDS = 1.0
+# Per-step stand-in for GPU forward+backward in training_step. Configurable via
+# SIMULATED_STEP_COMPUTE_SECONDS (default 1.0) and recorded in the run summary.
+SIMULATED_STEP_COMPUTE_SECONDS = float(
+    os.getenv("SIMULATED_STEP_COMPUTE_SECONDS", "1.0")
+)
+# Single grep-able config marker per knob (parity with the model_id: line).
+logging.info("simulated_step_compute_seconds: %s", SIMULATED_STEP_COMPUTE_SECONDS)
 
 # ---- Config (env-overridable, mirrors original script's pattern) ----------
 preset_max_steps = int(os.getenv("MAX_STEPS", "1000"))
@@ -84,6 +89,18 @@ checkpoint_write_interval = int(os.getenv("CHECKPOINT_WRITE_INTERVAL", "25"))
 checkpoint_write_interval = min(checkpoint_write_interval, preset_max_steps)
 checkpoints_to_keep = int(os.getenv("CKPT_TO_KEEP", "1"))
 model_id = os.getenv("MODEL_ID", "meta-llama/Llama-3.1-8B")
+
+# Parallel training strategy. ``ddp`` (default) replicates the frozen model on
+# every rank and rank 0 writes the full checkpoint. Validate eagerly -- before
+# the 16 GB model load -- so a typo fails fast instead of after a long download.
+# (The ``fsdp`` strategy is added by the fsdp-cpu-macrobench branch.)
+training_strategy = os.getenv("TRAINING_STRATEGY", "ddp").lower()
+if training_strategy not in ("ddp",):
+    raise SystemExit(
+        f"TRAINING_STRATEGY must be 'ddp' (got {training_strategy!r})."
+    )
+# Parity with the model_id: line -- a single grep-able config marker per knob.
+logging.info("training_strategy: %s", training_strategy)
 
 # Map model_id to the canonical id and log it as ``model_id: <id>``.
 # NOTE: this macrobenchmarks pipeline does NOT consume this line -- it derives
@@ -190,7 +207,7 @@ class LlamaLitModel(pl.LightningModule):
     runs a fake forward via a tiny trainable Linear so DDP all-reduce has
     something to sync without paying 8B-param collective costs.
 
-    ``training_step`` sleeps for ``SIMULATED_STEP_SECONDS`` to mimic the time
+    ``training_step`` sleeps for ``SIMULATED_STEP_COMPUTE_SECONDS`` to mimic the time
     a GPU step would take. ``self.model``'s parameters end up in the
     Lightning state_dict, and AdamW is configured over ``self.model`` with
     materialized optimizer state. When ``ModelCheckpoint`` writes via fsspec
@@ -211,7 +228,7 @@ class LlamaLitModel(pl.LightningModule):
         # GCS read traffic we are benchmarking. The batch contents are then
         # ignored; we sleep to simulate GPU compute.
         del batch
-        time.sleep(SIMULATED_STEP_SECONDS)
+        time.sleep(SIMULATED_STEP_COMPUTE_SECONDS)
         # Real loss with a real grad path so backward + DDP all-reduce run.
         # Squared so the loss is always non-negative: the metrics pipeline's
         # step-metrics regex matches "Loss: [0-9.]+" (no leading '-'), so a
@@ -373,6 +390,26 @@ class LoggedDDPStrategy(DDPStrategy):
         return checkpoint
 
 
+def build_strategy(name):
+    """Construct the parallel-training strategy for ``name`` (currently ddp).
+
+    Uses the gloo CPU backend and a 600s collective timeout so a stuck rank
+    surfaces a Gloo timeout (which names the missing rank) within ~10 min
+    instead of hanging. (The ``fsdp`` branch is added by fsdp-cpu-macrobench.)
+    """
+    timeout = timedelta(seconds=600)
+    if name == "ddp":
+        # find_unused_parameters=False: the frozen Llama params have
+        # requires_grad=False, so only self.trainable participates in DDP
+        # autograd, and it is fully used -- no unused parameters.
+        return LoggedDDPStrategy(
+            timeout=timeout,
+            process_group_backend="gloo",
+            find_unused_parameters=False,
+        )
+    raise SystemExit(f"Unsupported TRAINING_STRATEGY: {name!r} (use ddp).")
+
+
 if __name__ == "__main__":
     # ---- Verify gcsfs is the active fsspec backend for "gs" ----------------
     # Matches the original benchmark's startup self-check; keeps the same log
@@ -442,19 +479,11 @@ if __name__ == "__main__":
     callbacks.append(StepTimeCallback())
 
     # ---- Strategy: DDP on CPU via gloo --------------------------------------
-    # We set find_unused_parameters=False because the frozen Llama params have
-    # requires_grad=False, meaning only self.trainable participates in DDP
-    # autograd. Since self.trainable is fully used in the training step, there
-    # are no unused parameters.
-    strategy = LoggedDDPStrategy(
-        # 600s (was 7200s): a stuck rank should surface a Gloo collective
-        # timeout -- which names the missing rank -- within ~10 min instead of
-        # hanging for 2h. Comfortably above the worst-case first-batch latency
-        # (DataLoader worker cold start + initial GCS streaming reads).
-        timeout=timedelta(seconds=600),
-        process_group_backend="gloo",
-        find_unused_parameters=False,
-    )
+    # Selected by TRAINING_STRATEGY (default ddp). The 600s collective timeout
+    # surfaces a stuck rank (which Gloo names) within ~10 min instead of
+    # hanging; it is comfortably above the worst-case first-batch latency
+    # (DataLoader worker cold start + initial GCS streaming reads).
+    strategy = build_strategy(training_strategy)
 
     # ---- Trainer ------------------------------------------------------------
     # accelerator="cpu" + devices=local_world_size dynamically matches the

--- a/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/templates/workload-job.yaml
+++ b/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/templates/workload-job.yaml
@@ -105,6 +105,10 @@ spec:
                 value: "{{ $root.Values.workload.ckptToKeep }}"
               - name: MODEL_ID
                 value: "{{ $root.Values.workload.modelId }}"
+              - name: TRAINING_STRATEGY
+                value: "{{ $root.Values.workload.trainingStrategy }}"
+              - name: SIMULATED_STEP_COMPUTE_SECONDS
+                value: "{{ $root.Values.workload.simulatedStepComputeSeconds }}"
               - name: REQUIREMENTS
                 value: "{{ $root.Values.workload.requirements }}"
               {{- if $root.Values.workload.envs }}

--- a/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/values_base.yaml
+++ b/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/values_base.yaml
@@ -21,7 +21,13 @@ workload:
   ckptWriterInterval: 25
   ckptToKeep: 1
   modelId: "gs://huggingface-model-weights/Llama-3.1-8B"
-  # gcsfs-under-test (git ref or gcsfs==<version>); fed to launcher REQUIREMENTS.
+  # Parallel training strategy: ddp (fsdp is enabled by the FSDP branch).
+  trainingStrategy: ddp
+  # Per-step simulated compute time in seconds (stands in for GPU compute).
+  simulatedStepComputeSeconds: 1.0
+  # Packages installed/overridden for the run (gcsfs under test and/or a custom
+  # lightning build, etc.); fed to the launcher REQUIREMENTS install (runs last,
+  # so it overrides requirements.txt pins).
   requirements:
   envs:
     - name: GLOO_SOCKET_IFNAME


### PR DESCRIPTION
- Rename `--gcsfs-source` (and `_GCSFS_SOURCE` / `gcsfs_source`) to `--requirements` (and `_REQUIREMENTS` / `requirements`) to support arbitrary pip package installations and overrides (e.g. custom PyTorch Lightning builds) in the launcher.
- Introduce `TRAINING_STRATEGY` parameter (defaulting to "ddp") to configure the parallel training strategy. This includes eager validation in scripts and `llama_3_1_8b_cpu_sim.py`, and dynamically building the PyTorch Lightning strategy object.
- Parameterize simulated step compute time using `SIMULATED_STEP_COMPUTE_SECONDS` (defaulting to 1.0s) instead of hardcoding it as `SIMULATED_STEP_SECONDS`.
- Add validation, Helm values propagation, metrics scraping, schema fields, and unit tests for both `training_strategy` and `simulated_step_compute_seconds`.