### PR TITLE
Use memoryview to enable zero-copy in _pipe_file

### DIFF
--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -1572,8 +1572,9 @@ class ExtendedGcsFileSystem(HnsDirCacheUpdater, GCSFileSystem):
         # Works for both 'overwrite' and 'create' modes
         writer = await zb_hns_utils.init_aaow(self.grpc_client, bucket, key)
         try:
-            for i in range(0, len(data), chunksize):
-                await writer.append(data[i : i + chunksize])
+            with memoryview(data) as data_view:
+                for i in range(0, len(data_view), chunksize):
+                    await writer.append(data_view[i : i + chunksize])
         finally:
             finalize_on_close = kwargs.get("finalize_on_close", self.finalize_on_close)
             await zb_hns_utils.close_aaow(writer, finalize_on_close=finalize_on_close)


### PR DESCRIPTION
This commit wraps the input `data` in a `memoryview` before slicing. Slicing a `memoryview` returns a zero-copy sub-view of the underlying buffer, which is natively and efficiently accepted by `AsyncAppendableObjectWriter.append` .

## Benchmark

* **File Size**: 2 GB
* **Chunk Size**: 50 MiB
* **Rounds**: 3
* **Concurrency**: 1 process, 1 thread

### Performance Comparison

| Metric | Before (Unoptimized) | After (memoryview Zero-Copy) | Impact / Improvement |
| :--- | :---: | :---: | :---: |
| **Mean Latency (s)** | `8.6438` s | `7.8415` s | **-9.28%** |
| **Mean Throughput (MiB/s)** | `236.93` MiB/s | `261.18` MiB/s | **+10.24%** |
| **Max CPU (%)** | `1.81` % | `0.88` % | **-51.38%** |
| **Max Memory (MiB)** | `2296.23` MiB | `2296.78` MiB | Negligible |