### PR TITLE
Fix root cache invalidation

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -929,7 +929,8 @@ class GCSFileSystem(DirCacheUpdater, asyn.AsyncFileSystem):
             self.dircache.clear()
         else:
             path = self._strip_protocol(path).rstrip("/")
-
+            if not path:
+                self.dircache.pop("", None)
             while path:
                 self.dircache.pop(path, None)
                 path = self._parent(path)
@@ -1023,6 +1024,7 @@ class GCSFileSystem(DirCacheUpdater, asyn.AsyncFileSystem):
             json_out=True,
         )
         self.invalidate_cache(bucket)
+        self.invalidate_cache("")
 
     mkdir = asyn.sync_wrapper(_mkdir)
 

--- a/gcsfs/tests/test_dircache.py
+++ b/gcsfs/tests/test_dircache.py
@@ -116,3 +116,39 @@ class TestDirCacheUpdaterMv:
 
         assert src_parent not in fs.dircache
         assert dst_parent not in fs.dircache
+
+
+class TestDirCacheUpdaterMkdirRmdir:
+    @pytest.mark.asyncio
+    async def test_mkdir_invalidates_root_cache(self):
+        fs = _fs()
+        # Seed the root cache (list of buckets)
+        fs.dircache[""] = [{"name": "bucket1", "type": "directory"}]
+
+        # Mock _call to prevent actual network requests
+        async def mock_call(*args, **kwargs):
+            return {"name": "new-bucket"}
+
+        fs._call = mock_call
+
+        await fs._mkdir("new-bucket")
+
+        # The root cache must be invalidated because a new bucket was created
+        assert "" not in fs.dircache
+
+    @pytest.mark.asyncio
+    async def test_rmdir_invalidates_root_cache(self):
+        fs = _fs()
+        # Seed the root cache (list of buckets)
+        fs.dircache[""] = [{"name": "bucket1", "type": "directory"}]
+
+        # Mock _call to prevent actual network requests
+        async def mock_call(*args, **kwargs):
+            return {}
+
+        fs._call = mock_call
+
+        await fs._rmdir("bucket1")
+
+        # The root cache must be invalidated because a bucket was removed
+        assert "" not in fs.dircache


### PR DESCRIPTION
This PR fixes a cache consistency issue where the root directory cache (`self.dircache[""]`), which stores the list of all buckets, is not correctly invalidated when buckets are created or deleted. This leads to stale listings when calling `fs.ls("")` until the cache naturally expires.
