### PR TITLE
Fix ValueError message for invalid access in GCSFileSystem

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -336,7 +336,7 @@ class GCSFileSystem(DirCacheUpdater, asyn.AsyncFileSystem):
             **kwargs,
         )
         if access not in self.scopes:
-            raise ValueError("access must be one of {}", self.scopes)
+            raise ValueError(f"access must be one of {self.scopes}")
         if project is None:
             warnings.warn("GCS project not set - cannot list or create buckets")
         if block_size is not None:

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -52,6 +52,16 @@ def test_simple(gcs, monkeypatch):
     gcs.ls("/" + TEST_BUCKET)  # OK to lead with '/'
 
 
+def test_gcs_init_invalid_access():
+    with pytest.raises(ValueError) as excinfo:
+        GCSFileSystem(access="invalid_access_value", token="anon")
+    msg = str(excinfo.value)
+    assert msg.startswith("access must be one of {")
+    assert msg.endswith("}")
+    for scope in GCSFileSystem.scopes:
+        assert f"'{scope}'" in msg or f'"{scope}"' in msg
+
+
 def test_exists(gcs):
     # Existing file
     fn = TEST_BUCKET + "/nested/file1"


### PR DESCRIPTION
Corrects a bug in `GCSFileSystem.__init__` where the ValueError message raised  for an invalid access scope was not formatted properly (printing a literal '{}' instead of the actual scopes). Switched the exception to use a Python f-string.