### PR TITLE
Track whether cache_type is explicitly set or defaulting in User-Agent header

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -181,6 +181,18 @@ def _is_directory_marker(entry):
     return entry["size"] == 0 and entry["name"].endswith("/")
 
 
+def _get_cache_type_header_value(cache_type, cache_source=None):
+    """Format cache_type and cache_source into a User-Agent header value."""
+    if not cache_type:
+        return ""
+    suffix = ""
+    if cache_source == "explicit":
+        suffix = ":e"
+    elif cache_source == "default":
+        suffix = ":d"
+    return f"cache_type/{cache_type}{suffix}"
+
+
 class GCSFileSystem(DirCacheUpdater, asyn.AsyncFileSystem):
     r"""
     Connect to Google Cloud Storage.
@@ -475,13 +487,9 @@ class GCSFileSystem(DirCacheUpdater, asyn.AsyncFileSystem):
             out.update(headers)
         if "User-Agent" not in out:
             ua = "python-gcsfs/" + version
-            if cache_type:
-                suffix = ""
-                if cache_source == "explicit":
-                    suffix = ":e"
-                elif cache_source == "default":
-                    suffix = ":d"
-                ua += f" cache_type/{cache_type}{suffix}"
+            cache_val = _get_cache_type_header_value(cache_type, cache_source)
+            if cache_val:
+                ua += f" {cache_val}"
             out["User-Agent"] = ua
         self.credentials.apply(out)
         return out

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -469,14 +469,19 @@ class GCSFileSystem(DirCacheUpdater, asyn.AsyncFileSystem):
             params["userProject"] = user_project
         return params
 
-    def _get_headers(self, headers, cache_type=None):
+    def _get_headers(self, headers, cache_type=None, cache_source=None):
         out = {}
         if headers is not None:
             out.update(headers)
         if "User-Agent" not in out:
             ua = "python-gcsfs/" + version
             if cache_type:
-                ua += f" cache_type/{cache_type}"
+                suffix = ""
+                if cache_source == "explicit":
+                    suffix = ":e"
+                elif cache_source == "default":
+                    suffix = ":d"
+                ua += f" cache_type/{cache_type}{suffix}"
             out["User-Agent"] = ua
         self.credentials.apply(out)
         return out
@@ -499,6 +504,7 @@ class GCSFileSystem(DirCacheUpdater, asyn.AsyncFileSystem):
         json=None,
         data=None,
         cache_type=None,
+        cache_source=None,
         **kwargs,
     ):
         await self._set_session()
@@ -509,7 +515,9 @@ class GCSFileSystem(DirCacheUpdater, asyn.AsyncFileSystem):
             url=self._format_path(path, args),
             params=self._get_params(kwargs),
             json=json,
-            headers=self._get_headers(headers, cache_type=cache_type),
+            headers=self._get_headers(
+                headers, cache_type=cache_type, cache_source=cache_source
+            ),
             data=data,
             timeout=self.requests_timeout,
         ) as r:
@@ -1214,7 +1222,10 @@ class GCSFileSystem(DirCacheUpdater, asyn.AsyncFileSystem):
             head = {}
 
         cache_type = kwargs.get("cache_type")
-        headers, out = await self._call("GET", u2, headers=head, cache_type=cache_type)
+        cache_source = kwargs.get("cache_source")
+        headers, out = await self._call(
+            "GET", u2, headers=head, cache_type=cache_type, cache_source=cache_source
+        )
         return out
 
     async def _cat_file_concurrent(
@@ -2309,16 +2320,22 @@ GoogleCredentials.load_tokens()
 
 def _get_prefetcher_and_cache_config(cache_type, kwargs):
     """
-    Resolves effective cache_type and whether prefetch reader should be enabled.
+    Resolves effective cache_type, whether prefetch reader should be enabled,
+    and cache_source ("explicit" vs "default").
 
     Rules:
-    - If user explicitly sets cache_type (cache_type is not None), prefetcher is disabled and cache_type is used.
-    - If cache_type is None and prefetcher is enabled (default), cache_type is "none" and prefetcher is active.
-    - If cache_type is None and prefetcher is disabled, fallback to default_cache_type.
+    - If user explicitly sets cache_type (cache_type is not None), prefetcher is disabled,
+      cache_type is used, and cache_source is "explicit".
+    - If cache_type is None and prefetcher is enabled (default), cache_type is "none",
+      prefetcher is active, and cache_source is "default".
+    - If cache_type is None and prefetcher is disabled, fallback to default_cache_type ("readahead"),
+      and cache_source is "default".
     """
     if cache_type is not None:
         use_prefetch_reader = False
+        cache_source = "explicit"
     else:
+        cache_source = "default"
         if "use_experimental_adaptive_prefetching" in kwargs:
             val = kwargs["use_experimental_adaptive_prefetching"]
             use_prefetch_reader = (
@@ -2332,7 +2349,7 @@ def _get_prefetcher_and_cache_config(cache_type, kwargs):
                 "1",
             )
         cache_type = "none" if use_prefetch_reader else "readahead"
-    return cache_type, use_prefetch_reader
+    return cache_type, use_prefetch_reader, cache_source
 
 
 class GCSFile(fsspec.spec.AbstractBufferedFile):
@@ -2406,8 +2423,8 @@ class GCSFile(fsspec.spec.AbstractBufferedFile):
             raise OSError("Attempt to open a bucket")
         self.generation = _coalesce_generation(generation, path_generation)
         self.concurrency = kwargs.get("concurrency", DEFAULT_CONCURRENCY)
-        cache_type, use_prefetch_reader = _get_prefetcher_and_cache_config(
-            cache_type, kwargs
+        cache_type, use_prefetch_reader, self.cache_source = (
+            _get_prefetcher_and_cache_config(cache_type, kwargs)
         )
 
         super().__init__(
@@ -2640,6 +2657,7 @@ class GCSFile(fsspec.spec.AbstractBufferedFile):
                 end=end,
                 concurrency=self.concurrency,
                 cache_type=self.cache_type,
+                cache_source=self.cache_source,
             )
         except RuntimeError as e:
             if "not satisfiable" in str(e):
@@ -2654,6 +2672,7 @@ class GCSFile(fsspec.spec.AbstractBufferedFile):
             end=start_offset + total_size,
             concurrency=split_factor,
             cache_type=self.cache_type,
+            cache_source=self.cache_source,
         )
 
     def close(self):

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -2818,36 +2818,42 @@ def test_gcsfile_prefetch_and_cache_type_rules(gcs):
     fn = f"{TEST_BUCKET}/cache_rules.txt"
     gcs.pipe(fn, b"HelloWorld")
 
-    # 1. Default: cache_type is not set -> prefetcher active, cache_type is "none"
+    # 1. Default: cache_type is not set -> prefetcher active, cache_type is "none", cache_source is "default"
     with gcs.open(fn, "rb") as f:
         assert getattr(f, "_prefetch_engine", None) is not None
         assert f.cache_type == "none"
+        assert f.cache_source == "default"
         assert f.read() == b"HelloWorld"
 
-    # 2. Prefetcher disabled, no cache_type set -> no prefetcher, cache_type falls back to "readahead"
+    # 2. Prefetcher disabled, no cache_type set -> no prefetcher, cache_type falls back to "readahead",
+    # cache_source is "default"
     with gcs.open(fn, "rb", use_experimental_adaptive_prefetching=False) as f:
         assert getattr(f, "_prefetch_engine", None) is None
         assert f.cache_type == "readahead"
+        assert f.cache_source == "default"
         assert f.read() == b"HelloWorld"
 
-    # 3. User sets cache_type="readahead" -> prefetcher NOT used, cache_type is "readahead"
+    # 3. User sets cache_type="readahead" -> prefetcher NOT used, cache_type is "readahead", cache_source is "explicit"
     with gcs.open(fn, "rb", cache_type="readahead") as f:
         assert getattr(f, "_prefetch_engine", None) is None
         assert f.cache_type == "readahead"
+        assert f.cache_source == "explicit"
         assert f.read() == b"HelloWorld"
 
-    # 4. User sets cache_type="readahead" even with prefetcher=True -> prefetcher NOT used
+    # 4. User sets cache_type="readahead" even with prefetcher=True -> prefetcher NOT used, cache_source is "explicit"
     with gcs.open(
         fn, "rb", cache_type="readahead", use_experimental_adaptive_prefetching=True
     ) as f:
         assert getattr(f, "_prefetch_engine", None) is None
         assert f.cache_type == "readahead"
+        assert f.cache_source == "explicit"
         assert f.read() == b"HelloWorld"
 
-    # 5. User explicitly sets cache_type="none" -> prefetcher NOT used
+    # 5. User explicitly sets cache_type="none" -> prefetcher NOT used, cache_source is "explicit"
     with gcs.open(fn, "rb", cache_type="none") as f:
         assert getattr(f, "_prefetch_engine", None) is None
         assert f.cache_type == "none"
+        assert f.cache_source == "explicit"
         assert f.read() == b"HelloWorld"
 
 
@@ -3580,9 +3586,23 @@ def test_file_url_generation():
 
 def test_get_headers_includes_cache_type(gcs):
     # Test that _get_headers correctly appends cache_type to User-Agent
-    headers = gcs._get_headers(None, cache_type="test_cache")
-    assert "cache_type/test_cache" in headers["User-Agent"]
-    assert "python-gcsfs/" in headers["User-Agent"]
+    headers_explicit = gcs._get_headers(
+        None, cache_type="test_cache", cache_source="explicit"
+    )
+    assert "cache_type/test_cache:e" in headers_explicit["User-Agent"]
+    assert "python-gcsfs/" in headers_explicit["User-Agent"]
+
+    headers_default = gcs._get_headers(
+        None, cache_type="test_cache", cache_source="default"
+    )
+    assert "cache_type/test_cache:d" in headers_default["User-Agent"]
+
+    headers_plain = gcs._get_headers(None, cache_type="test_cache")
+    assert "cache_type/test_cache" in headers_plain["User-Agent"]
+    assert (
+        ":e" not in headers_plain["User-Agent"]
+        and ":d" not in headers_plain["User-Agent"]
+    )
 
     # Test that it doesn't append if cache_type is None
     headers_none = gcs._get_headers(None, cache_type=None)
@@ -3591,12 +3611,12 @@ def test_get_headers_includes_cache_type(gcs):
 
     # Test that it doesn't override if User-Agent is already present
     headers_preset = gcs._get_headers(
-        {"User-Agent": "custom-ua"}, cache_type="test_cache"
+        {"User-Agent": "custom-ua"}, cache_type="test_cache", cache_source="explicit"
     )
     assert headers_preset["User-Agent"] == "custom-ua"
 
 
-def test_user_agent_includes_cache_type_in_read(gcs):
+def test_user_agent_includes_cache_type_and_source_in_read(gcs):
     # TODO(lankita): Remove this skip when User-Agent is updated to include cache_type for gRPC/rapid buckets.
     # Zonal buckets currently use the gRPC path which does not use the HTTP client.
     if hasattr(gcs, "_is_zonal_bucket") and sync(
@@ -3606,6 +3626,7 @@ def test_user_agent_includes_cache_type_in_read(gcs):
 
     fn = TEST_BUCKET + "/2014-01-01.csv"
 
+    # 1. Explicit cache_type="mmap" -> User-Agent contains cache_type/mmap:e
     with mock.patch.object(
         gcs.session, "request", wraps=gcs.session.request
     ) as mock_session_request:
@@ -3618,10 +3639,48 @@ def test_user_agent_includes_cache_type_in_read(gcs):
                 out.append(data)
             assert gcs.cat(fn) == b"".join(out)
 
-        # Verify that the user-agent header has cache_type
         user_agents = [
             call.kwargs.get("headers", {}).get("User-Agent")
             for call in mock_session_request.call_args_list
         ]
-        expected_ua = f"python-gcsfs/{version} cache_type/mmap"
+        expected_ua = f"python-gcsfs/{version} cache_type/mmap:e"
         assert expected_ua in user_agents
+
+    # 2. Default open (prefetcher active) -> User-Agent contains cache_type/none:d
+    with mock.patch.object(
+        gcs.session, "request", wraps=gcs.session.request
+    ) as mock_session_request:
+        with gcs.open(fn, "rb") as f:
+            _ = f.read(10)
+
+        user_agents = [
+            call.kwargs.get("headers", {}).get("User-Agent", "")
+            for call in mock_session_request.call_args_list
+        ]
+        assert any("cache_type/none:d" in ua for ua in user_agents)
+
+    # 3. Explicit cache_type="none" -> User-Agent contains cache_type/none:e
+    with mock.patch.object(
+        gcs.session, "request", wraps=gcs.session.request
+    ) as mock_session_request:
+        with gcs.open(fn, "rb", cache_type="none") as f:
+            _ = f.read(10)
+
+        user_agents = [
+            call.kwargs.get("headers", {}).get("User-Agent", "")
+            for call in mock_session_request.call_args_list
+        ]
+        assert any("cache_type/none:e" in ua for ua in user_agents)
+
+    # 4. Prefetcher disabled fallback -> User-Agent contains cache_type/readahead:d
+    with mock.patch.object(
+        gcs.session, "request", wraps=gcs.session.request
+    ) as mock_session_request:
+        with gcs.open(fn, "rb", use_experimental_adaptive_prefetching=False) as f:
+            _ = f.read(10)
+
+        user_agents = [
+            call.kwargs.get("headers", {}).get("User-Agent", "")
+            for call in mock_session_request.call_args_list
+        ]
+        assert any("cache_type/readahead:d" in ua for ua in user_agents)

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -3584,6 +3584,32 @@ def test_file_url_generation():
         f.closed = True
 
 
+def test_get_cache_type_header_value():
+    from gcsfs.core import _get_cache_type_header_value
+
+    # Explicit source
+    assert _get_cache_type_header_value("none", "explicit") == "cache_type/none:e"
+    assert (
+        _get_cache_type_header_value("readahead", "explicit")
+        == "cache_type/readahead:e"
+    )
+    assert _get_cache_type_header_value("mmap", "explicit") == "cache_type/mmap:e"
+
+    # Default source
+    assert _get_cache_type_header_value("none", "default") == "cache_type/none:d"
+    assert (
+        _get_cache_type_header_value("readahead", "default") == "cache_type/readahead:d"
+    )
+
+    # Unspecified / None source (backward compatibility)
+    assert _get_cache_type_header_value("mmap", None) == "cache_type/mmap"
+
+    # None or empty cache_type
+    assert _get_cache_type_header_value(None, "explicit") == ""
+    assert _get_cache_type_header_value("", "explicit") == ""
+    assert _get_cache_type_header_value(None) == ""
+
+
 def test_get_headers_includes_cache_type(gcs):
     # Test that _get_headers correctly appends cache_type to User-Agent
     headers_explicit = gcs._get_headers(


### PR DESCRIPTION
### Summary of Changes

This PR adds tracking for whether `cache_type` was explicitly configured by the user or assigned as a default/fallback, differentiating them in the HTTP `User-Agent` header.

#### 1. Background & Problem
Previously, `gcsfs` emitted `cache_type/<type>` in the `User-Agent` header. With the introduction of the default adaptive prefetcher (which sets `cache_type="none"`), `cache_type/none` was emitted in two opposite scenarios:
- **Default (Prefetcher Enabled)**: User left `cache_type=None`.
- **Explicit Unbuffered (Prefetcher Disabled)**: User explicitly specified `cache_type="none"`.

Similarly, `cache_type/readahead` was emitted for both explicit `cache_type="readahead"" and when falling back because prefetching was disabled.

#### 2. Solution
- Track `cache_source` (`"explicit"` vs `"default"`) internally in `_get_prefetcher_and_cache_config` and `GCSFile`.
- In `_get_headers`, append `:e` for explicit cache configurations and `:d` for defaults:
  - Default open (`open(fn, "rb")`): `cache_type/none:d`
  - Explicit none (`open(fn, "rb", cache_type="none")`): `cache_type/none:e`
  - Explicit readahead (`open(fn, "rb", cache_type="readahead")`): `cache_type/readahead:e`
  - Fallback readahead (`open(fn, "rb", use_experimental_adaptive_prefetching=False)`): `cache_type/readahead:d`
  - Explicit custom (`open(fn, "rb", cache_type="mmap")`): `cache_type/mmap:e`
- Pass `cache_type` and `cache_source` through `_cat_file_sequential`, `_request`, and `_get_headers`.

#### 3. Tests
- Updated `test_gcsfile_prefetch_and_cache_type_rules` to verify `f.cache_source` across all 5 configurations.
- Updated `test_get_headers_includes_cache_type` to test unit header formatting.
- Updated `test_user_agent_includes_cache_type_and_source_in_read` for end-to-end live request header assertions.