### PR TITLE
fix(benchmarks): force reinstall requirements overrides in macro and subsystem benchmarks

### DIFF
--- a/cloudbuild/macrobenchmarks/scripts/create_cluster.sh
+++ b/cloudbuild/macrobenchmarks/scripts/create_cluster.sh
@@ -57,3 +57,27 @@ gcloud container node-pools create "${_MACHINE_TYPE}" "${NODE_POOL_ARGS[@]}"
 gcloud container clusters get-credentials "$CLUSTER_NAME" --zone="${_ZONE}" --project="${PROJECT_ID}"
 kubectl apply --server-side -f "https://github.com/kubernetes-sigs/jobset/releases/download/${_JOBSET_VERSION}/manifests.yaml"
 kubectl rollout status deployment/jobset-controller-manager -n jobset-system --timeout=300s
+
+echo "Waiting for JobSet mutating webhook to accept connections..."
+for i in $(seq 1 30); do
+  if WEBHOOK_PROBE_OUTPUT=$(kubectl create --dry-run=server -f - 2>&1 <<EOF
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: webhook-probe
+  namespace: default
+spec:
+  replicatedJobs: []
+EOF
+  ); then
+    echo "JobSet webhook is ready and accepting requests."
+    break
+  fi
+  if [ "$i" -eq 30 ]; then
+    echo "ERROR: Timed out waiting for JobSet webhook readiness" >&2
+    printf 'Last probe error:\n%s\n' "$WEBHOOK_PROBE_OUTPUT" >&2
+    record_failure create-cluster
+    exit 1
+  fi
+  sleep 2
+done

--- a/cloudbuild/subsystembenchmarks/scripts/setup.sh
+++ b/cloudbuild/subsystembenchmarks/scripts/setup.sh
@@ -20,7 +20,10 @@ pip install -r "gcsfs/tests/perf/subsystembenchmarks/$GROUP/requirements.txt" >/
 
 read -r -a REQUIREMENT_SPECS <<< "$REQUIREMENTS_OVERRIDE"
 if ((${#REQUIREMENT_SPECS[@]})); then
+  # Resolve any dependencies needed by the override, then reinstall only the
+  # requested packages in case an existing installation has the same version.
   pip install -- "${REQUIREMENT_SPECS[@]}"
+  pip install --no-deps --force-reinstall -- "${REQUIREMENT_SPECS[@]}"
 fi
 REQUIREMENTS_OVERRIDE="${REQUIREMENT_SPECS[*]}"
 REQUIREMENTS_RESOLVED=$(pip list --format=json)

--- a/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/launcher.sh
+++ b/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/launcher.sh
@@ -79,6 +79,10 @@ if [[ -n "${REQUIREMENTS:-}" ]]; then
   # Word-split intentional.
   # shellcheck disable=SC2086
   pip3 install $REQUIREMENTS
+  # Reinstall only the requested packages so their dependency graph is not
+  # unnecessarily reinstalled after the normal resolution pass above.
+  # shellcheck disable=SC2086
+  pip3 install --no-deps --force-reinstall $REQUIREMENTS
 fi
 
 # JOB_COMPLETION_INDEX is set by the K8s Indexed Job (one value per pod,


### PR DESCRIPTION
Ensure custom package overrides specified via REQUIREMENTS/REQUIREMENTS_OVERRIDE are always installed with --force-reinstall, preventing pip from skipping packages that match pre-installed version numbers.
