### PR TITLE
subsystembenchmarks: support model id substitution in checkpointing save

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+.venv/
 build/
 develop-eggs/
 dist/
@@ -106,3 +107,4 @@ target/
 libs/*.whl
 
 gcsfs/tests/perf/microbenchmarks/__run__
+gcsfs/tests/perf/subsystembenchmarks/__run__

--- a/cloudbuild/subsystembenchmarks/scripts/run-benchmarks.sh
+++ b/cloudbuild/subsystembenchmarks/scripts/run-benchmarks.sh
@@ -16,4 +16,5 @@ python gcsfs/tests/perf/subsystembenchmarks/run.py \
   "--project=$PROJECT_ID" \
   "--location=$REGION" \
   "--zone=$ZONE" \
+  "--model-id=${MODEL_ID:-}" \
   --require-amplification

--- a/cloudbuild/subsystembenchmarks/scripts/setup.sh
+++ b/cloudbuild/subsystembenchmarks/scripts/setup.sh
@@ -18,7 +18,7 @@ fi
 pip install -e . >/dev/null
 pip install -r "gcsfs/tests/perf/subsystembenchmarks/$GROUP/requirements.txt" >/dev/null
 
-if [[ "${MODEL_ID:-}" == gs://* ]]; then
+if [[ "${GROUP}" == checkpointing/* ]] && [[ "${MODEL_ID:-}" == gs://* ]]; then
   echo "MODEL_ID is a GCS path: $MODEL_ID"
   DIR_NAME=$(basename "${MODEL_ID%/}")
   LOCAL_MODEL_PATH="/tmp/$DIR_NAME"

--- a/cloudbuild/subsystembenchmarks/scripts/setup.sh
+++ b/cloudbuild/subsystembenchmarks/scripts/setup.sh
@@ -18,6 +18,33 @@ fi
 pip install -e . >/dev/null
 pip install -r "gcsfs/tests/perf/subsystembenchmarks/$GROUP/requirements.txt" >/dev/null
 
+if [[ "${MODEL_ID:-}" == gs://* ]]; then
+  echo "MODEL_ID is a GCS path: $MODEL_ID"
+  DIR_NAME=$(basename "${MODEL_ID%/}")
+  LOCAL_MODEL_PATH="/tmp/$DIR_NAME"
+  if [[ ! -d "$LOCAL_MODEL_PATH" ]]; then
+    echo "Installing standalone gcloud CLI..."
+    # Install in /tmp/gcloud-install
+    mkdir -p /tmp/gcloud-install
+    (
+      cd /tmp/gcloud-install
+      curl -sSO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz
+      tar -xf google-cloud-cli-linux-x86_64.tar.gz
+    )
+    GCLOUD="/tmp/gcloud-install/google-cloud-sdk/bin/gcloud"
+
+    echo "Downloading model from GCS to $LOCAL_MODEL_PATH..."
+    # gcloud storage cp -r gs://bucket/dir /tmp/ will create /tmp/dir/
+    $GCLOUD storage cp -r "${MODEL_ID%/}" /tmp/
+    echo "Download complete."
+
+    # Clean up gcloud installation to free space
+    rm -rf /tmp/gcloud-install
+  else
+    echo "Model already exists at $LOCAL_MODEL_PATH, skipping download."
+  fi
+fi
+
 read -r -a REQUIREMENT_SPECS <<< "$REQUIREMENTS_OVERRIDE"
 if ((${#REQUIREMENT_SPECS[@]})); then
   # Resolve any dependencies needed by the override, then reinstall only the

--- a/cloudbuild/subsystembenchmarks/subsystembenchmarks-cloudbuild.yaml
+++ b/cloudbuild/subsystembenchmarks/subsystembenchmarks-cloudbuild.yaml
@@ -9,6 +9,7 @@ substitutions:
   _SWEEP_AXES: ""
   _FILTER: ""
   _HF_TOKEN: ""
+  _MODEL_ID: "gs://huggingface-model-weights/Llama-3.1-8B"
 
 steps:
   # 1. Generate a persistent SSH key for this build run.
@@ -41,6 +42,7 @@ steps:
       - "_SWEEP_AXES=${_SWEEP_AXES}"
       - "_FILTER=${_FILTER}"
       - "_HF_TOKEN=${_HF_TOKEN}"
+      - "_MODEL_ID=${_MODEL_ID}"
       - "PROJECT_ID=${PROJECT_ID}"
     args:
       - "-c"
@@ -88,6 +90,7 @@ steps:
           printf 'export SWEEP_AXES=%q\n' "$${_SWEEP_AXES}"
           printf 'export FILTER=%q\n' "$${_FILTER}"
           printf 'export HF_TOKEN=%q\n' "$${_HF_TOKEN}"
+          printf 'export MODEL_ID=%q\n' "$${_MODEL_ID}"
         } > /workspace/build_vars.env
     waitFor: ["-"]
 

--- a/gcsfs/tests/perf/subsystembenchmarks/checkpointing/configurator.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/checkpointing/configurator.py
@@ -72,6 +72,9 @@ class OneFactorCheckpointConfigurator(OneFactorConfigurator):
             rounds=common_config.get("rounds", 1),
             scenario=scenario["scenario"],
             bucket_type=os.environ.get("GCSFS_SUBSYSTEM_BUCKET_TYPE", "regional"),
+            model_id=os.environ.get(
+                "GCSFS_SUBSYSTEM_MODEL_ID", common_config.get("model_id")
+            ),
         )
 
     def validate_case(self, p):

--- a/gcsfs/tests/perf/subsystembenchmarks/checkpointing/pytorch_lightning/configs.yaml
+++ b/gcsfs/tests/perf/subsystembenchmarks/checkpointing/pytorch_lightning/configs.yaml
@@ -1,7 +1,7 @@
 common:
   rounds: 1
+  model_id: "gs://huggingface-model-weights/Llama-3.1-8B"
   baseline:
-    model_id: "meta-llama/Llama-3.1-8B"
     strategy: "single"
     world_size: 1
 

--- a/gcsfs/tests/perf/subsystembenchmarks/checkpointing/pytorch_lightning/write/test_checkpoint.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/checkpointing/pytorch_lightning/write/test_checkpoint.py
@@ -18,6 +18,7 @@ pytestmark = pytest.mark.skipif(
 CASES = PyTorchLightningCheckpointConfigurator(configs.__file__).generate_cases()
 
 
+@pytest.mark.timeout(7200)
 @pytest.mark.parametrize("params", CASES, ids=lambda p: p.name)
 def test_checkpoint_save(benchmark, params, monitor):
     from gcsfs.tests.perf.subsystembenchmarks.checkpointing.checkpoint_case import (

--- a/gcsfs/tests/perf/subsystembenchmarks/checkpointing/tests/test_configs.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/checkpointing/tests/test_configs.py
@@ -1,0 +1,31 @@
+from gcsfs.tests.perf.subsystembenchmarks.checkpointing.pytorch_lightning import configs
+from gcsfs.tests.perf.subsystembenchmarks.checkpointing.pytorch_lightning.configs import (
+    PyTorchLightningCheckpointConfigurator,
+)
+
+CONFIG = configs.__file__
+
+
+def _cases():
+    return PyTorchLightningCheckpointConfigurator(CONFIG).generate_cases()
+
+
+def test_case_ids_unique_and_named():
+    cases = _cases()
+    assert len(cases) == len({c.name for c in cases})
+    assert all(c.name.startswith("save-") for c in cases)
+    assert all(c.scenario == "checkpoint_write" for c in cases)
+
+
+def test_default_model_id():
+    cases = _cases()
+    assert all(
+        c.model_id == "gs://huggingface-model-weights/Llama-3.1-8B" for c in cases
+    )
+
+
+def test_model_id_override(monkeypatch):
+    monkeypatch.setenv("GCSFS_SUBSYSTEM_MODEL_ID", "custom-model-id")
+    cases = _cases()
+    assert all(c.model_id == "custom-model-id" for c in cases)
+    assert all("custom_model_id" in c.name for c in cases)

--- a/gcsfs/tests/perf/subsystembenchmarks/run.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/run.py
@@ -24,6 +24,8 @@ def _setup_environment(args):
     os.environ["GCSFS_SUBSYSTEM_LOCATION"] = args.location
     os.environ["GCSFS_SUBSYSTEM_ZONE"] = args.zone or ""
     os.environ["GCSFS_SUBSYSTEM_SWEEP_AXES"] = args.sweep_axes
+    if args.model_id:
+        os.environ["GCSFS_SUBSYSTEM_MODEL_ID"] = args.model_id
     os.environ["GCSFS_EXPERIMENTAL_ZB_HNS_SUPPORT"] = "true"
     os.environ["STORAGE_EMULATOR_HOST"] = "https://storage.googleapis.com"
 
@@ -62,6 +64,11 @@ def _build_parser():
     )
     parser.add_argument(
         "--zone", help="placement zone; required when --bucket-type=zonal"
+    )
+    parser.add_argument(
+        "--model-id",
+        default="",
+        help="model id override (e.g. gs://path/to/model or hf-repo-id)",
     )
     parser.add_argument(
         "--amplification-wait",


### PR DESCRIPTION
This PR adds support for specifying a custom model_id in the checkpointing save subsystem benchmark via Cloud Build substitutions. It allows it to use pre-downloaded model weights hosted on Google Cloud Storage instead of downloading them from the Hugging Face Hub on every run.