### PR TITLE
feat(subsystembenchmarks): generalize dataloading seam for multiple loaders

### DIFF
--- a/gcsfs/tests/perf/subsystembenchmarks/dataloading/bucket.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/dataloading/bucket.py
@@ -16,6 +16,13 @@ _MAX_BUCKET_NAME = 63
 _SUFFIX_LEN = 8
 
 
+def bucket_name_of(prefix):
+    """Extract GCS bucket name from a gs:// prefix, or "" if non-GCS."""
+    if not prefix.startswith("gs://"):
+        return ""
+    return prefix[len("gs://") :].split("/", 1)[0]
+
+
 @dataclass(frozen=True)
 class BucketSpec:
     """How to create this run's per-case buckets (exported by run.py from its CLI args)."""
@@ -106,7 +113,7 @@ def _delete(fs, name):
 
 @contextlib.contextmanager
 def case_bucket(spec, case_id, *, fs=None):
-    """Create this case's bucket, yield its name, delete it (and its objects) on the way out."""
+    """Create this case's bucket, yield its corpus prefix, delete it on the way out."""
     if fs is None:
         import gcsfs
 
@@ -114,6 +121,16 @@ def case_bucket(spec, case_id, *, fs=None):
     name = case_bucket_name(spec.prefix, case_id)
     fs.mkdir(name, location=spec.location, **bucket_kwargs(spec))
     try:
-        yield name
+        yield f"gs://{name}/data/"
     finally:
         _delete(fs, name)
+
+
+def local_case_bucket(root):
+    """Local-directory stand-in for case_bucket for runs without GCS."""
+
+    @contextlib.contextmanager
+    def ctx(case_id):
+        yield os.path.join(str(root).rstrip("/"), case_id) + "/data/"
+
+    return ctx

--- a/gcsfs/tests/perf/subsystembenchmarks/dataloading/configurator.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/dataloading/configurator.py
@@ -11,8 +11,10 @@ from gcsfs.tests.perf.subsystembenchmarks._common.config_loader import (
     OneFactorConfigurator,
 )
 
-_FMT = {"pretok_parquet": "ptpq", "text_parquet": "txpq", "pretok_jsonl": "ptjsonl"}
 _BUCKET = {"regional": "reg", "zonal": "zon", "hns": "hns"}
+
+# Traversal patterns published in the read_access_pattern column.
+ACCESS_PATTERNS = ("sequential", "shuffled")
 
 # Run-level environment keys; YAML variants must not override them.
 _RUN_LEVEL_KEYS = ("bucket_type",)
@@ -23,6 +25,8 @@ class ReadParameters:
     """One self-contained streaming read case (fresh per-case bucket ingested at runtime)."""
 
     LOADER_TAG = "base"
+    # Format to case ID token mapping for loader-supported formats.
+    FMT_TAGS = {}
 
     name: str
     bucket_name: str
@@ -32,10 +36,8 @@ class ReadParameters:
     framework: str
 
     fmt: str
-    seq_len: int
     file_count: int
     rows_per_file: int
-    row_group_size: int  # parquet only
 
     access: str
     num_workers: int
@@ -45,6 +47,24 @@ class ReadParameters:
     world_size: int = 1
     # YAML axis that produced this case ("baseline" or factor name).
     sweep_axis: str = "baseline"
+
+    @property
+    def dataset_format(self):
+        """Published corpus format representation."""
+        return self.fmt
+
+    @property
+    def read_access_pattern(self):
+        """Published dataset traversal pattern."""
+        return self.access
+
+    def ingest(self, prefix):
+        """Write corpus under prefix and return its manifest."""
+        raise NotImplementedError
+
+    def _id_corpus_tokens(self):
+        """Corpus-shape case ID tokens."""
+        return [f"fc{self.file_count}x{self.rows_per_file}"]
 
     def _id_extra_tokens(self):
         """Loader-specific id tokens inserted between split and bucket tokens."""
@@ -59,12 +79,11 @@ class ReadParameters:
         acc = "shuf" if self.access == "shuffled" else "seq"
         parts = [
             f"read-{self.LOADER_TAG}",
-            _FMT[self.fmt],
+            self.FMT_TAGS[self.fmt],
             acc,
             f"nw{self.num_workers}",
-            f"rg{self.row_group_size}",
-            f"fc{self.file_count}x{self.rows_per_file}",
         ]
+        parts += self._id_corpus_tokens()
         if self.split_by_node:
             div = "div" if self.file_count % self.world_size == 0 else "indiv"
             parts.append(f"splitws{self.world_size}{div}")
@@ -84,7 +103,6 @@ class OneFactorReadConfigurator(OneFactorConfigurator):
         return dict(
             rounds=common_config.get("rounds", 3),
             scenario=scenario["scenario"],
-            seq_len=common_config.get("seq_len", 2048),
             batch_size=common_config.get("batch_size", 64),
             bucket_type=os.environ.get("GCSFS_SUBSYSTEM_BUCKET_TYPE", "regional"),
         )

--- a/gcsfs/tests/perf/subsystembenchmarks/dataloading/datagen.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/dataloading/datagen.py
@@ -15,7 +15,7 @@ _CHARS_PER_TOKEN = 6  # ~6 chars per token matches token-row byte scale.
 _MAX_INGEST_THREADS = 64
 
 
-def _ingest_workers(file_count):
+def ingest_workers(file_count):
     """Write-pool worker count capped at min(max_threads, file_count), >= 1."""
     cap = int(os.environ.get("GCSFS_SUBSYSTEM_INGEST_THREADS", _MAX_INGEST_THREADS))
     return max(1, min(cap, file_count))
@@ -137,7 +137,7 @@ def ingest_dataset(prefix, *, fmt, seq_len, file_count, rows_per_file, row_group
         path = writer(fs, root, idx, seq_len, rows_per_file, row_group_size)
         return int(fs.info(path)["size"])
 
-    with ThreadPoolExecutor(max_workers=_ingest_workers(file_count)) as pool:
+    with ThreadPoolExecutor(max_workers=ingest_workers(file_count)) as pool:
         total_bytes = sum(pool.map(_write, range(file_count)))
 
     return {

--- a/gcsfs/tests/perf/subsystembenchmarks/dataloading/driver.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/dataloading/driver.py
@@ -23,14 +23,64 @@ class ReadResult:
 class ReadDriver(Protocol):
     formats: tuple
 
-    def run_read(self, prefix, params) -> ReadResult:
-        """Read per-case corpus for params.rounds epochs."""
+    def run_read(self, prefix, params, manifest) -> ReadResult:
+        """Read corpus at prefix for params.rounds epochs using ingestion manifest."""
         ...
 
 
 def timestamp():
     """Monotonic clock specified system-wide for cross-process timestamp comparisons."""
     return time.clock_gettime(time.CLOCK_MONOTONIC)
+
+
+# Timeout in seconds for rank synchronization at the round barrier.
+ROUND_BARRIER_TIMEOUT_SECONDS = 3600
+
+
+def round_barrier(ctx, world_size):
+    """Return a Barrier for multi-rank synchronization, or None if single-rank."""
+    return ctx.Barrier(world_size) if world_size > 1 else None
+
+
+def await_round(barrier):
+    """Synchronize ranks at the barrier before starting a round."""
+    if barrier is not None:
+        barrier.wait(timeout=ROUND_BARRIER_TIMEOUT_SECONDS)
+
+
+def measure_epochs(
+    loader,
+    rounds,
+    rows_in_batch,
+    *,
+    barrier=None,
+    on_epoch=None,
+    target=None,
+):
+    """Return per-epoch timestamps, row counts, and first-epoch TTFB."""
+    per_epoch = []
+    ttfb = None
+    for epoch in range(rounds):
+        if on_epoch is not None:
+            on_epoch(epoch)
+        await_round(barrier)
+        begin = timestamp()
+        rows = 0
+        if target is not None and target <= 0:
+            # Skip reading if target budget is zero to avoid uncounted batches.
+            per_epoch.append((begin, timestamp(), 0))
+            continue
+        for batch in loader:
+            if epoch == 0 and ttfb is None:
+                ttfb = timestamp() - begin
+            batch_rows = rows_in_batch(batch)
+            if target is not None:
+                batch_rows = min(batch_rows, target - rows)
+            rows += batch_rows
+            if target is not None and rows >= target:
+                break
+        per_epoch.append((begin, timestamp(), rows))
+    return per_epoch, ttfb if ttfb is not None else float("inf")
 
 
 def reduce_split(results, rounds):
@@ -45,6 +95,31 @@ def reduce_split(results, rounds):
     first_batches = [res[0][0][0] + res[1] for res in results]
     ttfb = max(first_batches) - min(first_begins)
     return durations, rows_list, ttfb
+
+
+def spawn_rank_epochs(rank_entry, prefix, params, *rank_args):
+    """Spawn rank processes and reduce epoch metrics and dataset build time."""
+    import torch.multiprocessing as mp
+
+    ctx = mp.get_context("spawn")
+    with ctx.Manager() as manager:
+        queue = manager.Queue()
+        mp.spawn(
+            rank_entry,
+            args=(
+                params.world_size,
+                prefix,
+                params,
+                round_barrier(ctx, params.world_size),
+                queue,
+                *rank_args,
+            ),
+            nprocs=params.world_size,
+            join=True,
+        )
+        results = [queue.get() for _ in range(params.world_size)]
+    durations, rows, ttfb = reduce_split(results, params.rounds)
+    return durations, rows, ttfb, max(result[2] for result in results)
 
 
 def assert_fsspec_gcsfs(prefix):

--- a/gcsfs/tests/perf/subsystembenchmarks/dataloading/huggingface_datasets/configs.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/dataloading/huggingface_datasets/configs.py
@@ -11,3 +11,9 @@ from gcsfs.tests.perf.subsystembenchmarks.dataloading.huggingface_datasets.param
 class HuggingFaceReadConfigurator(OneFactorReadConfigurator):
     FRAMEWORK = "huggingface_datasets"
     PARAMS_CLASS = HFReadParameters
+
+    def shared_keys(self, scenario, common_config):
+        keys = super().shared_keys(scenario, common_config)
+        # seq_len sizes the text corpus for this benchmark group.
+        keys["seq_len"] = common_config.get("seq_len", 2048)
+        return keys

--- a/gcsfs/tests/perf/subsystembenchmarks/dataloading/huggingface_datasets/parameters.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/dataloading/huggingface_datasets/parameters.py
@@ -10,10 +10,37 @@ class HFReadParameters(ReadParameters):
     """Read parameters for streaming HuggingFace datasets benchmark cases."""
 
     LOADER_TAG = "hf"
+    FMT_TAGS = {
+        "pretok_parquet": "ptpq",
+        "text_parquet": "txpq",
+        "pretok_jsonl": "ptjsonl",
+    }
+
+    # Text-corpus shape parameters.
+    seq_len: int = 2048
+    row_group_size: int = 1024  # parquet only
 
     # Shuffle-only configuration for streaming datasets.
     shuffle_buffer_size: int = 1000
     max_buffer_input_shards: int = 0
+
+    def ingest(self, prefix):
+        from gcsfs.tests.perf.subsystembenchmarks.dataloading import datagen
+
+        return datagen.ingest_dataset(
+            prefix,
+            fmt=self.fmt,
+            seq_len=self.seq_len,
+            file_count=self.file_count,
+            rows_per_file=self.rows_per_file,
+            row_group_size=self.row_group_size,
+        )
+
+    def _id_corpus_tokens(self):
+        return [
+            f"rg{self.row_group_size}",
+            f"fc{self.file_count}x{self.rows_per_file}",
+        ]
 
     def _id_extra_tokens(self):
         if self.access == "shuffled" and self.max_buffer_input_shards:
@@ -24,4 +51,10 @@ class HFReadParameters(ReadParameters):
         return {
             "persistent_data_loader_workers_enabled": self.num_workers > 0,
             "shuffle_max_buffer_input_shards": self.max_buffer_input_shards,
+            # 0 represents no shuffling for sequential access.
+            "shuffle_buffer_size": (
+                self.shuffle_buffer_size if self.access == "shuffled" else 0
+            ),
+            "sample_sequence_length_tokens": self.seq_len,
+            "parquet_row_group_size_rows": self.row_group_size,
         }

--- a/gcsfs/tests/perf/subsystembenchmarks/dataloading/huggingface_datasets/read/driver.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/dataloading/huggingface_datasets/read/driver.py
@@ -4,8 +4,8 @@ import time
 
 from gcsfs.tests.perf.subsystembenchmarks.dataloading.driver import (
     ReadResult,
-    reduce_split,
-    timestamp,
+    measure_epochs,
+    spawn_rank_epochs,
 )
 
 _EXT = {"pretok_parquet": "parquet", "text_parquet": "parquet", "pretok_jsonl": "jsonl"}
@@ -94,25 +94,16 @@ def run_epochs(
         num_workers=num_workers,
         prefetch_factor=prefetch_factor,
     )
-    durations, rows_list = [], []
-    ttfb = None
-    for epoch in range(rounds):
-        # Reseed shuffle buffer per epoch so persistent workers iterate different orders.
-        ds.set_epoch(epoch)
-        rows = 0
-        begin = time.perf_counter()
-        for batch in loader:
-            if ttfb is None:
-                ttfb = time.perf_counter() - begin
-            rows += _rows_in_batch(batch)
-        durations.append(time.perf_counter() - begin)
-        rows_list.append(rows)
-    return (
-        durations,
-        rows_list,
-        (ttfb if ttfb is not None else durations[0]),
-        build_seconds,
+    # Reseed shuffle buffer per epoch so workers iterate different orders.
+    per_epoch, ttfb = measure_epochs(
+        loader,
+        rounds,
+        _rows_in_batch,
+        on_epoch=ds.set_epoch,
     )
+    durations = [end - begin for begin, end, _ in per_epoch]
+    rows = [count for _, _, count in per_epoch]
+    return durations, rows, ttfb, build_seconds
 
 
 def _split(ds, rank, world_size):
@@ -121,29 +112,7 @@ def _split(ds, rank, world_size):
     return split_dataset_by_node(ds, rank=rank, world_size=world_size)
 
 
-def rank_rows(
-    prefix,
-    fmt,
-    rank,
-    world_size,
-    seed=0,
-    *,
-    access="sequential",
-    max_buffer_input_shards=0,
-):
-    """Rows one rank yields after split_dataset_by_node."""
-    ds = _build_dataset(
-        prefix,
-        fmt,
-        access,
-        seed,
-        max_buffer_input_shards=max_buffer_input_shards,
-    )
-    ds = _split(ds, rank, world_size).with_format("torch")
-    return sum(1 for _ in ds)
-
-
-def run_rank_epochs(rank, world_size, prefix, params):
+def run_rank_epochs(rank, world_size, prefix, params, barrier=None):
     """Run persistent split DataLoader for a single rank across `rounds` epochs.
 
     Returns (per_epoch_timestamps, ttfb, build_seconds).
@@ -167,44 +136,24 @@ def run_rank_epochs(rank, world_size, prefix, params):
         num_workers=params.num_workers,
         prefetch_factor=params.prefetch_factor,
     )
-    per_epoch, ttfb = [], None
-    for epoch in range(params.rounds):
-        ds.set_epoch(epoch)
-        rows = 0
-        begin = timestamp()
-        for batch in loader:
-            if ttfb is None:
-                ttfb = timestamp() - begin
-            rows += _rows_in_batch(batch)
-        end = timestamp()
-        per_epoch.append((begin, end, rows))
-    default_ttfb = per_epoch[0][1] - per_epoch[0][0]
-    return per_epoch, (ttfb if ttfb is not None else default_ttfb), build_seconds
+    # Barrier absorbs dataset construction skew before round 1.
+    per_epoch, ttfb = measure_epochs(
+        loader,
+        params.rounds,
+        _rows_in_batch,
+        barrier=barrier,
+        on_epoch=ds.set_epoch,
+    )
+    return per_epoch, ttfb, build_seconds
 
 
-def _rank_entry(rank, world_size, prefix, params, q):
-    per_epoch, ttfb, build_seconds = run_rank_epochs(rank, world_size, prefix, params)
-    q.put((per_epoch, ttfb, build_seconds))
+def _rank_entry(rank, world_size, prefix, params, barrier, queue):
+    queue.put(run_rank_epochs(rank, world_size, prefix, params, barrier))
 
 
 def run_split_epochs(prefix, params):
     """Spawn `world_size` ranks running `run_rank_epochs` and reduce results across ranks."""
-    import torch.multiprocessing as mp
-
-    ctx = mp.get_context("spawn")
-    with ctx.Manager() as manager:
-        q = manager.Queue()
-        mp.spawn(
-            _rank_entry,
-            args=(params.world_size, prefix, params, q),
-            nprocs=params.world_size,
-            join=True,
-        )
-        results = [q.get() for _ in range(params.world_size)]
-    durations, rows_list, ttfb = reduce_split(results, params.rounds)
-    # Build time is bounded by the slowest rank.
-    build_seconds = max(r[2] for r in results)
-    return durations, rows_list, ttfb, build_seconds
+    return spawn_rank_epochs(_rank_entry, prefix, params)
 
 
 class HFReadDriver:
@@ -212,7 +161,8 @@ class HFReadDriver:
 
     formats = ("pretok_parquet", "text_parquet", "pretok_jsonl")
 
-    def run_read(self, prefix, params):
+    def run_read(self, prefix, params, manifest):
+        del manifest  # HuggingFace reads full shards rather than a sample budget.
         if params.split_by_node:
             durations, rows_list, ttfb, build_seconds = run_split_epochs(prefix, params)
         else:

--- a/gcsfs/tests/perf/subsystembenchmarks/dataloading/huggingface_datasets/read/tests/test_hf_split.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/dataloading/huggingface_datasets/read/tests/test_hf_split.py
@@ -1,4 +1,5 @@
 import dataclasses
+import math
 
 import pytest
 
@@ -28,16 +29,23 @@ def _ingest(tmp_path, files, rows=20):
     return prefix, man
 
 
+def _rank_rows(prefix, fmt, rank, world_size):
+    """Rows one rank yields after split_dataset_by_node."""
+    ds = _hf_read._build_dataset(prefix, fmt, "sequential", seed=0)
+    ds = _hf_read._split(ds, rank, world_size).with_format("torch")
+    return sum(1 for _ in ds)
+
+
 def test_divisible_shards_are_disjoint(tmp_path):
     prefix, man = _ingest(tmp_path, files=8)  # 8 % 4 == 0
-    per = [_hf_read.rank_rows(prefix, "pretok_parquet", r, 4) for r in range(4)]
+    per = [_rank_rows(prefix, "pretok_parquet", r, 4) for r in range(4)]
     assert sum(per) == man["sample_count"]
     assert all(x == man["sample_count"] // 4 for x in per)
 
 
 def test_indivisible_every_rank_reads_some(tmp_path):
     prefix, man = _ingest(tmp_path, files=7)  # 7 % 4 != 0
-    per = [_hf_read.rank_rows(prefix, "pretok_parquet", r, 4) for r in range(4)]
+    per = [_rank_rows(prefix, "pretok_parquet", r, 4) for r in range(4)]
     assert sum(per) == man["sample_count"]
     assert all(x > 0 for x in per)
 
@@ -92,6 +100,32 @@ def test_run_epochs_reports_build_seconds(tmp_path):
     assert rows_list[0] == man["sample_count"]
     assert isinstance(build_seconds, float)
     assert build_seconds > 0.0
+
+
+def test_run_epochs_reports_infinite_ttfb_when_no_batch_is_yielded(monkeypatch):
+    class EmptyDataset:
+        def with_format(self, _format):
+            return self
+
+        def set_epoch(self, epoch):
+            pass
+
+    monkeypatch.setattr(
+        _hf_read, "_build_dataset", lambda *args, **kwargs: EmptyDataset()
+    )
+    monkeypatch.setattr(_hf_read, "_build_loader", lambda *args, **kwargs: [])
+
+    _, rows, ttfb, _ = _hf_read.run_epochs(
+        prefix="unused",
+        fmt="pretok_parquet",
+        access="sequential",
+        num_workers=0,
+        batch_size=8,
+        rounds=1,
+    )
+
+    assert rows == [0]
+    assert math.isinf(ttfb)
 
 
 def test_run_split_epochs_totals(tmp_path):

--- a/gcsfs/tests/perf/subsystembenchmarks/dataloading/huggingface_datasets/tests/test_configs.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/dataloading/huggingface_datasets/tests/test_configs.py
@@ -71,6 +71,15 @@ def test_macrobenchmark_baseline_present():
     assert baseline.max_buffer_input_shards == 10
 
 
+def test_shuffle_buffer_size_is_published_with_webdataset_semantics():
+    """Verify shuffle_buffer_size is 0 when access is sequential."""
+    shuffled = next(c for c in _cases() if c.sweep_axis == "baseline")
+    sequential = next(c for c in _cases() if c.access == "sequential")
+
+    assert shuffled.extra_columns()["shuffle_buffer_size"] == 10000
+    assert sequential.extra_columns()["shuffle_buffer_size"] == 0
+
+
 def test_bucket_type_uniform_from_run_env(monkeypatch):
     monkeypatch.delenv("GCSFS_SUBSYSTEM_BUCKET_TYPE", raising=False)
     assert {c.bucket_type for c in _cases()} == {"regional"}

--- a/gcsfs/tests/perf/subsystembenchmarks/dataloading/read_case.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/dataloading/read_case.py
@@ -1,5 +1,7 @@
 """Per-case benchmark lifecycle runner: bucket management, corpus ingestion, driver timing, and metric publishing."""
 
+import functools
+import math
 import statistics
 import time
 
@@ -16,22 +18,24 @@ def publish_common(benchmark, params, manifest, ttfb, window, build_seconds):
     benchmark.extra_info.update(
         {
             "workload_family": "data_loading",
-            "dataset_format": params.fmt,
-            "sample_sequence_length_tokens": params.seq_len,
+            "dataset_format": params.dataset_format,
             "dataset_file_count": manifest["file_count"],
             "dataset_size_bytes": manifest["corpus_bytes"],
             "dataset_sample_count": manifest["sample_count"],
             "batch_size_samples": params.batch_size,
             "dataloader_num_workers": params.num_workers,
             "dataloader_prefetch_factor": params.prefetch_factor,
-            "read_access_pattern": params.access,
+            "read_access_pattern": params.read_access_pattern,
             "dataset_split_by_node_enabled": params.split_by_node,
             "world_size": params.world_size,
-            "parquet_row_group_size_rows": params.row_group_size,
-            "time_to_first_batch_seconds": ttfb,
+            # Publish None instead of inf so BigQuery CSV load treats it as null.
+            "time_to_first_batch_seconds": ttfb if math.isfinite(ttfb) else None,
             "dataset_build_time": build_seconds,
         }
     )
+    # Optional image count for multimodal corpora.
+    if "image_count" in manifest:
+        benchmark.extra_info["dataset_image_count"] = manifest["image_count"]
     benchmark.extra_info.update(params.extra_columns())
 
 
@@ -41,9 +45,9 @@ def run_read_case(benchmark, monitor, params, driver, *, bucket_ctx=None):
         publish_resource_metrics,
         publish_round_stats,
     )
-    from gcsfs.tests.perf.subsystembenchmarks.dataloading import datagen
     from gcsfs.tests.perf.subsystembenchmarks.dataloading.bucket import (
         BucketSpec,
+        bucket_name_of,
         case_bucket,
     )
 
@@ -52,25 +56,19 @@ def run_read_case(benchmark, monitor, params, driver, *, bucket_ctx=None):
             f"{params.framework} driver does not support format {params.fmt!r}; "
             f"supported: {driver.formats}"
         )
-    bucket_ctx = bucket_ctx or case_bucket
+    if bucket_ctx is None:
+        # Only real GCS buckets require and validate environment configuration.
+        bucket_ctx = functools.partial(case_bucket, BucketSpec.from_env())
 
-    with bucket_ctx(BucketSpec.from_env(), params.name) as bucket:
-        params.bucket_name = bucket
-        prefix = f"gs://{bucket}/data/"
+    with bucket_ctx(params.name) as prefix:
+        params.bucket_name = bucket_name_of(prefix)
         assert_fsspec_gcsfs(prefix)
-        manifest = datagen.ingest_dataset(
-            prefix,
-            fmt=params.fmt,
-            seq_len=params.seq_len,
-            file_count=params.file_count,
-            rows_per_file=params.rows_per_file,
-            row_group_size=params.row_group_size,
-        )
+        manifest = params.ingest(prefix)
 
         expected_rows = manifest["sample_count"]
         window_start = time.time()
         with monitor() as m:
-            result = driver.run_read(prefix, params)
+            result = driver.run_read(prefix, params, manifest)
         window_end = time.time()
 
         for rows in result.rows_per_epoch:

--- a/gcsfs/tests/perf/subsystembenchmarks/dataloading/read_case.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/dataloading/read_case.py
@@ -29,7 +29,9 @@ def publish_common(benchmark, params, manifest, ttfb, window, build_seconds):
             "dataset_split_by_node_enabled": params.split_by_node,
             "world_size": params.world_size,
             # Publish None instead of inf so BigQuery CSV load treats it as null.
-            "time_to_first_batch_seconds": ttfb if ttfb is not None and math.isfinite(ttfb) else None,
+            "time_to_first_batch_seconds": (
+                ttfb if ttfb is not None and math.isfinite(ttfb) else None
+            ),
             "dataset_build_time": build_seconds,
         }
     )

--- a/gcsfs/tests/perf/subsystembenchmarks/dataloading/read_case.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/dataloading/read_case.py
@@ -29,7 +29,7 @@ def publish_common(benchmark, params, manifest, ttfb, window, build_seconds):
             "dataset_split_by_node_enabled": params.split_by_node,
             "world_size": params.world_size,
             # Publish None instead of inf so BigQuery CSV load treats it as null.
-            "time_to_first_batch_seconds": ttfb if math.isfinite(ttfb) else None,
+            "time_to_first_batch_seconds": ttfb if ttfb is not None and math.isfinite(ttfb) else None,
             "dataset_build_time": build_seconds,
         }
     )

--- a/gcsfs/tests/perf/subsystembenchmarks/dataloading/tests/test_bucket.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/dataloading/tests/test_bucket.py
@@ -89,9 +89,19 @@ def test_case_bucket_name_truncates_to_the_gcs_limit():
     assert not name.startswith("-") and "--" not in name.strip("-")
 
 
+def test_bucket_name_of_reads_the_bucket_back_out_of_a_prefix():
+    assert bucket.bucket_name_of("gs://pfx-read-hf-x-abcd1234/data/") == (
+        "pfx-read-hf-x-abcd1234"
+    )
+    # Local runs have no bucket name.
+    assert bucket.bucket_name_of("/tmp/case/data/") == ""
+
+
 def test_case_bucket_creates_then_deletes():
     fs = _FakeFS()
-    with bucket.case_bucket(_spec(bucket_type="hns"), "read-hf-x", fs=fs) as name:
+    with bucket.case_bucket(_spec(bucket_type="hns"), "read-hf-x", fs=fs) as prefix:
+        name = bucket.bucket_name_of(prefix)
+        assert prefix == f"gs://{name}/data/"
         assert fs.made == [
             (
                 name,
@@ -116,6 +126,6 @@ def test_case_bucket_deletes_even_when_the_case_raises():
 
 def test_empty_bucket_still_gets_dropped():
     fs = _FakeFS(fail_rm=True)
-    with bucket.case_bucket(_spec(), "read-hf-x", fs=fs) as name:
+    with bucket.case_bucket(_spec(), "read-hf-x", fs=fs) as prefix:
         pass
-    assert fs.rmdirs == [name]
+    assert fs.rmdirs == [bucket.bucket_name_of(prefix)]

--- a/gcsfs/tests/perf/subsystembenchmarks/dataloading/tests/test_configurator.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/dataloading/tests/test_configurator.py
@@ -11,6 +11,7 @@ from gcsfs.tests.perf.subsystembenchmarks.dataloading.configurator import (
 @dataclass
 class _FakeParams(ReadParameters):
     LOADER_TAG = "fk"
+    FMT_TAGS = {"pretok_parquet": "ptpq"}
 
 
 class _FakeConfigurator(OneFactorReadConfigurator):
@@ -21,13 +22,11 @@ class _FakeConfigurator(OneFactorReadConfigurator):
 _YAML = """
 common:
   rounds: 3
-  seq_len: 2048
   batch_size: 64
   baseline:
     fmt: "pretok_parquet"
     file_count: 8
     rows_per_file: 4096
-    row_group_size: 1024
     access: "sequential"
     num_workers: 8
     prefetch_factor: 2
@@ -54,8 +53,8 @@ def test_baseline_and_variant_expand_with_stable_ids(tmp_path):
     )
     cases = _write(tmp_path, text).generate_cases()
     assert [c.name for c in cases] == [
-        "read-fk-ptpq-seq-nw8-rg1024-fc8x4096-reg",
-        "read-fk-ptpq-seq-nw1-rg1024-fc8x4096-reg",
+        "read-fk-ptpq-seq-nw8-fc8x4096-reg",
+        "read-fk-ptpq-seq-nw1-fc8x4096-reg",
     ]
     assert all(c.framework == "fake" for c in cases)
     assert [c.sweep_axis for c in cases] == ["baseline", "workers"]

--- a/gcsfs/tests/perf/subsystembenchmarks/dataloading/tests/test_datagen.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/dataloading/tests/test_datagen.py
@@ -150,12 +150,12 @@ def test_jsonl_shard_is_streamed_not_buffered_whole():
 def test_ingest_workers_scales_and_caps(monkeypatch):
     """Verify ingest worker count calculation and cap behavior."""
     monkeypatch.delenv("GCSFS_SUBSYSTEM_INGEST_THREADS", raising=False)
-    assert datagen._ingest_workers(4) == 4
-    assert datagen._ingest_workers(10_000) == datagen._MAX_INGEST_THREADS
+    assert datagen.ingest_workers(4) == 4
+    assert datagen.ingest_workers(10_000) == datagen._MAX_INGEST_THREADS
     assert datagen._MAX_INGEST_THREADS >= 64
     monkeypatch.setenv("GCSFS_SUBSYSTEM_INGEST_THREADS", "128")
-    assert datagen._ingest_workers(10_000) == 128
-    assert datagen._ingest_workers(0) == 1
+    assert datagen.ingest_workers(10_000) == 128
+    assert datagen.ingest_workers(0) == 1
 
 
 def test_shards_are_written_concurrently():

--- a/gcsfs/tests/perf/subsystembenchmarks/dataloading/tests/test_driver.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/dataloading/tests/test_driver.py
@@ -1,12 +1,73 @@
+import math
+from types import SimpleNamespace
+
 import pytest
 
 from gcsfs.tests.perf.subsystembenchmarks.dataloading import driver
 
 
-def test_timestamp_is_monotonic():
-    a = driver.timestamp()
-    b = driver.timestamp()
-    assert b >= a
+class _Barrier:
+    def __init__(self):
+        self.calls = []
+
+    def wait(self, timeout):
+        self.calls.append(timeout)
+
+
+def test_measure_epochs_times_rows_and_runs_epoch_setup(monkeypatch):
+    clock = iter([10.0, 10.25, 11.0, 20.0, 21.0])
+    monkeypatch.setattr(driver, "timestamp", lambda: next(clock))
+    barrier = _Barrier()
+    epochs = []
+
+    per_epoch, ttfb = driver.measure_epochs(
+        [[1, 2], [3]],
+        2,
+        len,
+        barrier=barrier,
+        on_epoch=epochs.append,
+    )
+
+    assert per_epoch == [(10.0, 11.0, 3), (20.0, 21.0, 3)]
+    assert ttfb == 0.25
+    assert epochs == [0, 1]
+    assert barrier.calls == [driver.ROUND_BARRIER_TIMEOUT_SECONDS] * 2
+
+
+def test_measure_epochs_trims_row_count_at_target(monkeypatch):
+    clock = iter([1.0, 1.1, 2.0])
+    monkeypatch.setattr(driver, "timestamp", lambda: next(clock))
+
+    per_epoch, _ = driver.measure_epochs([[0] * 8, [0] * 8], 1, len, target=10)
+
+    assert per_epoch == [(1.0, 2.0, 10)]
+
+
+def test_measure_epochs_reads_nothing_at_a_zero_target(monkeypatch):
+    """Verify a rank with zero target budget fetches no batches."""
+    clock = iter([1.0, 2.0])
+    monkeypatch.setattr(driver, "timestamp", lambda: next(clock))
+    pulled = []
+
+    def loader():
+        pulled.append(1)
+        yield [0] * 8
+
+    per_epoch, ttfb = driver.measure_epochs(loader(), 1, len, target=0)
+
+    assert per_epoch == [(1.0, 2.0, 0)]
+    assert math.isinf(ttfb)
+    assert pulled == [], "a zero-target rank pulled a batch anyway"
+
+
+def test_measure_epochs_reports_infinite_ttfb_for_an_empty_epoch(monkeypatch):
+    clock = iter([1.0, 2.0])
+    monkeypatch.setattr(driver, "timestamp", lambda: next(clock))
+
+    per_epoch, ttfb = driver.measure_epochs([], 1, len)
+
+    assert per_epoch == [(1.0, 2.0, 0)]
+    assert math.isinf(ttfb)
 
 
 def test_reduce_split_spans_rank_wall_time_and_global_first_batch_readiness():
@@ -30,18 +91,59 @@ def test_assert_gcsfs_backed_rejects_non_pyfilesystem():
         driver.assert_gcsfs_backed(object())
 
 
-def test_read_driver_protocol_is_runtime_checkable():
-    class Good:
-        formats = ("pretok_parquet",)
-
-        def run_read(self, prefix, params):
-            return driver.ReadResult(
-                durations=[1.0], rows_per_epoch=[1], ttfb_seconds=0.0, build_seconds=0.0
-            )
-
-    assert isinstance(Good(), driver.ReadDriver)
+# Module-level probe functions for mp.spawn pickling.
 
 
-def test_read_result_extra_columns_default_empty():
-    r = driver.ReadResult([1.0], [1], 0.0, 0.0)
-    assert r.extra_columns == {}
+def _asymmetric_round_probe(rank, barrier, queue):
+    import time
+
+    for round_index in range(3):
+        driver.await_round(barrier)
+        begin = driver.timestamp()
+        # Vary rank sleep durations to test barrier synchronization across rounds.
+        time.sleep(0.05 * (rank + 1))
+        queue.put((round_index, begin, driver.timestamp()))
+
+
+def test_round_barrier_keeps_every_rank_inside_its_own_round():
+    mp = pytest.importorskip("torch.multiprocessing")
+
+    world_size = 3
+    ctx = mp.get_context("spawn")
+    with ctx.Manager() as manager:
+        queue = manager.Queue()
+        mp.spawn(
+            _asymmetric_round_probe,
+            args=(driver.round_barrier(ctx, world_size), queue),
+            nprocs=world_size,
+            join=True,
+        )
+        marks = [queue.get() for _ in range(world_size * 3)]
+
+    for round_index in range(2):
+        latest_end = max(end for r, _, end in marks if r == round_index)
+        earliest_begin = min(begin for r, begin, _ in marks if r == round_index + 1)
+        assert (
+            earliest_begin >= latest_end
+        ), f"round {round_index + 1} started before round {round_index} finished"
+
+
+def _rank_result_probe(rank, world_size, prefix, params, barrier, queue):
+    assert world_size == params.world_size
+    assert prefix == "unused"
+    driver.await_round(barrier)
+    queue.put(
+        (
+            [(float(rank), float(2 + 2 * rank), 10 - 5 * rank)],
+            0.5 + 0.4 * rank,
+            1.0 + rank,
+        )
+    )
+
+
+def test_spawn_rank_epochs_reduces_results_and_uses_slowest_build():
+    params = SimpleNamespace(world_size=2, rounds=1)
+
+    result = driver.spawn_rank_epochs(_rank_result_probe, "unused", params)
+
+    assert result == ([4.0], [15], 1.9, 2.0)

--- a/gcsfs/tests/perf/subsystembenchmarks/dataloading/tests/test_read_case.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/dataloading/tests/test_read_case.py
@@ -15,9 +15,22 @@ def _bucket_env(monkeypatch):
     monkeypatch.setenv("GCSFS_SUBSYSTEM_LOCATION", "us-central1")
 
 
+_DEFAULT_MANIFEST = {
+    "file_count": 2,
+    "corpus_bytes": 1000,
+    "sample_count": 10,
+    "fmt": "pretok_parquet",
+    "rows_per_file": 5,
+}
+
+
 @dataclass
 class _P(ReadParameters):
     LOADER_TAG = "fk"
+    FMT_TAGS = {"pretok_parquet": "ptpq"}
+
+    def ingest(self, prefix):
+        return self._manifest
 
 
 class _FakeDriver:
@@ -28,7 +41,7 @@ class _FakeDriver:
         self._build = build_seconds
         self._extra = extra_columns or {}
 
-    def run_read(self, prefix, params):
+    def run_read(self, prefix, params, manifest):
         from gcsfs.tests.perf.subsystembenchmarks.dataloading.driver import ReadResult
 
         return ReadResult(
@@ -61,7 +74,7 @@ class _Monitor:
         return contextlib.nullcontext(self)
 
 
-def _params(**over):
+def _params(manifest=None, **over):
     kw = dict(
         name="c",
         bucket_name="",
@@ -70,29 +83,27 @@ def _params(**over):
         scenario="read",
         framework="fake",
         fmt="pretok_parquet",
-        seq_len=8,
         file_count=2,
         rows_per_file=5,
-        row_group_size=5,
         access="sequential",
         num_workers=2,
         batch_size=4,
     )
     kw.update(over)
-    return _P(**kw)
+    p = _P(**kw)
+    p._manifest = manifest if manifest is not None else _DEFAULT_MANIFEST
+    return p
 
 
 def _local_bucket_ctx(tmp_path):
-    @contextlib.contextmanager
-    def ctx(spec, case_id, **kw):
-        yield str(tmp_path)
+    from gcsfs.tests.perf.subsystembenchmarks.dataloading.bucket import (
+        local_case_bucket,
+    )
 
-    return ctx
+    return local_case_bucket(tmp_path)
 
 
 def test_run_read_case_publishes_throughput_and_passes_guard(tmp_path, monkeypatch):
-    from gcsfs.tests.perf.subsystembenchmarks.dataloading import datagen
-
     monkeypatch.setenv("MACHINE_TYPE", "c4-standard-192")
     monkeypatch.delenv("GCE_MACHINE_TYPE", raising=False)
     monkeypatch.setenv("COMMIT_SHA", "source123")
@@ -102,14 +113,6 @@ def test_run_read_case_publishes_throughput_and_passes_guard(tmp_path, monkeypat
         '[{"name":"gcsfs","version":"1.0"}]',
     )
     monkeypatch.setenv("GCSFS_SUBSYSTEM_SWEEP_AXES", "workers workers prefetch")
-    man = {
-        "file_count": 2,
-        "corpus_bytes": 1000,
-        "sample_count": 10,
-        "fmt": "pretok_parquet",
-        "rows_per_file": 5,
-    }
-    monkeypatch.setattr(datagen, "ingest_dataset", lambda *a, **k: man)
     monkeypatch.setattr(read_case, "assert_fsspec_gcsfs", lambda prefix: None)
 
     bench = _Bench()
@@ -152,16 +155,6 @@ def test_run_read_case_publishes_throughput_and_passes_guard(tmp_path, monkeypat
 
 def test_run_read_case_publishes_dataset_build_time(tmp_path, monkeypatch):
     """Dataset initialization latency uses the macrobenchmark field name."""
-    from gcsfs.tests.perf.subsystembenchmarks.dataloading import datagen
-
-    man = {
-        "file_count": 2,
-        "corpus_bytes": 1000,
-        "sample_count": 10,
-        "fmt": "pretok_parquet",
-        "rows_per_file": 5,
-    }
-    monkeypatch.setattr(datagen, "ingest_dataset", lambda *a, **k: man)
     monkeypatch.setattr(read_case, "assert_fsspec_gcsfs", lambda prefix: None)
 
     bench = _Bench()
@@ -176,23 +169,15 @@ def test_run_read_case_publishes_dataset_build_time(tmp_path, monkeypatch):
 
 
 def test_run_read_case_fails_partial_read(tmp_path, monkeypatch):
-    from gcsfs.tests.perf.subsystembenchmarks.dataloading import datagen
-
-    man = {
-        "file_count": 2,
-        "corpus_bytes": 1000,
-        "sample_count": 99,
-        "fmt": "pretok_parquet",
-        "rows_per_file": 5,
-    }
-    monkeypatch.setattr(datagen, "ingest_dataset", lambda *a, **k: man)
     monkeypatch.setattr(read_case, "assert_fsspec_gcsfs", lambda prefix: None)
+
+    man = {**_DEFAULT_MANIFEST, "sample_count": 99}
 
     with pytest.raises(ValueError, match="partial read"):
         read_case.run_read_case(
             _Bench(),
             _Monitor(),
-            _params(),
+            _params(manifest=man),
             _FakeDriver(rows=10),
             bucket_ctx=_local_bucket_ctx(tmp_path),
         )


### PR DESCRIPTION
- Move corpus shape and ingestion behind ReadParameters.ingest() and loader-specific FMT_TAGS so the shared runner no longer assumes a text/Parquet corpus.
- Update case_bucket and local_case_bucket to yield corpus URI prefixes and extract GCS bucket names via bucket_name_of().
- Add measure_epochs, round_barrier, and spawn_rank_epochs in driver.py to centralize multi-rank execution, epoch callbacks, target budgeting, and barrier synchronization across rounds.
- Generalize metric publishing in read_case.py to use dataset_format and read_access_pattern properties, sanitize non-finite TTFB for BigQuery loads, and support dataset_image_count.
- Migrate huggingface_datasets onto the new seam, scoping seq_len, row_group_size, and shuffle buffer metrics to HFReadParameters.
- Update dataloading and HuggingFace unit tests to cover new driver helpers, prefix bucket lifecycle, and configuration generation.