### PR TITLE
perf(subsystembenchmarks): remove num_workers=0 variant from webdataset read benchmarks

### DIFF
--- a/gcsfs/tests/perf/subsystembenchmarks/dataloading/webdataset/configs.yaml
+++ b/gcsfs/tests/perf/subsystembenchmarks/dataloading/webdataset/configs.yaml
@@ -47,7 +47,6 @@ scenarios:
       - {axis: "shard_divisibility", file_count: 40, rows_per_file: 1254}
 
       # PyTorch DataLoader settings.
-      - {axis: "workers", num_workers: 0}
       - {axis: "workers", num_workers: 2}
       - {axis: "workers", num_workers: 8}
       - {axis: "prefetch", prefetch_factor: 4}


### PR DESCRIPTION
Removes the zero-worker (`num_workers: 0`) variant from the PyTorch DataLoader `workers` sweep axis in the WebDataset dataloading read benchmarks configuration (`configs.yaml`).

With the baseline set to 4 workers, DataLoader worker scaling continues to be evaluated across the 2-worker and 8-worker variants.