### PR TITLE
fix: prevent NotImplementedError when closing GCSFile from event loop thread

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -11,6 +11,7 @@ import os
 import posixpath
 import re
 import sys
+import threading
 import uuid
 import warnings
 import weakref
@@ -2360,7 +2361,31 @@ def _get_prefetcher_and_cache_config(cache_type, kwargs):
     return cache_type, use_prefetch_reader, cache_source
 
 
+_DEFERRED_CLOSE_THREAD_NAME = "gcsfs-deferred-close"
+
+
+def _on_loop_thread(loop):
+    if loop is None:
+        return False
+    try:
+        return asyncio.get_running_loop() is loop
+    except RuntimeError:
+        return False
+
+
+def _defer_close(file):
+    def _run():
+        try:
+            file._close_impl()
+        except Exception:
+            logger.exception("deferred close of %s failed", file.path)
+
+    threading.Thread(target=_run, name=_DEFERRED_CLOSE_THREAD_NAME, daemon=True).start()
+
+
 class GCSFile(fsspec.spec.AbstractBufferedFile):
+    _close_deferred = False
+
     def __init__(
         self,
         gcsfs,
@@ -2657,7 +2682,7 @@ class GCSFile(fsspec.spec.AbstractBufferedFile):
             if not both None, fetch only given range
         """
         try:
-            if hasattr(self, "_prefetch_engine") and self._prefetch_engine:
+            if getattr(self, "_prefetch_engine", None):
                 return self._prefetch_engine.fetch(start=start, end=end)
             return self.fs.cat_file(
                 self.path,
@@ -2684,8 +2709,23 @@ class GCSFile(fsspec.spec.AbstractBufferedFile):
         )
 
     def close(self):
+        if self.closed or self._close_deferred:
+            return
+
+        if sys.is_finalizing():
+            self.closed = True
+            return
+
+        if _on_loop_thread(getattr(getattr(self, "gcsfs", None), "loop", None)):
+            self._close_deferred = True
+            _defer_close(self)
+            return
+
+        self._close_impl()
+
+    def _close_impl(self):
         super().close()
-        if hasattr(self, "_prefetch_engine") and self._prefetch_engine:
+        if getattr(self, "_prefetch_engine", None):
             self._prefetch_engine.close()
 
 

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -15,6 +15,7 @@ import threading
 import uuid
 import warnings
 import weakref
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
 from glob import has_magic
 from urllib.parse import parse_qs
@@ -2361,9 +2362,6 @@ def _get_prefetcher_and_cache_config(cache_type, kwargs):
     return cache_type, use_prefetch_reader, cache_source
 
 
-_DEFERRED_CLOSE_THREAD_NAME = "gcsfs-deferred-close"
-
-
 def _on_loop_thread(loop):
     if loop is None:
         return False
@@ -2373,6 +2371,21 @@ def _on_loop_thread(loop):
         return False
 
 
+_DEFERRED_CLOSE_THREAD_NAME = "gcsfs-deferred-close"
+_deferred_close_executor = None
+_deferred_close_executor_lock = threading.Lock()
+
+
+def _get_deferred_close_executor():
+    global _deferred_close_executor
+    with _deferred_close_executor_lock:
+        if _deferred_close_executor is None:
+            _deferred_close_executor = ThreadPoolExecutor(
+                thread_name_prefix=_DEFERRED_CLOSE_THREAD_NAME
+            )
+        return _deferred_close_executor
+
+
 def _defer_close(file):
     def _run():
         try:
@@ -2380,7 +2393,10 @@ def _defer_close(file):
         except Exception:
             logger.exception("deferred close of %s failed", file.path)
 
-    threading.Thread(target=_run, name=_DEFERRED_CLOSE_THREAD_NAME, daemon=True).start()
+    try:
+        _get_deferred_close_executor().submit(_run)
+    except RuntimeError:  # pragma: no cover
+        logger.debug("could not defer close of %s at shutdown", file.path)
 
 
 class GCSFile(fsspec.spec.AbstractBufferedFile):

--- a/gcsfs/tests/test_close_from_event_loop.py
+++ b/gcsfs/tests/test_close_from_event_loop.py
@@ -8,6 +8,7 @@ from unittest import mock
 import fsspec.asyn
 import pytest
 
+from gcsfs import core
 from gcsfs.zonal_file import ZonalFile
 
 
@@ -96,6 +97,49 @@ def test_close_on_loop_thread_is_idempotent(fake_fs, io_loop):
     assert wait_until(lambda: len(calls) == 1), "teardown did not run exactly once"
     time.sleep(0.2)
     assert calls == [1], f"mrd_pool.close() ran {len(calls)} times"
+
+
+def test_deferred_closes_share_a_bounded_thread_pool(fake_fs, io_loop):
+    n_files = 64
+    workers = []
+    lock = threading.Lock()
+
+    class RecordingZonalFile(ZonalFile):
+        def _close_impl(self):
+            current = threading.current_thread()
+            with lock:
+                workers.append((current.ident, current.name))
+            super()._close_impl()
+
+    async def pool_close():
+        pass
+
+    files = []
+    for _ in range(n_files):
+        pool = mock.Mock(persisted_size=1000, details=None, close=pool_close)
+        fake_fs._mrd_pool_cache.get = mock.AsyncMock(return_value=pool)
+        zf = RecordingZonalFile(gcsfs=fake_fs, path="gs://b/test-key", mode="rb")
+        zf.mrd_pool = pool
+        files.append(zf)
+
+    async def close_all():
+        for zf in files:
+            zf.close()
+
+    fsspec.asyn.sync(io_loop, close_all)
+
+    assert wait_until(
+        lambda: len(workers) == n_files
+    ), f"only {len(workers)}/{n_files} deferred closes ran"
+    idents = {ident for ident, _ in workers}
+    max_workers = core._get_deferred_close_executor()._max_workers
+    assert len(idents) <= max_workers, (
+        f"{len(idents)} threads used for {n_files} closes, "
+        f"pool is capped at {max_workers}"
+    )
+    assert all(
+        name.startswith(core._DEFERRED_CLOSE_THREAD_NAME) for _, name in workers
+    ), f"closes ran on unexpected threads: {sorted({n for _, n in workers})}"
 
 
 def test_off_loop_close_still_blocks_and_propagates_errors(fake_fs):

--- a/gcsfs/tests/test_close_from_event_loop.py
+++ b/gcsfs/tests/test_close_from_event_loop.py
@@ -1,0 +1,111 @@
+import asyncio
+import gc
+import sys
+import threading
+import time
+from unittest import mock
+
+import fsspec.asyn
+import pytest
+
+from gcsfs.zonal_file import ZonalFile
+
+
+def wait_until(predicate, timeout=10.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.005)
+    return predicate()
+
+
+@pytest.fixture
+def io_loop():
+    return fsspec.asyn.get_loop()
+
+
+@pytest.fixture
+def fake_fs(io_loop):
+    fs = mock.Mock()
+    fs.split_path.return_value = ("b", "test-key", "1")
+    fs.info.return_value = {"size": 1000, "generation": "1", "name": "test-key"}
+    fs.loop = io_loop
+    return fs
+
+
+def make_read_file(fake_fs, pool_close):
+    pool = mock.Mock(persisted_size=1000, details=None, close=pool_close)
+    fake_fs._mrd_pool_cache.get = mock.AsyncMock(return_value=pool)
+    return ZonalFile(gcsfs=fake_fs, path="gs://b/test-key", mode="rb")
+
+
+def finalize_on_loop(io_loop, holder):
+    async def _drop_and_collect():
+        holder.clear()
+        gc.collect()
+
+    fsspec.asyn.sync(io_loop, _drop_and_collect)
+
+
+def test_read_file_finalized_on_loop_thread_releases_mrd_pool(
+    fake_fs, io_loop, monkeypatch
+):
+    seen = []
+    monkeypatch.setattr(sys, "unraisablehook", seen.append)
+    closed = threading.Event()
+    zf = make_read_file(fake_fs, lambda: closed.set() or asyncio.sleep(0))
+    holder = [zf]
+    del zf
+    finalize_on_loop(io_loop, holder)
+    assert wait_until(closed.is_set), "mrd_pool.close() was never awaited"
+    assert seen == [], f"exception escaped the finalizer: {seen}"
+
+
+def test_write_file_finalized_on_loop_thread_flushes_and_finalizes(fake_fs, io_loop):
+    zf = ZonalFile(
+        gcsfs=fake_fs, path="gs://b/test-key", mode="wb", finalize_on_close=True
+    )
+    aaow = mock.Mock()
+    aaow.flush = mock.AsyncMock()
+    aaow.close = mock.AsyncMock()
+    zf.aaow = aaow
+    zf.buffer.write(b"important data")
+    zf.loc = 14
+    holder = [zf]
+    del zf
+    finalize_on_loop(io_loop, holder)
+    assert wait_until(lambda: aaow.flush.called), "buffered data was never flushed"
+    assert wait_until(lambda: aaow.close.called), "writer was never finalized"
+    assert aaow.close.call_args.kwargs.get("finalize_on_close") is True
+
+
+def test_close_on_loop_thread_is_idempotent(fake_fs, io_loop):
+    calls = []
+
+    async def pool_close():
+        calls.append(1)
+
+    zf = make_read_file(fake_fs, pool_close)
+
+    async def close_twice():
+        zf.close()
+        zf.close()
+
+    fsspec.asyn.sync(io_loop, close_twice)
+    assert wait_until(lambda: len(calls) == 1), "teardown did not run exactly once"
+    time.sleep(0.2)
+    assert calls == [1], f"mrd_pool.close() ran {len(calls)} times"
+
+
+def test_off_loop_close_still_blocks_and_propagates_errors(fake_fs):
+    started = threading.Event()
+
+    async def failing_close():
+        started.set()
+        raise RuntimeError("MRD pool teardown failed")
+
+    zf = make_read_file(fake_fs, failing_close)
+    with pytest.raises(RuntimeError, match="MRD pool teardown failed"):
+        zf.close()
+    assert started.is_set(), "close() must run the teardown synchronously"

--- a/gcsfs/zonal_file.py
+++ b/gcsfs/zonal_file.py
@@ -374,21 +374,12 @@ class ZonalFile(GCSFile):
             "_upload_chunk is not implemented yet for ZonalFile. Please use write() instead."
         )
 
-    def close(self):
-        """
-        Closes the ZonalFile and the underlying AsyncMultiRangeDownloader and AsyncAppendableObjectWriter.
-        If in write mode, finalizes the write if finalize_on_close is True.
-        """
-        if self.closed:
-            return
-
-        # super is closed before aaow since flush may need aaow
-        super().close()
+    def _close_impl(self):
+        super()._close_impl()
 
         if hasattr(self, "mrd_pool") and self.mrd_pool:
             asyn.sync(self.gcsfs.loop, self.mrd_pool.close)
 
-        # Only close aaow if the stream is open
         if self.aaow and self.aaow._is_stream_open:
             asyn.sync(
                 self.gcsfs.loop,


### PR DESCRIPTION
In the webdataset subsystem benchmark, the file is not closed properly, so file cleanup relies on the GC.

When a GCSFile or ZonalFile is garbage collected without an explicit close(), its __del__() finalizer calls close(). If finalization executes on the background fsspec I/O loop thread, synchronous asyn.sync() calls (such as ZonalFile MRD pool / AAOW teardown and file flushing) raise NotImplementedError ("Calling sync() from within a running loop").

- Add _on_loop_thread and _defer_close helpers in gcsfs/core.py to detect execution on the active event loop thread and offload _close_impl() to a daemon thread (gcsfs-deferred-close).
- Refactor GCSFile.close() to guard against re-entrancy via _close_deferred, bypass operations during interpreter shutdown (sys.is_finalizing()), and separate teardown logic into _close_impl().
- Update ZonalFile in gcsfs/zonal_file.py to override _close_impl() instead of close(), inheriting event loop thread detection and deferred execution.
- Add unit tests in gcsfs/tests/test_close_from_event_loop.py verifying read/write finalization on loop threads, idempotency, and synchronous off-loop error propagation.