### PR TITLE
fix(subsystembenchmarks): enable finalize_on_close for datagen shard writes

### DIFF
--- a/gcsfs/tests/perf/subsystembenchmarks/dataloading/datagen.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/dataloading/datagen.py
@@ -40,7 +40,7 @@ def _write_parquet_shard(fs, root, idx, rows, row_group_size, schema, make_chunk
     import pyarrow.parquet as pq
 
     path = f"{root}/shard_{idx:05d}.parquet"
-    with fs.open(path, "wb") as f:
+    with fs.open(path, "wb", finalize_on_close=True) as f:
         with pq.ParquetWriter(f, schema, compression="none") as writer:
             for n in _chunks(rows, row_group_size):
                 writer.write_table(make_chunk(n))
@@ -100,7 +100,7 @@ def _write_pretok_jsonl(fs, root, idx, seq_len, rows, row_group_size):
 
     rng = np.random.default_rng(idx)
     path = f"{root}/shard_{idx:05d}.jsonl"
-    with fs.open(path, "wb") as f:
+    with fs.open(path, "wb", finalize_on_close=True) as f:
         for n in _chunks(rows, row_group_size):
             buf = io.StringIO()
             for _ in range(n):

--- a/gcsfs/tests/perf/subsystembenchmarks/dataloading/tests/test_datagen.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/dataloading/tests/test_datagen.py
@@ -130,7 +130,7 @@ class _RecordingFS:
     def __init__(self):
         self.file = _RecordingFile()
 
-    def open(self, path, mode):
+    def open(self, path, mode, **kwargs):
         return self.file
 
 

--- a/gcsfs/tests/perf/subsystembenchmarks/dataloading/webdataset/imagegen.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/dataloading/webdataset/imagegen.py
@@ -155,7 +155,7 @@ def _write_shard(
     rng = np.random.default_rng([seed, idx])
     path = f"{root}/shard_{idx:05d}{SHARD_EXT[fmt]}"
     images = 0
-    with fs.open(path, "wb") as handle:
+    with fs.open(path, "wb", finalize_on_close=True) as handle:
         with wds.TarWriter(handle, compress=(fmt == "image_tar_gz")) as sink:
             for doc_idx, doc_images in enumerate(document_plan):
                 sample = {


### PR DESCRIPTION
Pass finalize_on_close=True when opening shard files for writing during synthetic dataset generation across dataloading subsystem benchmarks:

- datagen.py: Pass finalize_on_close=True in _write_parquet_shard and _write_pretok_jsonl so Parquet and JSONL shards are finalized upon stream close.
- webdataset/imagegen.py: Pass finalize_on_close=True in _write_shard so WebDataset tar/tar.gz shards are finalized upon stream close.
- test_datagen.py: Accept **kwargs in _RecordingFS.open to support open keyword arguments like finalize_on_close in unit tests.

This ensures generated shard objects are immediately finalized and readable when writing to GCS (such as zonal/Rapid buckets with appendable object writers).