### PR TITLE
fix: preserve user headers in cat_file requests

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1226,10 +1226,10 @@ class GCSFileSystem(DirCacheUpdater, asyn.AsyncFileSystem):
             return b""
 
         u2 = self.url(path, generation=kwargs.get("generation"))
+        head = dict(kwargs.get("headers") or {})
         if start is not None or end is not None:
-            head = {"Range": await self._process_limits(path, start, end)}
-        else:
-            head = {}
+            head = {key: value for key, value in head.items() if key.lower() != "range"}
+            head["Range"] = await self._process_limits(path, start, end)
 
         cache_type = kwargs.get("cache_type")
         cache_source = kwargs.get("cache_source")
@@ -2181,8 +2181,7 @@ class GCSFileSystem(DirCacheUpdater, asyn.AsyncFileSystem):
         )
 
         try:
-            # The concurrent path uses `_cat_file` to interact with gcsfs which doesn't take headers as argument.
-            if concurrency > 1 and "headers" not in kwargs:
+            if concurrency > 1:
                 await self._get_file_concurrent(
                     rpath,
                     lpath,

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -3571,6 +3571,60 @@ async def test_cat_file_generation():
             assert "generation=12345" in url
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "start,end,expected_headers",
+    [
+        (None, None, {"If-Match": "etag", "range": "bytes=1-2"}),
+        (0, 10, {"If-Match": "etag", "Range": "bytes=0-10"}),
+    ],
+)
+async def test_cat_file_headers(start, end, expected_headers):
+    fs = gcsfs.core.GCSFileSystem(token="anon")
+    headers = {"If-Match": "etag", "range": "bytes=1-2"}
+
+    with (
+        mock.patch.object(
+            fs, "_call", new_callable=mock.AsyncMock, return_value=({}, b"data")
+        ) as mock_call,
+        mock.patch.object(
+            fs,
+            "_process_limits",
+            new_callable=mock.AsyncMock,
+            return_value="bytes=0-10",
+        ),
+    ):
+        await fs._cat_file(
+            "bucket/file", start=start, end=end, concurrency=1, headers=headers
+        )
+
+        sent_headers = mock_call.call_args.kwargs["headers"]
+        assert sent_headers == expected_headers
+        assert headers == {"If-Match": "etag", "range": "bytes=1-2"}
+
+
+@pytest.mark.asyncio
+async def test_get_file_headers_use_concurrent_path(tmp_path):
+    fs = gcsfs.core.GCSFileSystem(token="anon")
+    headers = {"If-Match": "etag"}
+
+    with (
+        mock.patch.object(
+            fs, "_get_file_concurrent", new_callable=mock.AsyncMock
+        ) as mock_concurrent,
+        mock.patch.object(
+            fs, "_get_file_request", new_callable=mock.AsyncMock
+        ) as mock_request,
+    ):
+        await fs._get_file(
+            "bucket/file", tmp_path / "file", concurrency=2, headers=headers
+        )
+
+        mock_concurrent.assert_awaited_once()
+        assert mock_concurrent.await_args.kwargs["headers"] is headers
+        mock_request.assert_not_awaited()
+
+
 def test_file_url_generation():
     fs = gcsfs.core.GCSFileSystem(token="anon")
     f = gcsfs.core.GCSFile(fs, "bucket/file", mode="wb")


### PR DESCRIPTION
Fixes #889.

## Summary

- Preserve caller-provided headers in `_cat_file` requests.
- Let explicit `start`/`end` bounds replace any case-insensitive caller `Range` without mutating the caller's mapping.
- Remove the temporary sequential fallback from #877 so concurrent `get_file` downloads retain conditional headers too.

## Testing

- On the upstream base, the three new regression cases failed: both `_cat_file` header cases dropped `If-Match`, and headers forced `get_file` onto the sequential path.
- After rebasing onto current `main` (`ab6bc825`), six focused header, routing, and adjacent generation tests passed with `STORAGE_EMULATOR_HOST=http://localhost:4443`.
- A two-chunk concurrent probe preserved `If-Match`, generated the correct range per chunk, and left the caller mapping unchanged.
- `flake8`, `isort --check-only`, Black, and `git diff --check` passed.

The full emulator-backed suite was not run locally because the Docker daemon is unavailable; upstream CI remains the integration gate.

## AI assistance disclosure

OpenAI Codex prepared the issue reproduction, implementation, tests, rebase, and validation. The GitHub account owner explicitly authorized publication and transition to ready for maintainer review.
