### PR TITLE
fix(subsystembenchmarks): make checkpoint_case prefix generation robust to bucket URIs

### DIFF
--- a/gcsfs/tests/perf/subsystembenchmarks/checkpointing/checkpoint_case.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/checkpointing/checkpoint_case.py
@@ -26,7 +26,11 @@ def run_checkpoint_case(
     with bucket_ctx(BucketSpec.from_env(), params.name) as bucket:
         # bucket_ctx may yield a raw name or a full URI depending on the branch/version.
         # Extract just the bucket name so we can safely construct our own prefix.
-        bucket_name = bucket[len("gs://"):].split("/", 1)[0] if bucket.startswith("gs://") else bucket
+        bucket_name = (
+            bucket[len("gs://") :].split("/", 1)[0]
+            if bucket.startswith("gs://")
+            else bucket
+        )
         params.bucket_name = bucket_name
         prefix = f"gs://{bucket_name}/checkpoint/"
         assert_fsspec_gcsfs(prefix)

--- a/gcsfs/tests/perf/subsystembenchmarks/checkpointing/checkpoint_case.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/checkpointing/checkpoint_case.py
@@ -24,8 +24,11 @@ def run_checkpoint_case(
     bucket_ctx = bucket_ctx or case_bucket
 
     with bucket_ctx(BucketSpec.from_env(), params.name) as bucket:
-        params.bucket_name = bucket
-        prefix = f"gs://{bucket}/checkpoint/"
+        # bucket_ctx may yield a raw name or a full URI depending on the branch/version.
+        # Extract just the bucket name so we can safely construct our own prefix.
+        bucket_name = bucket[len("gs://"):].split("/", 1)[0] if bucket.startswith("gs://") else bucket
+        params.bucket_name = bucket_name
+        prefix = f"gs://{bucket_name}/checkpoint/"
         assert_fsspec_gcsfs(prefix)
 
         # We run the setup phase (which generates the checkpoint) in an isolated OS process.

--- a/gcsfs/tests/perf/subsystembenchmarks/checkpointing/tests/test_checkpoint_case.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/checkpointing/tests/test_checkpoint_case.py
@@ -24,13 +24,16 @@ class _FakeWriteResult:
 
 
 class _FakeWriteDriver:
-    def setup(self, prefix, params):
-        pass
-
     def __init__(self, durations=None):
         self._durations = durations or [1.0, 1.5]
+        self.setup_prefix = None
+        self.run_prefix = None
+
+    def setup(self, prefix, params):
+        self.setup_prefix = prefix
 
     def run(self, prefix, params):
+        self.run_prefix = prefix
         return _FakeWriteResult(durations=self._durations)
 
 
@@ -164,3 +167,56 @@ def test_run_checkpoint_read_case(tmp_path, monkeypatch):
     assert bench.extra_info["workload_implementation"] == "fake"
     assert bench.extra_info["checkpoint_physical_size_bytes"] == 500
     assert bench.extra_info["checkpoint_read_throughput_mean_bytes_per_second"] > 0
+
+def test_checkpoint_case_prefix_generation(monkeypatch):
+    monkeypatch.setattr(checkpoint_case, "assert_fsspec_gcsfs", lambda p: None)
+
+    original_url_to_fs = fsspec.core.url_to_fs
+    def mock_url_to_fs(url, **kwargs):
+        if url.startswith("gs://"):
+            mem_url = url.replace("gs://", "memory://")
+            fs, path = original_url_to_fs(mem_url)
+            # Create a mock checkpoint file
+            model_file = os.path.join(path, "model.ckpt")
+            fs.makedirs(os.path.dirname(model_file), exist_ok=True)
+            with fs.open(model_file, "wb") as f:
+                f.write(b"0" * 500)  # 500 bytes
+            return fs, path
+        return original_url_to_fs(url, **kwargs)
+
+    monkeypatch.setattr(fsspec.core, "url_to_fs", mock_url_to_fs)
+
+    bench = _Bench()
+    params = _params()
+    
+    # Test with full URI returned by bucket_ctx
+    driver_uri = _FakeWriteDriver()
+    @contextlib.contextmanager
+    def uri_bucket_ctx(spec, case_id, **kw):
+        yield "gs://my-bucket/data/"
+
+    checkpoint_case.run_checkpoint_case(
+        bench,
+        _Monitor(),
+        params,
+        driver_uri,
+        bucket_ctx=uri_bucket_ctx,
+    )
+
+    assert driver_uri.run_prefix == "gs://my-bucket/checkpoint/"
+
+    # Test with plain bucket name returned by bucket_ctx
+    driver_name = _FakeWriteDriver()
+    @contextlib.contextmanager
+    def name_bucket_ctx(spec, case_id, **kw):
+        yield "my-bucket-name"
+
+    checkpoint_case.run_checkpoint_case(
+        bench,
+        _Monitor(),
+        params,
+        driver_name,
+        bucket_ctx=name_bucket_ctx,
+    )
+
+    assert driver_name.run_prefix == "gs://my-bucket-name/checkpoint/"

--- a/gcsfs/tests/perf/subsystembenchmarks/checkpointing/tests/test_checkpoint_case.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/checkpointing/tests/test_checkpoint_case.py
@@ -168,10 +168,12 @@ def test_run_checkpoint_read_case(tmp_path, monkeypatch):
     assert bench.extra_info["checkpoint_physical_size_bytes"] == 500
     assert bench.extra_info["checkpoint_read_throughput_mean_bytes_per_second"] > 0
 
+
 def test_checkpoint_case_prefix_generation(monkeypatch):
     monkeypatch.setattr(checkpoint_case, "assert_fsspec_gcsfs", lambda p: None)
 
     original_url_to_fs = fsspec.core.url_to_fs
+
     def mock_url_to_fs(url, **kwargs):
         if url.startswith("gs://"):
             mem_url = url.replace("gs://", "memory://")
@@ -188,9 +190,10 @@ def test_checkpoint_case_prefix_generation(monkeypatch):
 
     bench = _Bench()
     params = _params()
-    
+
     # Test with full URI returned by bucket_ctx
     driver_uri = _FakeWriteDriver()
+
     @contextlib.contextmanager
     def uri_bucket_ctx(spec, case_id, **kw):
         yield "gs://my-bucket/data/"
@@ -207,6 +210,7 @@ def test_checkpoint_case_prefix_generation(monkeypatch):
 
     # Test with plain bucket name returned by bucket_ctx
     driver_name = _FakeWriteDriver()
+
     @contextlib.contextmanager
     def name_bucket_ctx(spec, case_id, **kw):
         yield "my-bucket-name"


### PR DESCRIPTION
### What does this PR do?
This PR fixes a bug in the subsystem benchmark pipeline where the checkpointing case was generating invalid Cloud Storage URIs with a double `gs://gs://` prefix, causing subsequent `NotImplementedError` and HTTP 400 (Invalid Bucket Name) crashes.

### Why was this needed?
In PR #1004, `bucket_ctx` in `bucket.py` was refactored to yield a full corpus URI prefix (e.g., `gs://my-bucket/data/`) instead of a plain bucket name (`my-bucket`). 

However, `checkpoint_case.py` (introduced in PR #994) was still assuming it received a raw bucket name and was hardcoding its own prefix via `f"gs://{bucket}/checkpoint/"`. When run on `main`, this combination resulted in paths like `gs://gs://my-bucket/data//checkpoint/`. 

### How does this fix it?
- Updates `checkpoint_case.py` to defensively parse the bucket name by stripping any `gs://` prefix if one is present before constructing the checkpoint URI. 
- This makes `checkpoint_case` robust to both the old and new behaviors of `bucket.py`, ensuring backward compatibility for users testing older branches.
- Adds a unit test in `test_checkpoint_case.py` to explicitly verify that both `gs://my-bucket/data/` and `my-bucket` correctly resolve to the `gs://my-bucket/checkpoint/` target prefix without duplicating the scheme.