### PR TITLE
fix(benchmark): accurately simulate PyTorch Lightning initialization and isolate pure I/O

### DIFF
--- a/gcsfs/tests/perf/subsystembenchmarks/checkpointing/pytorch_lightning/read/driver.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/checkpointing/pytorch_lightning/read/driver.py
@@ -87,16 +87,14 @@ def _setup_read_trainer(prefix, params, world_size=1, strategy=None):
     trainer.state.fn = TrainerFn.FITTING
     trainer.strategy.setup_environment()
     _call_configure_model(trainer)
-    trainer.strategy.setup(trainer)
+    if trainer.strategy.restore_checkpoint_after_setup:
+        trainer.strategy.setup(trainer)
+
     return trainer
 
 
 def _load_step(trainer, ckpt_path):
-    ckpt = trainer.strategy.load_checkpoint(ckpt_path)
-    if isinstance(ckpt, dict) and "state_dict" in ckpt:
-        trainer.strategy.load_model_state_dict(ckpt)
-        if trainer.optimizers and "optimizer_states" in ckpt:
-            trainer.strategy.load_optimizer_state_dict(ckpt)
+    trainer.strategy.load_checkpoint(ckpt_path)
 
 
 def _rank_load(rank, world_size, port, prefix, params, q):


### PR DESCRIPTION
### Description
This PR refactors the PyTorch Lightning subsystem checkpoint read benchmark to correctly simulate Lightning's internal initialization sequence while strictly isolating pure I/O performance.

**Key Changes:**
1. **Dynamic Setup Phase Validation:** We now mirror PyTorch Lightning's `restore_checkpoint_after_setup` property during the initialization phase (`_setup_read_trainer`) to conditionally trigger model parameter distribution.
   - **FSDP / DeepSpeed / Model Parallel:** `setup()` is invoked *first* (during initialization) to shard the empty model parameters. The subsequent `load_checkpoint()` benchmarking loop simply streams chunks directly from disk into those local shards.
   - **DDP / Single Device:** `setup()` is intentionally skipped entirely. The benchmarking loop runs `load_checkpoint()` to fetch the monolithic checkpoint from disk into memory, mirroring Lightning's behavior without executing the subsequent framework distribution logic.
2. **Isolating File System Metrics:** We removed all post-load PyTorch framework memory copies (`load_model_state_dict` and `load_optimizer_state_dict`) from the benchmarking loop. 
   - These framework operations do zero disk I/O but artificially inflate system memory pressure by maintaining duplicate copies of the weights in memory.
