### PR TITLE
ci: add GitHub Actions workflow to mark and close stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,6 +11,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       issues: write
 
     steps:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,38 @@
+# This workflow warns and then closes issues that have had no activity for a specified amount of time.
+name: Mark and close stale issues
+
+on:
+  schedule:
+    # Scheduled to run at 1:30 UTC everyday
+    - cron: '30 1 * * *'
+  workflow_dispatch: {}
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - uses: actions/stale@v10
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          operations-per-run: 100
+          days-before-issue-stale: 14
+          days-before-issue-close: 7
+          stale-issue-label: "status:stale"
+          close-issue-reason: not_planned
+          any-of-labels: "status:awaiting user response"
+          remove-stale-when-updated: true
+          labels-to-remove-when-unstale: "status:awaiting user response,status:stale"
+          stale-issue-message: >
+            This issue has been marked as stale because it has been awaiting a response for 14 days with no activity.
+            It will be closed in 7 days if no further activity occurs.
+          close-issue-message: >
+            This issue was closed because it has been inactive for 3 weeks after awaiting user response.
+            Please feel free to reopen or open a new issue if you still need assistance. Thanks!
+          # Label that can be assigned to issues to exclude them from being marked as stale
+          exempt-issue-labels: "override-stale"
+          # Exclude Pull Requests
+          days-before-pr-stale: -1
+          days-before-pr-close: -1


### PR DESCRIPTION
### Description
This PR introduces a targeted GitHub Actions workflow (`.github/workflows/stale.yml`) using `actions/stale@v10` to automatically manage and close stale issues that are awaiting user responses.

### Key Policy & Lifecycle Design:
* **Targeted Trigger**: Only affects issues explicitly labeled `status:awaiting user response` (avoids blanket auto-closing open bugs or backlog tasks).
* **3-Week Timeline**:
  * **Day 14 (2 weeks)**: Stale warning comment + adds `status:stale` label.
  * **Day 21 (3 weeks total)**: Closes issue as `not_planned` with an informative closing note.
* **Auto-Recovery**: Any new comment/activity from the author automatically removes both `status:stale` and `status:awaiting user response`, returning the issue to active triage.
* **Exemptions**: Issues tagged `override-stale` are permanently exempt. Pull requests are excluded (`days-before-pr-stale: -1`).

### Maintainer Action Required:
Please ensure the following labels are created in repository settings if not already present:
- `status:awaiting user response` (Color: `#fbca04`)
- `override-stale` (Color: `#ffffff`)
*(Note: `status:stale` will be created automatically by `actions/stale` on its first run if missing).*