### PR TITLE
fix(core): prevent deadlock in deferred file close during garbage collection

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -9,13 +9,13 @@ import logging
 import mimetypes
 import os
 import posixpath
+import queue
 import re
 import sys
 import threading
 import uuid
 import warnings
 import weakref
-from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
 from glob import has_magic
 from urllib.parse import parse_qs
@@ -2369,18 +2369,36 @@ def _on_loop_thread(loop):
 
 
 _DEFERRED_CLOSE_THREAD_NAME = "gcsfs-deferred-close"
-_deferred_close_executor = None
-_deferred_close_executor_lock = threading.Lock()
+_deferred_close_queue = None
+_deferred_close_lock = threading.Lock()
 
 
-def _get_deferred_close_executor():
-    global _deferred_close_executor
-    with _deferred_close_executor_lock:
-        if _deferred_close_executor is None:
-            _deferred_close_executor = ThreadPoolExecutor(
-                thread_name_prefix=_DEFERRED_CLOSE_THREAD_NAME
-            )
-        return _deferred_close_executor
+def _deferred_close_worker(work):
+    while True:
+        job = work.get()
+        if job is None:  # pragma: no cover
+            return
+        try:
+            job()
+        except Exception:
+            logger.exception("deferred close failed")
+
+
+def _start_deferred_close_worker():
+    global _deferred_close_queue
+    if _deferred_close_queue is not None:
+        return _deferred_close_queue
+    with _deferred_close_lock:
+        if _deferred_close_queue is None:
+            work = queue.SimpleQueue()
+            threading.Thread(
+                target=_deferred_close_worker,
+                args=(work,),
+                name=_DEFERRED_CLOSE_THREAD_NAME,
+                daemon=True,
+            ).start()
+            _deferred_close_queue = work
+        return _deferred_close_queue
 
 
 def _defer_close(file):
@@ -2390,10 +2408,10 @@ def _defer_close(file):
         except Exception:
             logger.exception("deferred close of %s failed", file.path)
 
-    try:
-        _get_deferred_close_executor().submit(_run)
-    except RuntimeError:  # pragma: no cover
-        logger.debug("could not defer close of %s at shutdown", file.path)
+    work = _deferred_close_queue
+    if work is None:  # pragma: no cover
+        work = _start_deferred_close_worker()
+    work.put(_run)
 
 
 class GCSFile(fsspec.spec.AbstractBufferedFile):
@@ -2516,6 +2534,7 @@ class GCSFile(fsspec.spec.AbstractBufferedFile):
         self.fixed_key_metadata.update(fixed_key_metadata or {})
         self.kms_key_name = kms_key_name
         self.timeout = timeout
+        _start_deferred_close_worker()
         if mode in {"wb", "xb"}:
             if self.blocksize < GCS_MIN_BLOCK_SIZE:
                 warnings.warn("Setting block size to minimum value, 2**18")

--- a/gcsfs/tests/test_close_from_event_loop.py
+++ b/gcsfs/tests/test_close_from_event_loop.py
@@ -132,10 +132,9 @@ def test_deferred_closes_share_a_bounded_thread_pool(fake_fs, io_loop):
         lambda: len(workers) == n_files
     ), f"only {len(workers)}/{n_files} deferred closes ran"
     idents = {ident for ident, _ in workers}
-    max_workers = core._get_deferred_close_executor()._max_workers
-    assert len(idents) <= max_workers, (
-        f"{len(idents)} threads used for {n_files} closes, "
-        f"pool is capped at {max_workers}"
+    assert len(idents) == 1, (
+        f"{len(idents)} threads used for {n_files} closes; deferred closes "
+        "should share one worker"
     )
     assert all(
         name.startswith(core._DEFERRED_CLOSE_THREAD_NAME) for _, name in workers


### PR DESCRIPTION
### Why Deadlock Occurred

`_defer_close()` used `ThreadPoolExecutor.submit()`, which acquires Python's module-level, non-reentrant `_global_shutdown_lock` for its entire execution.

Because `GCSFile.__del__` calls `_defer_close()` during garbage collection, a GC sweep triggered by memory allocation inside `submit()` causes the same thread to re-enter `submit()`. Attempting to acquire the non-reentrant lock a second time immediately deadlocks the thread against itself. On the `fsspecIO` event loop thread, this permanently freezes all GCS I/O.

### How It Was Fixed

1. Replaced `ThreadPoolExecutor` in `_defer_close` with a dedicated daemon worker thread and a `queue.SimpleQueue`.
2. `SimpleQueue.put()` is a C-level non-blocking append that acquires no locks, making it safe to call from finalizers (`__del__`) during GC.
3. Pre-started the worker thread in `GCSFile.__init__` so `_defer_close` only ever enqueues work.