### PR TITLE
Add engine and method fields to BigQuery benchmarks schema

### DIFF
--- a/cloudbuild/benchmarks/benchmarks_schema.json
+++ b/cloudbuild/benchmarks/benchmarks_schema.json
@@ -33,6 +33,8 @@
       {"name": "min_chunk_size", "type": "STRING"},
       {"name": "max_chunk_size", "type": "STRING"},
       {"name": "seq_probability", "type": "STRING"},
+      {"name": "engine", "type": "STRING"},
+      {"name": "method", "type": "STRING"},
       {"name": "min", "type": "FLOAT"},
       {"name": "max", "type": "FLOAT"},
       {"name": "mean", "type": "FLOAT"},


### PR DESCRIPTION
Add the missing 'engine' and 'method' fields to benchmarks_schema.json to match
the columns generated by the microbenchmark. 