### PR TITLE
feat(macrobenchmarks): add Ray Data and Ray Train metrics parsers and calculation engine

### DIFF
--- a/cloudbuild/macrobenchmarks/metrics/calculate.py
+++ b/cloudbuild/macrobenchmarks/metrics/calculate.py
@@ -254,6 +254,8 @@ def calc_ray_data_metrics(ray_data_iteration_rows: list) -> dict:
         _fail_validation("Ray Data blocked_calls must be a nonnegative integer")
     if total == 0 and blocked != 0:
         _fail_validation("Ray Data blocked time is nonzero for a zero lifetime")
+    if setup > blocked:
+        _fail_validation("Ray Data first-batch time exceeds blocked time")
     percent = 0.0 if total == 0 else 100.0 * blocked / total
     if percent > 100.0 + 1e-9:
         _fail_validation("Ray Data blocked percent exceeds 100")
@@ -966,20 +968,6 @@ def main(argv=None) -> None:
     size_rows = tables.size_rows
     system_rows = tables.system_rows
 
-    validate_required_metrics(
-        step_rows=step_rows,
-        write_rows=write_rows,
-        dl_rows=dl_rows,
-        data_wait_rows=tables.data_wait_rows,
-        restore_rows=restore_rows,
-        expected_steps=args.expected_steps,
-        min_write_datapoints=args.min_write_datapoints,
-        min_restore_datapoints=args.min_restore_datapoints,
-        require_data_loading=args.require_data_loading_metrics,
-        require_data_wait=args.require_data_wait_metrics,
-        resume_run=args.resume_run,
-        checkpoint_interval=args.checkpoint_interval,
-    )
     if args.require_ray_metrics:
         validate_required_ray_metrics(
             step_rows=step_rows,
@@ -997,6 +985,21 @@ def main(argv=None) -> None:
             training_strategy=args.training_strategy,
             data_parallel_size=args.data_parallel_size,
             resume_run=args.resume_run,
+        )
+    else:
+        validate_required_metrics(
+            step_rows=step_rows,
+            write_rows=write_rows,
+            dl_rows=dl_rows,
+            data_wait_rows=tables.data_wait_rows,
+            restore_rows=restore_rows,
+            expected_steps=args.expected_steps,
+            min_write_datapoints=args.min_write_datapoints,
+            min_restore_datapoints=args.min_restore_datapoints,
+            require_data_loading=args.require_data_loading_metrics,
+            require_data_wait=args.require_data_wait_metrics,
+            resume_run=args.resume_run,
+            checkpoint_interval=args.checkpoint_interval,
         )
 
     # Tensor-parallel ranks cooperate on each sample, so model-parallel runs

--- a/cloudbuild/macrobenchmarks/metrics/calculate.py
+++ b/cloudbuild/macrobenchmarks/metrics/calculate.py
@@ -7,9 +7,10 @@ intentionally excluded.
 
 import argparse
 import csv
+import math
 import os
 import sys
-from collections import defaultdict
+from collections import Counter, defaultdict
 
 from metrics import raw_store, stats, summary_schema
 
@@ -102,11 +103,35 @@ def _prefixed(stats_dict: dict, prefix: str, count: int, count_name: str) -> dic
     return out
 
 
-def calc_write_metrics(write_rows: list) -> dict:
+def _write_durations_by_group(write_rows: list, *, maximum_rank_duration: bool) -> dict:
+    groups = defaultdict(list)
+    for row in write_rows:
+        key = (row["checkpoint_step"], row["checkpoint_location"])
+        groups[key].append(row)
+
+    if maximum_rank_duration:
+        return {
+            key: max(row["end_time"] - row["start_time"] for row in rows)
+            for key, rows in groups.items()
+        }
+    return {
+        key: max(row["end_time"] for row in rows)
+        - min(row["start_time"] for row in rows)
+        for key, rows in groups.items()
+    }
+
+
+def calc_write_metrics(
+    write_rows: list, *, maximum_rank_duration: bool = False
+) -> dict:
     if not write_rows:
         return {}
-    groups = _durations_by_group(write_rows, ("checkpoint_step", "checkpoint_location"))
-    durations = [g["duration"] for g in groups.values()]
+    durations = list(
+        _write_durations_by_group(
+            write_rows,
+            maximum_rank_duration=maximum_rank_duration,
+        ).values()
+    )
     return _prefixed(
         stats.duration_stats(durations),
         "checkpoint_write_time",
@@ -186,6 +211,61 @@ def calc_data_loading_metrics(dl_rows: list) -> dict:
     }
 
 
+def _finite_nonnegative(row: dict, field_name: str) -> float:
+    value = row.get(field_name)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        _fail_validation(f"Ray Data {field_name} must be finite nonnegative")
+    value = float(value)
+    if not math.isfinite(value) or value < 0:
+        _fail_validation(f"Ray Data {field_name} must be finite nonnegative")
+    return value
+
+
+def calc_ray_data_metrics(ray_data_iteration_rows: list) -> dict:
+    """Map the bottleneck Ray Data iterator snapshot to summary fields.
+
+    ``num_data_wait_spans`` is deliberately not populated. Ray's ``blocked_calls``
+    counts every batch fetch of the run, which is not the same quantity as the
+    Lightning profiler spans that column carries for the other workload; filling
+    it here would put two values differing by orders of magnitude in one column.
+    ``data_wait_iterator_setup_time`` is Ray's time-to-first-batch, which Ray
+    restarts each epoch, so it is the per-epoch total for the run.
+    """
+    if not ray_data_iteration_rows:
+        return {}
+
+    blocked_values = [
+        _finite_nonnegative(row, "total_blocked_s") for row in ray_data_iteration_rows
+    ]
+    row = ray_data_iteration_rows[
+        max(range(len(ray_data_iteration_rows)), key=blocked_values.__getitem__)
+    ]
+    blocked = _finite_nonnegative(row, "total_blocked_s")
+    setup = _finite_nonnegative(row, "time_to_first_batch_s")
+    total = _finite_nonnegative(row, "total_s")
+    # Validated but not reported: a snapshot with a nonsensical fetch count is a
+    # broken observation even though the count itself has no summary column.
+    blocked_calls = row.get("blocked_calls")
+    if (
+        isinstance(blocked_calls, bool)
+        or not isinstance(blocked_calls, int)
+        or blocked_calls < 0
+    ):
+        _fail_validation("Ray Data blocked_calls must be a nonnegative integer")
+    if total == 0 and blocked != 0:
+        _fail_validation("Ray Data blocked time is nonzero for a zero lifetime")
+    percent = 0.0 if total == 0 else 100.0 * blocked / total
+    if percent > 100.0 + 1e-9:
+        _fail_validation("Ray Data blocked percent exceeds 100")
+    return {
+        "data_wait_total_time": blocked,
+        "data_wait_iterator_setup_time": setup,
+        "data_wait_batch_fetch_time": max(0.0, blocked - setup),
+        "accelerator_blocked_time": blocked,
+        "accelerator_blocked_percent": min(percent, 100.0),
+    }
+
+
 # The two Lightning profiler actions DataWaitProfiler watches; disjoint and
 # jointly exhaustive of the time the fit loop blocks on the train dataloader
 # (see the workload's DATA_WAIT_ACTIONS).
@@ -253,7 +333,12 @@ def calc_dataset_build_metrics(dataset_build_rows: list) -> dict:
     return {"dataset_build_time": max(durations)}
 
 
-def calc_throughput_metrics(write_rows: list, size_rows: list) -> dict:
+def calc_throughput_metrics(
+    write_rows: list,
+    size_rows: list,
+    *,
+    maximum_rank_duration: bool = False,
+) -> dict:
     out = {}
 
     written_sizes = [
@@ -267,13 +352,14 @@ def calc_throughput_metrics(write_rows: list, size_rows: list) -> dict:
         for r in size_rows
         if r.get("checkpoint_step") is not None and r.get("size_bytes") is not None
     }
-    write_groups = _durations_by_group(
-        write_rows, ("checkpoint_step", "checkpoint_location")
+    write_durations = _write_durations_by_group(
+        write_rows,
+        maximum_rank_duration=maximum_rank_duration,
     )
     write_tps = [
-        size_by_step[step] / g["duration"]
-        for (step, _loc), g in write_groups.items()
-        if step in size_by_step and g["duration"] > 0
+        size_by_step[step] / duration
+        for (step, _loc), duration in write_durations.items()
+        if step in size_by_step and duration > 0
     ]
     if write_tps:
         out["checkpoint_write_throughput_avg_bytes_per_sec"] = stats.mean(write_tps)
@@ -439,7 +525,9 @@ def build_summary_row(
     system_rows: list = None,
     data_wait_rows: list = None,
     dataset_build_rows: list = None,
+    ray_data_iteration_rows: list = None,
     dimensions: dict = None,
+    maximum_rank_write_duration: bool = False,
 ) -> dict:
     row = {
         "run_id": run_id,
@@ -449,13 +537,27 @@ def build_summary_row(
     if dimensions:
         row.update({k: v for k, v in dimensions.items() if v is not None})
     row.update(calc_step_time_metrics(step_rows))
-    row.update(calc_write_metrics(write_rows))
+    row.update(
+        calc_write_metrics(
+            write_rows,
+            maximum_rank_duration=maximum_rank_write_duration,
+        )
+    )
     row.update(calc_restore_metrics(restore_rows))
     row.update(calc_delete_metrics(delete_rows))
     row.update(calc_data_loading_metrics(dl_rows))
     row.update(calc_data_wait_metrics(data_wait_rows or []))
     row.update(calc_dataset_build_metrics(dataset_build_rows or []))
-    row.update(calc_throughput_metrics(write_rows, size_rows or []))
+    # Ray's structured iterator snapshot is more complete than the legacy
+    # Lightning profiler rows, so it deliberately owns the overlapping fields.
+    row.update(calc_ray_data_metrics(ray_data_iteration_rows or []))
+    row.update(
+        calc_throughput_metrics(
+            write_rows,
+            size_rows or [],
+            maximum_rank_duration=maximum_rank_write_duration,
+        )
+    )
     row.update(calc_system_metrics(system_rows or []))
     restore_throughput = _restore_throughput(
         row.get("checkpoint_restored_bytes"),
@@ -592,6 +694,205 @@ def validate_required_metrics(
             )
 
 
+def _required_positive_int(value, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        _fail_validation(f"strict Ray metrics require positive {name}")
+    return value
+
+
+def _counter_for(rows: list, field_name: str) -> Counter:
+    return Counter(
+        row.get(field_name) for row in rows if row.get(field_name) is not None
+    )
+
+
+def validate_required_ray_metrics(
+    *,
+    step_rows: list,
+    write_rows: list,
+    restore_rows: list,
+    delete_rows: list,
+    size_rows: list,
+    dataset_build_rows: list,
+    ray_data_iteration_rows: list,
+    expected_steps: int,
+    nodes: int,
+    ranks_per_node: int,
+    checkpoint_interval: int,
+    checkpoints_to_keep: int,
+    training_strategy: str,
+    data_parallel_size: int = None,
+    resume_run: bool = False,
+) -> None:
+    """Enforce the complete structured-observation contract for Ray runs."""
+    nodes = _required_positive_int(nodes, "nodes")
+    ranks_per_node = _required_positive_int(ranks_per_node, "ranks_per_node")
+    checkpoint_interval = _required_positive_int(
+        checkpoint_interval, "checkpoint_interval"
+    )
+    checkpoints_to_keep = _required_positive_int(
+        checkpoints_to_keep, "checkpoints_to_keep"
+    )
+    if (
+        not isinstance(expected_steps, int)
+        or expected_steps == 0
+        or expected_steps < -1
+    ):
+        _fail_validation("strict Ray metrics require expected_steps > 0 or -1")
+    if not isinstance(training_strategy, str) or not training_strategy:
+        _fail_validation("strict Ray metrics require training_strategy")
+    world_size = nodes * ranks_per_node
+
+    observed_step_counter = _counter_for(step_rows, "step")
+    if expected_steps == -1:
+        if not observed_step_counter:
+            _fail_validation("Ray step IDs are missing")
+        last_step = max(observed_step_counter)
+        commit_steps = [
+            row.get("checkpoint_step")
+            for row in write_rows
+            if row.get("checkpoint_step") is not None
+        ]
+        # An epoch-bounded run has no configured step count, so a lost tail of
+        # `step` records would otherwise define the very expectation it is
+        # checked against. The checkpoint schedule is an independent witness:
+        # the run must have ended inside the interval that follows its last
+        # checkpoint, which bounds an undetectable loss to less than one
+        # interval instead of leaving it unbounded.
+        if commit_steps:
+            last_commit = max(commit_steps)
+            if not last_commit <= last_step < last_commit + checkpoint_interval:
+                _fail_validation(
+                    f"Ray step records end at {last_step}, which is inconsistent "
+                    f"with the last checkpoint at step {last_commit} and "
+                    f"checkpoint interval {checkpoint_interval}"
+                )
+    else:
+        last_step = expected_steps
+    expected_step_ids = set(range(1, last_step + 1))
+    if (
+        set(observed_step_counter) != expected_step_ids
+        or any(count != 1 for count in observed_step_counter.values())
+        or len(step_rows) != len(expected_step_ids)
+    ):
+        _fail_validation(
+            "Ray step IDs must be exactly contiguous from 1 through "
+            f"{last_step}; found {sorted(observed_step_counter)}"
+        )
+
+    scheduled_steps = {
+        step for step in expected_step_ids if step % checkpoint_interval == 0
+    }
+    checkpoint_ranks = (
+        range(world_size) if training_strategy.endswith("_sharded") else (0,)
+    )
+    expected_commits = Counter(
+        (step, rank) for step in scheduled_steps for rank in checkpoint_ranks
+    )
+    observed_commits = Counter(
+        (row.get("checkpoint_step"), row.get("global_rank")) for row in write_rows
+    )
+    if observed_commits != expected_commits:
+        _fail_validation(
+            "Ray checkpoint commits must contain exactly one row per expected "
+            f"step and rank; expected {dict(expected_commits)}, found "
+            f"{dict(observed_commits)}"
+        )
+    expected_checkpoint_counter = Counter({step: 1 for step in scheduled_steps})
+    size_counter = _counter_for(size_rows, "checkpoint_step")
+    if size_counter != expected_checkpoint_counter or len(size_rows) != len(
+        scheduled_steps
+    ):
+        _fail_validation(
+            "Ray checkpoint sizes must contain exactly one row for scheduled "
+            f"steps {sorted(scheduled_steps)}; found {dict(size_counter)}"
+        )
+    size_locations = {
+        row["checkpoint_step"]: row.get("checkpoint_location") for row in size_rows
+    }
+    commit_locations = defaultdict(set)
+    for row in write_rows:
+        commit_locations[row["checkpoint_step"]].add(row.get("checkpoint_location"))
+    if any(
+        commit_locations[step] != {size_locations.get(step)}
+        or not size_locations.get(step)
+        for step in scheduled_steps
+    ):
+        _fail_validation("Ray checkpoint commit and size locations do not match")
+
+    if len(dataset_build_rows) != 1:
+        _fail_validation(
+            "Ray metrics require exactly one dataset-build row; found "
+            f"{len(dataset_build_rows)}"
+        )
+    if dataset_build_rows[0].get("global_rank") != 0:
+        _fail_validation("Ray dataset-build row must be emitted by global rank 0")
+
+    model_parallel = training_strategy.startswith("model_parallel")
+    if model_parallel:
+        data_parallel_size = _required_positive_int(
+            data_parallel_size, "data_parallel_size"
+        )
+        if world_size % data_parallel_size:
+            _fail_validation(
+                "Ray model-parallel world size is not divisible by DP size"
+            )
+        tensor_parallel_size = world_size // data_parallel_size
+        expected_leader_ranks = {
+            split * tensor_parallel_size for split in range(data_parallel_size)
+        }
+        expected_data_leaders = data_parallel_size
+    else:
+        expected_leader_ranks = set(range(world_size))
+        expected_data_leaders = world_size
+    expected_splits = set(range(expected_data_leaders))
+    split_counter = _counter_for(ray_data_iteration_rows, "split_index")
+    observed_leader_ranks = {row.get("global_rank") for row in ray_data_iteration_rows}
+    if (
+        split_counter != Counter({split: 1 for split in expected_splits})
+        or len(ray_data_iteration_rows) != expected_data_leaders
+        or observed_leader_ranks != expected_leader_ranks
+    ):
+        _fail_validation(
+            "Ray Data snapshots must contain exactly one row per data leader; "
+            f"expected splits {sorted(expected_splits)} and ranks "
+            f"{sorted(expected_leader_ranks)}, found splits {dict(split_counter)} "
+            f"and ranks {sorted(observed_leader_ranks, key=str)}"
+        )
+    for row in ray_data_iteration_rows:
+        calc_ray_data_metrics([row])
+
+    expected_world_ranks = set(range(world_size))
+    if resume_run:
+        restore_rank_counter = _counter_for(restore_rows, "global_rank")
+        if (
+            restore_rank_counter != Counter({rank: 1 for rank in expected_world_ranks})
+            or len(restore_rows) != world_size
+        ):
+            _fail_validation(
+                "Ray restore metrics must contain exactly one row per world rank; "
+                f"found {dict(restore_rank_counter)}"
+            )
+        restore_locations = {row.get("checkpoint_location") for row in restore_rows}
+        if len(restore_locations) != 1 or None in restore_locations:
+            _fail_validation("Ray restore ranks did not restore the same checkpoint")
+    elif restore_rows:
+        _fail_validation("unexpected Ray restore metrics for a fresh run")
+
+    # A failed deletion is rejected by parsers/ray_train.py, which refuses to
+    # emit a row for it at all, so there is deliberately no second check here.
+    expected_deletes = max(0, len(scheduled_steps) - checkpoints_to_keep)
+    delete_keys = {
+        (row.get("checkpoint_step"), row.get("checkpoint_location"))
+        for row in delete_rows
+    }
+    if len(delete_rows) != expected_deletes or len(delete_keys) != expected_deletes:
+        _fail_validation(
+            f"Ray checkpoint deletion metrics require exactly {expected_deletes} "
+            f"unique rows; found {len(delete_rows)}"
+        )
+
+
 def _fail_validation(message: str) -> None:
     print(f"ERROR: {message}", file=sys.stderr)
     raise SystemExit(1)
@@ -619,6 +920,11 @@ def main(argv=None) -> None:
         "--require-data-wait-metrics",
         action="store_true",
         help="Fail unless both Data Wait span kinds (setup + fetch) are present.",
+    )
+    parser.add_argument(
+        "--require-ray-metrics",
+        action="store_true",
+        help="Fail unless the complete structured Ray metric profile is present.",
     )
     parser.add_argument(
         "--resume-run",
@@ -674,22 +980,45 @@ def main(argv=None) -> None:
         resume_run=args.resume_run,
         checkpoint_interval=args.checkpoint_interval,
     )
-
-    # global_batch_size = per_device_batch * grad_accum * world_size, with
-    # world_size = nodes * ranks_per_node -- mirrors the sim's formula. Derived
-    # here (not a flag) so it stays consistent with its components; left N/A
-    # when any component is absent rather than reporting a partial product.
-    global_batch_size = None
-    components = (
-        args.per_device_batch,
-        args.grad_accum,
-        args.nodes,
-        args.ranks_per_node,
-    )
-    if all(c is not None for c in components):
-        global_batch_size = (
-            args.per_device_batch * args.grad_accum * args.nodes * args.ranks_per_node
+    if args.require_ray_metrics:
+        validate_required_ray_metrics(
+            step_rows=step_rows,
+            write_rows=write_rows,
+            restore_rows=restore_rows,
+            delete_rows=delete_rows,
+            size_rows=size_rows,
+            dataset_build_rows=tables.dataset_build_rows,
+            ray_data_iteration_rows=tables.ray_data_iteration_rows,
+            expected_steps=args.expected_steps,
+            nodes=args.nodes,
+            ranks_per_node=args.ranks_per_node,
+            checkpoint_interval=args.checkpoint_interval,
+            checkpoints_to_keep=args.checkpoints_to_keep,
+            training_strategy=args.training_strategy,
+            data_parallel_size=args.data_parallel_size,
+            resume_run=args.resume_run,
         )
+
+    # Tensor-parallel ranks cooperate on each sample, so model-parallel runs
+    # scale batch size by DP replicas. Other strategies use every world rank as
+    # a data replica. Leave the result N/A when a required input is absent.
+    global_batch_size = None
+    model_parallel = (args.training_strategy or "").startswith("model_parallel")
+    if model_parallel:
+        components = (
+            args.per_device_batch,
+            args.grad_accum,
+            args.data_parallel_size,
+        )
+    else:
+        components = (
+            args.per_device_batch,
+            args.grad_accum,
+            args.nodes,
+            args.ranks_per_node,
+        )
+    if all(c is not None for c in components):
+        global_batch_size = math.prod(components)
 
     # max_epochs can end a run before --steps is reached; report what ran.
     recorded_steps = args.steps
@@ -724,7 +1053,7 @@ def main(argv=None) -> None:
     }
     # TP/DP apply to model_parallel only; omitting them for ddp/fsdp lets
     # DictWriter's restval="N/A" mark them not-applicable.
-    if (args.training_strategy or "").startswith("model_parallel"):
+    if model_parallel:
         dimensions["tensor_parallel_size"] = args.tensor_parallel_size
         dimensions["data_parallel_size"] = args.data_parallel_size
     row = build_summary_row(
@@ -740,7 +1069,9 @@ def main(argv=None) -> None:
         system_rows=system_rows,
         data_wait_rows=tables.data_wait_rows,
         dataset_build_rows=tables.dataset_build_rows,
+        ray_data_iteration_rows=tables.ray_data_iteration_rows,
         dimensions=dimensions,
+        maximum_rank_write_duration=args.require_ray_metrics,
     )
 
     os.makedirs(os.path.dirname(os.path.abspath(args.out_file)), exist_ok=True)

--- a/cloudbuild/macrobenchmarks/metrics/parsers/common.py
+++ b/cloudbuild/macrobenchmarks/metrics/parsers/common.py
@@ -1,0 +1,74 @@
+"""Cloud Logging helpers shared by macrobenchmark metric parsers."""
+
+from dataclasses import dataclass
+from typing import Iterable
+
+
+@dataclass
+class LogEntry:
+    timestamp: float  # epoch seconds
+    message: str
+
+
+_MAX_PAGE_SIZE = 1000
+
+
+def _default_read_retry():
+    from google.api_core import exceptions as gexc
+    from google.api_core import retry as retries
+
+    return retries.Retry(
+        predicate=retries.if_exception_type(gexc.ResourceExhausted),
+        initial=2.0,
+        maximum=60.0,
+        multiplier=2.0,
+        deadline=180.0,
+    )
+
+
+def _to_log_entry(entry) -> LogEntry:
+    payload = entry.text_payload or (
+        dict(entry.json_payload) if entry.json_payload else ""
+    )
+    message = (
+        payload
+        if isinstance(payload, str)
+        else (payload.get("message", "") if payload else "")
+    )
+    return LogEntry(timestamp=entry.timestamp.timestamp(), message=message)
+
+
+def iter_log_entries(
+    client,
+    project: str,
+    filter_string: str,
+    *,
+    page_size: int = _MAX_PAGE_SIZE,
+    retry=None,
+) -> Iterable[LogEntry]:
+    if retry is None:
+        retry = _default_read_retry()
+
+    def _fetch(token):
+        request = {
+            "resource_names": [f"projects/{project}"],
+            "filter": filter_string,
+            "order_by": "timestamp asc",
+            "page_size": page_size,
+            "page_token": token,
+        }
+        pager = client.list_log_entries(request=request)
+        page = next(pager.pages, None)
+        if page is None:
+            return None, None
+        return page.entries, page.next_page_token
+
+    page_token = None
+    while True:
+        page, page_token = retry(_fetch)(page_token)
+        if page is None:
+            return
+        for entry in page:
+            yield _to_log_entry(entry)
+        if not page_token:
+            return

--- a/cloudbuild/macrobenchmarks/metrics/parsers/hf.py
+++ b/cloudbuild/macrobenchmarks/metrics/parsers/hf.py
@@ -13,6 +13,17 @@ from dataclasses import dataclass, field
 from typing import Dict, Iterable, List
 
 from metrics import raw_store, schema
+from metrics.parsers.common import _MAX_PAGE_SIZE as _COMMON_MAX_PAGE_SIZE
+from metrics.parsers.common import LogEntry
+from metrics.parsers.common import _default_read_retry as _common_default_read_retry
+from metrics.parsers.common import _to_log_entry as _common_to_log_entry
+from metrics.parsers.common import iter_log_entries
+
+# Preserve the parser's prior private names for callers and tests that import
+# them while keeping the implementation shared with structured parsers.
+_MAX_PAGE_SIZE = _COMMON_MAX_PAGE_SIZE
+_default_read_retry = _common_default_read_retry
+_to_log_entry = _common_to_log_entry
 
 # --- regexes -----------------------------------------------------------
 STEP_METRICS_PATTERN = (
@@ -78,12 +89,6 @@ ALL_PATTERNS = [
     DATA_WAIT_PATTERN,
     DATASET_BUILD_PATTERN,
 ]
-
-
-@dataclass
-class LogEntry:
-    timestamp: float  # epoch seconds
-    message: str
 
 
 @dataclass
@@ -279,70 +284,6 @@ def parse_entries(
                 print(f"Warning: Could not parse dataset build metrics from: {message}")
 
     return out
-
-
-_MAX_PAGE_SIZE = 1000
-
-
-def _default_read_retry():
-    from google.api_core import exceptions as gexc
-    from google.api_core import retry as retries
-
-    return retries.Retry(
-        predicate=retries.if_exception_type(gexc.ResourceExhausted),
-        initial=2.0,
-        maximum=60.0,
-        multiplier=2.0,
-        deadline=180.0,
-    )
-
-
-def _to_log_entry(entry) -> LogEntry:
-    payload = entry.text_payload or (
-        dict(entry.json_payload) if entry.json_payload else ""
-    )
-    message = (
-        payload
-        if isinstance(payload, str)
-        else (payload.get("message", "") if payload else "")
-    )
-    return LogEntry(timestamp=entry.timestamp.timestamp(), message=message)
-
-
-def iter_log_entries(
-    client,
-    project: str,
-    filter_string: str,
-    *,
-    page_size: int = _MAX_PAGE_SIZE,
-    retry=None,
-) -> Iterable[LogEntry]:
-    if retry is None:
-        retry = _default_read_retry()
-
-    def _fetch(token):
-        request = {
-            "resource_names": [f"projects/{project}"],
-            "filter": filter_string,
-            "order_by": "timestamp asc",
-            "page_size": page_size,
-            "page_token": token,
-        }
-        pager = client.list_log_entries(request=request)
-        page = next(pager.pages, None)
-        if page is None:
-            return None, None
-        return page.entries, page.next_page_token
-
-    page_token = None
-    while True:
-        page, page_token = retry(_fetch)(page_token)
-        if page is None:
-            return
-        for entry in page:
-            yield _to_log_entry(entry)
-        if not page_token:
-            return
 
 
 def build_filter(*, project: str, run_id: str, start_time: str, end_time: str) -> str:

--- a/cloudbuild/macrobenchmarks/metrics/parsers/ray_train.py
+++ b/cloudbuild/macrobenchmarks/metrics/parsers/ray_train.py
@@ -1,0 +1,570 @@
+"""Strict regex parser for Ray macrobenchmark metric log records."""
+
+import argparse
+import json
+import math
+import re
+from collections import defaultdict
+from dataclasses import dataclass, field
+from numbers import Real
+from typing import Dict, Iterable, List
+
+from metrics import raw_store, schema
+from metrics.parsers.common import LogEntry, iter_log_entries
+from metrics.parsers.hf import (
+    CHECKPOINT_DELETE_PATTERN,
+    CHECKPOINT_END_PATTERN,
+    CHECKPOINT_RESTORE_END_PATTERN,
+    CHECKPOINT_RESTORE_START_PATTERN,
+    CHECKPOINT_SIZE_PATTERN,
+    CHECKPOINT_START_PATTERN,
+    DATASET_BUILD_PATTERN,
+    STEP_METRICS_PATTERN,
+)
+
+RAY_DATA_ITERATION_PATTERN = (
+    r"Ray Data Iteration : Rank : ([0-9]+) : Split : ([0-9]+) : "
+    r"Blocked : ([0-9.]+) seconds : Total : ([0-9.]+) seconds : "
+    r"First Batch : ([0-9.]+) seconds : Blocked Calls : ([0-9]+)"
+)
+
+# Cloud Logging must select candidate records, not pre-validate them. Stable
+# literal prefixes let malformed or truncated candidates reach the strict
+# parser and fail the scrape instead of disappearing silently.
+METRIC_PREFIXES = (
+    "Global Rank:",
+    "Dataset Build :",
+    "Checkpoint Save :",
+    "Finished saving checkpoint to ",
+    "Checkpoint Size :",
+    "Checkpoint Restore Start :",
+    "Finished restoring checkpoint :",
+    "Finished deleting checkpoint ",
+    "Ray Data Iteration :",
+)
+
+# Events whose checkpoint_location must sit under the run's checkpoint root.
+# Restores are excluded: a warm start reads a seed or external checkpoint that
+# was deliberately written outside the run's own root.
+_ROOTED_EVENTS = frozenset(
+    {"checkpoint_committed", "checkpoint_size", "checkpoint_deleted"}
+)
+
+
+class MetricEventError(ValueError):
+    """A Ray metric record violates the workload/parser contract."""
+
+
+@dataclass
+class ParsedRawMetrics:
+    step_metrics: List[schema.StepMetrics] = field(default_factory=list)
+    write_metrics: Dict[int, List[schema.WriteDurationMetrics]] = field(
+        default_factory=lambda: defaultdict(list)
+    )
+    restore_metrics: Dict[int, List[schema.RestoreDurationMetrics]] = field(
+        default_factory=lambda: defaultdict(list)
+    )
+    delete_metrics: Dict[int, List[schema.DeleteDurationMetrics]] = field(
+        default_factory=lambda: defaultdict(list)
+    )
+    data_loading_metrics: List[schema.DataLoadingMetrics] = field(default_factory=list)
+    checkpoint_sizes: List[schema.CheckpointSizeMetrics] = field(default_factory=list)
+    data_wait_metrics: List[schema.DataWaitMetrics] = field(default_factory=list)
+    dataset_build_metrics: List[schema.DatasetBuildMetrics] = field(
+        default_factory=list
+    )
+    ray_data_iteration_metrics: List[schema.RayDataIterationMetrics] = field(
+        default_factory=list
+    )
+
+
+def _require_string(payload: dict, field_name: str) -> str:
+    value = payload[field_name]
+    if not isinstance(value, str) or not value:
+        raise MetricEventError(f"Ray metric field {field_name} must be a string")
+    return value
+
+
+def _require_int(payload: dict, field_name: str, *, nonnegative=True) -> int:
+    value = payload[field_name]
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise MetricEventError(f"Ray metric field {field_name} must be an integer")
+    if nonnegative and value < 0:
+        raise MetricEventError(f"Ray metric field {field_name} must be nonnegative")
+    return value
+
+
+def _require_number(payload: dict, field_name: str, *, nonnegative=True) -> float:
+    value = payload[field_name]
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise MetricEventError(f"Ray metric field {field_name} must be numeric")
+    value = float(value)
+    if not math.isfinite(value):
+        raise MetricEventError(f"non-finite metric field {field_name}")
+    if nonnegative and value < 0:
+        raise MetricEventError(f"Ray metric field {field_name} must be nonnegative")
+    return value
+
+
+def _location_root(uri: str) -> str:
+    """The scheme-less prefix that checkpoint locations are expected under.
+
+    Ray keeps the URI scheme in the filesystem object and carries bare
+    ``bucket/path`` strings, while the pipeline supplies a ``gs://`` URI.
+    """
+    for scheme in ("gs://", "gcs://"):
+        if uri.startswith(scheme):
+            uri = uri[len(scheme) :]
+            break
+    return uri.rstrip("/")
+
+
+def _require_location_under(location: str, root: str, event: str) -> None:
+    # Normalized on both sides: Ray carries scheme-less paths, but a location is
+    # allowed to spell out the scheme the pipeline's root argument uses.
+    normalized = _location_root(location)
+    if normalized != root and not normalized.startswith(f"{root}/"):
+        raise MetricEventError(
+            f"{event} checkpoint_location {location!r} is not under the run's "
+            f"checkpoint root {root!r}"
+        )
+
+
+def _validate_event_fields(payload: dict) -> None:
+    event = payload["event"]
+    if event == "step":
+        _require_int(payload, "step")
+        _require_number(payload, "duration_s")
+        _require_number(payload, "samples_per_second")
+        if "end_time_s" in payload:
+            _require_number(payload, "end_time_s")
+    elif event == "dataset_build":
+        _require_int(payload, "global_rank")
+        _require_number(payload, "duration_s")
+        _require_string(payload, "dataset_path")
+    elif event in {"checkpoint_committed", "checkpoint_size"}:
+        _require_int(payload, "checkpoint_step")
+        _require_string(payload, "checkpoint_location")
+        if event == "checkpoint_committed":
+            _require_int(payload, "global_rank")
+            _require_number(payload, "duration_s")
+        else:
+            _require_int(payload, "size_bytes")
+    elif event in {
+        "checkpoint_restore_started",
+        "checkpoint_restore_completed",
+    }:
+        _require_string(payload, "restore_id")
+        _require_int(payload, "global_rank")
+        if "checkpoint_step" in payload:
+            _require_int(payload, "checkpoint_step")
+        _require_string(payload, "checkpoint_location")
+        _require_number(payload, "time_s")
+    elif event == "checkpoint_deleted":
+        _require_int(payload, "checkpoint_step")
+        _require_string(payload, "checkpoint_location")
+        _require_number(payload, "duration_s")
+        if not isinstance(payload["success"], bool):
+            raise MetricEventError("Ray metric field success must be a boolean")
+    elif event == "ray_data_iteration":
+        for field_name in ("global_rank", "split_index"):
+            _require_int(payload, field_name)
+        for field_name in (
+            "total_blocked_s",
+            "total_s",
+            "time_to_first_batch_s",
+        ):
+            _require_number(payload, field_name)
+        _require_int(payload, "blocked_calls")
+
+
+def _base_payload(event, event_id, **fields):
+    return {
+        "event": event,
+        "event_id": event_id,
+        **fields,
+    }
+
+
+def _record_checkpoint_half(store, key, value, half):
+    existing = store.get(key)
+    if existing is None:
+        store[key] = value
+    elif existing != value:
+        raise MetricEventError(f"conflicting checkpoint save {half} {key!r}")
+
+
+def _event_payloads(entries: Iterable[LogEntry]):
+    checkpoint_starts = {}
+    checkpoint_completions = {}
+    for entry in entries:
+        message = entry.message
+        match = re.fullmatch(STEP_METRICS_PATTERN, message)
+        if match:
+            step = int(match.group(1))
+            yield entry, _base_payload(
+                "step",
+                f"step:{step}",
+                step=step,
+                duration_s=float(match.group(2)),
+                samples_per_second=float(match.group(3)),
+            )
+            continue
+
+        match = re.fullmatch(DATASET_BUILD_PATTERN, message)
+        if match:
+            rank = int(match.group(1))
+            yield entry, _base_payload(
+                "dataset_build",
+                f"dataset-build:{rank}",
+                global_rank=rank,
+                duration_s=float(match.group(2)),
+                dataset_path=match.group(3),
+            )
+            continue
+
+        match = re.fullmatch(CHECKPOINT_START_PATTERN, message)
+        if match:
+            rank = int(match.group(1))
+            step = int(match.group(2))
+            _record_checkpoint_half(
+                checkpoint_starts,
+                (step, rank),
+                {
+                    "start_time": float(match.group(3)),
+                    "path": match.group(4),
+                },
+                "start",
+            )
+            continue
+
+        match = re.fullmatch(CHECKPOINT_END_PATTERN, message)
+        if match:
+            location = match.group(1)
+            duration = float(match.group(2))
+            step = int(match.group(3))
+            rank = int(match.group(4))
+            _record_checkpoint_half(
+                checkpoint_completions,
+                (step, rank),
+                {"path": location, "duration_s": duration},
+                "completion",
+            )
+            continue
+
+        match = re.fullmatch(CHECKPOINT_SIZE_PATTERN, message)
+        if match:
+            rank = int(match.group(1))
+            if rank != 0:
+                raise MetricEventError("checkpoint size must be emitted by rank 0")
+            step = int(match.group(2))
+            yield entry, _base_payload(
+                "checkpoint_size",
+                f"size:{step}",
+                checkpoint_step=step,
+                size_bytes=int(match.group(3)),
+                checkpoint_location=match.group(4),
+            )
+            continue
+
+        match = re.fullmatch(CHECKPOINT_RESTORE_START_PATTERN, message)
+        if match:
+            rank = int(match.group(1))
+            location = match.group(3)
+            restore_id = f"restore:{rank}:{location}"
+            yield entry, _base_payload(
+                "checkpoint_restore_started",
+                f"{restore_id}:started",
+                restore_id=restore_id,
+                global_rank=rank,
+                checkpoint_location=location,
+                time_s=float(match.group(2)),
+            )
+            continue
+
+        match = re.fullmatch(CHECKPOINT_RESTORE_END_PATTERN, message)
+        if match:
+            rank = int(match.group(1))
+            location = match.group(4)
+            restore_id = f"restore:{rank}:{location}"
+            yield entry, _base_payload(
+                "checkpoint_restore_completed",
+                f"{restore_id}:completed",
+                restore_id=restore_id,
+                global_rank=rank,
+                checkpoint_location=location,
+                time_s=float(match.group(3)),
+            )
+            continue
+
+        match = re.fullmatch(CHECKPOINT_DELETE_PATTERN, message)
+        if match:
+            rank = int(match.group(4))
+            if rank != 0:
+                raise MetricEventError("checkpoint delete must be emitted by rank 0")
+            step = int(match.group(3))
+            yield entry, _base_payload(
+                "checkpoint_deleted",
+                f"delete:{step}",
+                checkpoint_step=step,
+                checkpoint_location=match.group(1),
+                duration_s=float(match.group(2)),
+                success=True,
+            )
+            continue
+
+        match = re.fullmatch(RAY_DATA_ITERATION_PATTERN, message)
+        if match:
+            rank = int(match.group(1))
+            yield entry, _base_payload(
+                "ray_data_iteration",
+                f"ray-data:{rank}",
+                global_rank=rank,
+                split_index=int(match.group(2)),
+                total_blocked_s=float(match.group(3)),
+                total_s=float(match.group(4)),
+                time_to_first_batch_s=float(match.group(5)),
+                blocked_calls=int(match.group(6)),
+            )
+            continue
+
+        raise MetricEventError(f"unrecognized Ray metric record: {message}")
+
+    missing_completions = checkpoint_starts.keys() - checkpoint_completions.keys()
+    if missing_completions:
+        key = sorted(missing_completions)[0]
+        raise MetricEventError(f"unmatched checkpoint save start {key!r}")
+    missing_starts = checkpoint_completions.keys() - checkpoint_starts.keys()
+    if missing_starts:
+        key = sorted(missing_starts)[0]
+        raise MetricEventError(f"unmatched checkpoint save completion {key!r}")
+
+    for (step, rank), start in sorted(checkpoint_starts.items()):
+        completion = checkpoint_completions[(step, rank)]
+        if start["path"] != completion["path"]:
+            raise MetricEventError(
+                f"checkpoint save {(step, rank)!r} has mismatched path"
+            )
+        duration = completion["duration_s"]
+        yield LogEntry(
+            timestamp=start["start_time"] + duration,
+            message="",
+        ), _base_payload(
+            "checkpoint_committed",
+            f"commit:{step}:{rank}",
+            global_rank=rank,
+            checkpoint_step=step,
+            checkpoint_location=completion["path"],
+            duration_s=duration,
+        )
+
+
+def _unique_events(entries: Iterable[LogEntry]):
+    seen = {}
+    events = []
+    for entry, payload in _event_payloads(entries):
+        _require_string(payload, "event_id")
+        _validate_event_fields(payload)
+        event_id = payload["event_id"]
+        normalized = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+        if event_id in seen:
+            if seen[event_id] != normalized:
+                raise MetricEventError(f"conflicting duplicate event_id {event_id!r}")
+            continue
+        seen[event_id] = normalized
+        events.append((entry, payload))
+    return events
+
+
+def parse_entries(
+    entries: Iterable[LogEntry], *, run_id: str, checkpoint_location: str
+) -> ParsedRawMetrics:
+    """Decode complete, valid Ray benchmark observations into raw records."""
+    if not isinstance(checkpoint_location, str) or not checkpoint_location:
+        raise MetricEventError("checkpoint_location must be a nonempty string")
+    checkpoint_root = _location_root(checkpoint_location)
+
+    out = ParsedRawMetrics()
+    restore_starts = {}
+    restore_completions = {}
+
+    for entry, payload in _unique_events(entries):
+        event = payload["event"]
+        if event in _ROOTED_EVENTS:
+            _require_location_under(
+                payload["checkpoint_location"], checkpoint_root, event
+            )
+        if event == "step":
+            out.step_metrics.append(
+                schema.StepMetrics(
+                    step=payload["step"],
+                    step_duration=float(payload["duration_s"]),
+                    step_end_time=float(payload.get("end_time_s", entry.timestamp)),
+                    samples_per_second=float(payload["samples_per_second"]),
+                )
+            )
+        elif event == "dataset_build":
+            out.dataset_build_metrics.append(
+                schema.DatasetBuildMetrics(
+                    global_rank=payload["global_rank"],
+                    duration=float(payload["duration_s"]),
+                    dataset_path=payload["dataset_path"],
+                )
+            )
+        elif event == "checkpoint_committed":
+            rank = payload["global_rank"]
+            duration = float(payload["duration_s"])
+            out.write_metrics[rank].append(
+                schema.WriteDurationMetrics(
+                    global_rank=rank,
+                    checkpoint_step=payload["checkpoint_step"],
+                    checkpoint_location=payload["checkpoint_location"],
+                    start_time=entry.timestamp - duration,
+                    end_time=entry.timestamp,
+                )
+            )
+        elif event == "checkpoint_size":
+            out.checkpoint_sizes.append(
+                schema.CheckpointSizeMetrics(
+                    global_rank=0,
+                    checkpoint_step=payload["checkpoint_step"],
+                    checkpoint_location=payload["checkpoint_location"],
+                    size_bytes=payload["size_bytes"],
+                )
+            )
+        elif event == "checkpoint_restore_started":
+            restore_id = payload["restore_id"]
+            if restore_id in restore_starts:
+                raise MetricEventError(f"duplicate restore start {restore_id!r}")
+            restore_starts[restore_id] = payload
+        elif event == "checkpoint_restore_completed":
+            restore_id = payload["restore_id"]
+            if restore_id in restore_completions:
+                raise MetricEventError(f"duplicate restore completion {restore_id!r}")
+            restore_completions[restore_id] = payload
+        elif event == "checkpoint_deleted":
+            if not payload["success"]:
+                raise MetricEventError(
+                    "failed checkpoint deletion: " f"{payload['checkpoint_location']}"
+                )
+            end_time = entry.timestamp
+            duration = float(payload["duration_s"])
+            out.delete_metrics[0].append(
+                schema.DeleteDurationMetrics(
+                    global_rank=0,
+                    checkpoint_step=payload["checkpoint_step"],
+                    checkpoint_location=payload["checkpoint_location"],
+                    start_time=end_time - duration,
+                    end_time=end_time,
+                )
+            )
+        elif event == "ray_data_iteration":
+            out.ray_data_iteration_metrics.append(
+                schema.RayDataIterationMetrics(
+                    run_id=run_id,
+                    global_rank=payload["global_rank"],
+                    split_index=payload["split_index"],
+                    total_blocked_s=payload["total_blocked_s"],
+                    total_s=payload["total_s"],
+                    time_to_first_batch_s=payload["time_to_first_batch_s"],
+                    blocked_calls=payload["blocked_calls"],
+                )
+            )
+
+    missing_completions = restore_starts.keys() - restore_completions.keys()
+    if missing_completions:
+        raise MetricEventError(
+            f"unmatched restore start {sorted(missing_completions)[0]!r}"
+        )
+    missing_starts = restore_completions.keys() - restore_starts.keys()
+    if missing_starts:
+        raise MetricEventError(
+            f"unmatched restore completion {sorted(missing_starts)[0]!r}"
+        )
+
+    for restore_id, start in restore_starts.items():
+        completion = restore_completions[restore_id]
+        for field_name in ("global_rank", "checkpoint_location"):
+            if start[field_name] != completion[field_name]:
+                raise MetricEventError(
+                    f"restore {restore_id!r} has mismatched {field_name}"
+                )
+        if start.get("checkpoint_step") != completion.get("checkpoint_step"):
+            raise MetricEventError(
+                f"restore {restore_id!r} has mismatched checkpoint_step"
+            )
+        if completion["time_s"] < start["time_s"]:
+            raise MetricEventError(
+                f"restore {restore_id!r} completed before it started"
+            )
+        rank = start["global_rank"]
+        out.restore_metrics[rank].append(
+            schema.RestoreDurationMetrics(
+                global_rank=rank,
+                checkpoint_step=start.get("checkpoint_step"),
+                checkpoint_location=start["checkpoint_location"],
+                start_time=float(start["time_s"]),
+                end_time=float(completion["time_s"]),
+            )
+        )
+
+    return out
+
+
+def build_filter(*, project: str, run_id: str, start_time: str, end_time: str) -> str:
+    metric_candidates = " OR ".join(
+        f'textPayload:"{prefix}"' for prefix in METRIC_PREFIXES
+    )
+    return (
+        'resource.type="k8s_container" '
+        f'resource.labels.project_id="{project}" '
+        f'resource.labels.pod_name:"{run_id}-workload-0-" '
+        "severity>=DEFAULT "
+        f'timestamp>="{start_time}" '
+        f'timestamp<="{end_time}" '
+        f"AND ({metric_candidates})"
+    )
+
+
+def main(argv=None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Scrape Ray benchmark metrics from Cloud Logging into raw CSVs."
+    )
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--project", required=True)
+    parser.add_argument("--start-time", required=True, help="RFC3339")
+    parser.add_argument("--end-time", required=True, help="RFC3339")
+    parser.add_argument(
+        "--checkpoint-location",
+        required=True,
+        help=(
+            "The run's checkpoint root. Commit, size, and delete events must "
+            "name a location under it."
+        ),
+    )
+    parser.add_argument("--out-dir", required=True)
+    parser.add_argument("--run-type", default="perf_optimization")
+    args = parser.parse_args(argv)
+
+    from google.cloud.logging_v2.services.logging_service_v2 import (
+        LoggingServiceV2Client,
+    )
+
+    client = LoggingServiceV2Client()
+    filter_string = build_filter(
+        project=args.project,
+        run_id=args.run_id,
+        start_time=args.start_time,
+        end_time=args.end_time,
+    )
+    parsed = parse_entries(
+        iter_log_entries(client, args.project, filter_string),
+        run_id=args.run_id,
+        checkpoint_location=args.checkpoint_location,
+    )
+    raw_store.write_raw_metrics(parsed, args.out_dir, run_type=args.run_type)
+    print(f"Wrote raw metrics to {args.out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/cloudbuild/macrobenchmarks/metrics/parsers/ray_train.py
+++ b/cloudbuild/macrobenchmarks/metrics/parsers/ray_train.py
@@ -78,15 +78,21 @@ class ParsedRawMetrics:
     )
 
 
+def _require_field(payload: dict, field_name: str):
+    if field_name not in payload:
+        raise MetricEventError(f"Missing field {field_name}")
+    return payload[field_name]
+
+
 def _require_string(payload: dict, field_name: str) -> str:
-    value = payload[field_name]
+    value = _require_field(payload, field_name)
     if not isinstance(value, str) or not value:
         raise MetricEventError(f"Ray metric field {field_name} must be a string")
     return value
 
 
 def _require_int(payload: dict, field_name: str, *, nonnegative=True) -> int:
-    value = payload[field_name]
+    value = _require_field(payload, field_name)
     if isinstance(value, bool) or not isinstance(value, int):
         raise MetricEventError(f"Ray metric field {field_name} must be an integer")
     if nonnegative and value < 0:
@@ -95,7 +101,7 @@ def _require_int(payload: dict, field_name: str, *, nonnegative=True) -> int:
 
 
 def _require_number(payload: dict, field_name: str, *, nonnegative=True) -> float:
-    value = payload[field_name]
+    value = _require_field(payload, field_name)
     if isinstance(value, bool) or not isinstance(value, Real):
         raise MetricEventError(f"Ray metric field {field_name} must be numeric")
     value = float(value)
@@ -131,7 +137,7 @@ def _require_location_under(location: str, root: str, event: str) -> None:
 
 
 def _validate_event_fields(payload: dict) -> None:
-    event = payload["event"]
+    event = _require_field(payload, "event")
     if event == "step":
         _require_int(payload, "step")
         _require_number(payload, "duration_s")
@@ -164,7 +170,7 @@ def _validate_event_fields(payload: dict) -> None:
         _require_int(payload, "checkpoint_step")
         _require_string(payload, "checkpoint_location")
         _require_number(payload, "duration_s")
-        if not isinstance(payload["success"], bool):
+        if not isinstance(_require_field(payload, "success"), bool):
             raise MetricEventError("Ray metric field success must be a boolean")
     elif event == "ray_data_iteration":
         for field_name in ("global_rank", "split_index"):

--- a/cloudbuild/macrobenchmarks/metrics/raw_store.py
+++ b/cloudbuild/macrobenchmarks/metrics/raw_store.py
@@ -30,6 +30,7 @@ class RawMetricTables:
     system_rows: List[dict] = field(default_factory=list)
     data_wait_rows: List[dict] = field(default_factory=list)
     dataset_build_rows: List[dict] = field(default_factory=list)
+    ray_data_iteration_rows: List[dict] = field(default_factory=list)
 
 
 def write_raw_metrics(
@@ -125,6 +126,17 @@ def write_raw_metrics(
             parsed.dataset_build_metrics,
         )
 
+    if getattr(parsed, "ray_data_iteration_metrics", None):
+        _write_csv(
+            os.path.join(
+                out_dir,
+                schema.RAY_DATA_ITERATION_DIRECTORY,
+                schema.RAY_DATA_ITERATION_METRICS_FILE,
+            ),
+            schema.RayDataIterationMetrics,
+            parsed.ray_data_iteration_metrics,
+        )
+
 
 def write_system_metrics(system_rows, out_dir: str) -> None:
     """Write SystemMetric rows to the system-metrics CSV (owned here like the rest)."""
@@ -194,6 +206,13 @@ def read_raw_metrics(
                 in_dir,
                 schema.DATASET_BUILD_DIRECTORY,
                 schema.DATASET_BUILD_METRICS_FILE,
+            )
+        ),
+        ray_data_iteration_rows=_read_csv(
+            os.path.join(
+                in_dir,
+                schema.RAY_DATA_ITERATION_DIRECTORY,
+                schema.RAY_DATA_ITERATION_METRICS_FILE,
             )
         ),
     )

--- a/cloudbuild/macrobenchmarks/metrics/schema.py
+++ b/cloudbuild/macrobenchmarks/metrics/schema.py
@@ -24,6 +24,8 @@ DATASET_BUILD_DIRECTORY = "dataset_build"
 DATASET_BUILD_METRICS_FILE = "dataset_build_metrics.csv"
 SYSTEM_METRICS_DIRECTORY = "system_metrics"
 SYSTEM_METRICS_FILE = "system_metrics.csv"
+RAY_DATA_ITERATION_DIRECTORY = "ray_data_iteration"
+RAY_DATA_ITERATION_METRICS_FILE = "ray_data_iteration_metrics.csv"
 
 
 def fieldnames(dataclass_type) -> list:
@@ -130,3 +132,14 @@ class CheckpointSizeMetrics:
     checkpoint_location: str
     size_bytes: int
     global_rank: int = None
+
+
+@dataclass(kw_only=True)
+class RayDataIterationMetrics:
+    run_id: str
+    global_rank: int
+    split_index: int
+    total_blocked_s: float
+    total_s: float
+    time_to_first_batch_s: float
+    blocked_calls: int

--- a/cloudbuild/macrobenchmarks/metrics/tests/test_calculate_checkpoint.py
+++ b/cloudbuild/macrobenchmarks/metrics/tests/test_calculate_checkpoint.py
@@ -28,6 +28,18 @@ def test_write_metrics_groups_multiple_rows_per_step():
     assert m["checkpoint_write_time_max"] == 40.0
 
 
+def test_ray_write_metrics_use_the_slowest_rank_duration_not_log_span():
+    rows = [
+        _w(25, 28.0, 30.0),
+        _w(25, 93.0, 100.0),
+    ]
+
+    m = calculate.calc_write_metrics(rows, maximum_rank_duration=True)
+
+    assert m["num_checkpoint_write_datapoints"] == 1
+    assert m["checkpoint_write_time_max"] == 7.0
+
+
 def test_delete_metrics_prefix():
     rows = [
         {

--- a/cloudbuild/macrobenchmarks/metrics/tests/test_calculate_ray_data.py
+++ b/cloudbuild/macrobenchmarks/metrics/tests/test_calculate_ray_data.py
@@ -56,6 +56,10 @@ def test_ray_data_reducer_accepts_zero_lifetime_when_unblocked():
     [
         ({"total_blocked_s": 1.0, "total_s": 0.0}, "zero lifetime"),
         ({"total_blocked_s": 11.0, "total_s": 10.0}, "exceeds 100"),
+        (
+            {"total_blocked_s": 1.0, "time_to_first_batch_s": 2.0},
+            "first-batch time exceeds blocked time",
+        ),
         ({"total_blocked_s": float("nan")}, "finite nonnegative"),
         ({"time_to_first_batch_s": -1.0}, "finite nonnegative"),
         ({"blocked_calls": 1.5}, "blocked_calls"),

--- a/cloudbuild/macrobenchmarks/metrics/tests/test_calculate_ray_data.py
+++ b/cloudbuild/macrobenchmarks/metrics/tests/test_calculate_ray_data.py
@@ -1,0 +1,263 @@
+import pytest
+from metrics import calculate
+
+
+def ray_data_row(*, rank, split, blocked, total, setup, blocked_calls):
+    return {
+        "run_id": "run-1",
+        "global_rank": rank,
+        "split_index": split,
+        "total_blocked_s": blocked,
+        "total_s": total,
+        "time_to_first_batch_s": setup,
+        "blocked_calls": blocked_calls,
+    }
+
+
+def test_ray_data_reducer_carries_bottleneck_row_values_together():
+    rows = [
+        ray_data_row(
+            rank=0, split=0, blocked=4.0, total=20.0, setup=1.0, blocked_calls=2
+        ),
+        ray_data_row(
+            rank=1, split=1, blocked=10.0, total=25.0, setup=3.0, blocked_calls=5
+        ),
+    ]
+    assert calculate.calc_ray_data_metrics(rows) == {
+        "data_wait_total_time": 10.0,
+        "data_wait_iterator_setup_time": 3.0,
+        "data_wait_batch_fetch_time": 7.0,
+        "accelerator_blocked_time": 10.0,
+        "accelerator_blocked_percent": 40.0,
+    }
+
+
+def test_ray_data_reducer_leaves_the_lightning_span_count_alone():
+    """Ray's per-batch fetch count is not the profiler-span count that column holds."""
+    rows = [
+        ray_data_row(
+            rank=0, split=0, blocked=4.0, total=20.0, setup=1.0, blocked_calls=2
+        )
+    ]
+    assert "num_data_wait_spans" not in calculate.calc_ray_data_metrics(rows)
+
+
+def test_ray_data_reducer_accepts_zero_lifetime_when_unblocked():
+    rows = [
+        ray_data_row(
+            rank=0, split=0, blocked=0.0, total=0.0, setup=0.0, blocked_calls=0
+        )
+    ]
+    assert calculate.calc_ray_data_metrics(rows)["accelerator_blocked_percent"] == 0.0
+
+
+@pytest.mark.parametrize(
+    "overrides,match",
+    [
+        ({"total_blocked_s": 1.0, "total_s": 0.0}, "zero lifetime"),
+        ({"total_blocked_s": 11.0, "total_s": 10.0}, "exceeds 100"),
+        ({"total_blocked_s": float("nan")}, "finite nonnegative"),
+        ({"time_to_first_batch_s": -1.0}, "finite nonnegative"),
+        ({"blocked_calls": 1.5}, "blocked_calls"),
+    ],
+)
+def test_ray_data_reducer_rejects_invalid_snapshots(overrides, match, capsys):
+    row = ray_data_row(
+        rank=0, split=0, blocked=1.0, total=10.0, setup=0.5, blocked_calls=1
+    )
+    row.update(overrides)
+    with pytest.raises(SystemExit) as exc:
+        calculate.calc_ray_data_metrics([row])
+    assert exc.value.code == 1
+    assert match in capsys.readouterr().err
+
+
+def complete_metrics(*, model_parallel=False, resume=False):
+    checkpoint = "gs://bucket/checkpoints/checkpoint_000004"
+    rows = {
+        "step_rows": [
+            {
+                "step": step,
+                "step_duration": 1.0,
+                "step_end_time": float(step),
+            }
+            for step in range(1, 5)
+        ],
+        "write_rows": [
+            {
+                "checkpoint_step": step,
+                "checkpoint_location": checkpoint.replace("4", str(step)),
+                "start_time": float(step),
+                "end_time": float(step) + 1.0,
+                "global_rank": 0,
+            }
+            for step in (2, 4)
+        ],
+        "restore_rows": [],
+        "delete_rows": [
+            {
+                "checkpoint_step": 2,
+                "checkpoint_location": checkpoint.replace("4", "2"),
+                "start_time": 5.0,
+                "end_time": 6.0,
+                "global_rank": 0,
+            }
+        ],
+        "size_rows": [
+            {
+                "checkpoint_step": step,
+                "checkpoint_location": checkpoint.replace("4", str(step)),
+                "size_bytes": 1000,
+                "global_rank": 0,
+            }
+            for step in (2, 4)
+        ],
+        "dataset_build_rows": [
+            {"global_rank": 0, "duration": 3.0, "dataset_path": "gs://dataset"}
+        ],
+        "ray_data_iteration_rows": [
+            ray_data_row(
+                rank=rank,
+                split=split,
+                blocked=2.0 + split,
+                total=10.0,
+                setup=1.0,
+                blocked_calls=2,
+            )
+            for split, rank in enumerate((0, 2) if model_parallel else (0, 1))
+        ],
+        "expected_steps": 4,
+        "nodes": 1,
+        "ranks_per_node": 4 if model_parallel else 2,
+        "checkpoint_interval": 2,
+        "checkpoints_to_keep": 1,
+        "training_strategy": "model_parallel_sharded" if model_parallel else "ddp",
+        "data_parallel_size": 2 if model_parallel else None,
+        "resume_run": resume,
+    }
+    if resume:
+        rows["restore_rows"] = [
+            {
+                "checkpoint_step": 0,
+                "checkpoint_location": "gs://bucket/seed",
+                "start_time": 0.0,
+                "end_time": 1.0,
+                "global_rank": rank,
+            }
+            for rank in range(rows["nodes"] * rows["ranks_per_node"])
+        ]
+    if rows["training_strategy"].endswith("_sharded"):
+        rows["write_rows"] = [
+            {**row, "global_rank": rank}
+            for row in rows["write_rows"]
+            for rank in range(rows["nodes"] * rows["ranks_per_node"])
+        ]
+    return rows
+
+
+def test_strict_ray_validation_accepts_complete_ddp_metrics():
+    calculate.validate_required_ray_metrics(**complete_metrics())
+
+
+def test_strict_ray_validation_accepts_complete_model_parallel_resume_metrics():
+    calculate.validate_required_ray_metrics(
+        **complete_metrics(model_parallel=True, resume=True)
+    )
+
+
+def test_strict_ray_validation_rejects_missing_sharded_checkpoint_rank():
+    rows = complete_metrics(model_parallel=True)
+    rows["write_rows"].pop()
+
+    with pytest.raises(SystemExit) as exc:
+        calculate.validate_required_ray_metrics(**rows)
+
+    assert exc.value.code == 1
+
+
+def test_strict_ray_validation_rejects_nonzero_rank_for_full_checkpoint():
+    rows = complete_metrics()
+    rows["write_rows"][0]["global_rank"] = 1
+
+    with pytest.raises(SystemExit) as exc:
+        calculate.validate_required_ray_metrics(**rows)
+
+    assert exc.value.code == 1
+
+
+@pytest.mark.parametrize(
+    "mutate,match",
+    [
+        (lambda rows: rows["step_rows"].pop(1), "step IDs"),
+        (lambda rows: rows["write_rows"].pop(), "checkpoint commits"),
+        (lambda rows: rows["write_rows"].append(rows["write_rows"][0]), "commit"),
+        (lambda rows: rows["size_rows"].pop(), "checkpoint sizes"),
+        (lambda rows: rows["dataset_build_rows"].clear(), "dataset-build"),
+        (
+            lambda rows: rows["dataset_build_rows"].append(
+                rows["dataset_build_rows"][0]
+            ),
+            "dataset-build",
+        ),
+        (lambda rows: rows["ray_data_iteration_rows"].pop(), "Ray Data"),
+        (lambda rows: rows["delete_rows"].clear(), "deletion"),
+        (lambda rows: rows["delete_rows"].append(rows["delete_rows"][0]), "deletion"),
+    ],
+)
+def test_strict_ray_validation_rejects_incomplete_or_duplicate_metrics(mutate, match):
+    rows = complete_metrics()
+    mutate(rows)
+    with pytest.raises(SystemExit) as exc:
+        calculate.validate_required_ray_metrics(**rows)
+    assert exc.value.code == 1
+
+
+def test_strict_ray_validation_requires_every_restore_rank():
+    rows = complete_metrics(resume=True)
+    rows["restore_rows"].pop()
+    with pytest.raises(SystemExit) as exc:
+        calculate.validate_required_ray_metrics(**rows)
+    assert exc.value.code == 1
+
+
+def test_strict_ray_validation_rejects_wrong_data_split_identity():
+    rows = complete_metrics()
+    rows["ray_data_iteration_rows"][1]["split_index"] = 0
+    with pytest.raises(SystemExit) as exc:
+        calculate.validate_required_ray_metrics(**rows)
+    assert exc.value.code == 1
+
+
+def test_epoch_bounded_run_accepts_a_step_tail_inside_the_last_interval():
+    """steps=-1 ends wherever the data ran out, which need not be a boundary."""
+    rows = complete_metrics()
+    rows["expected_steps"] = -1
+    rows["step_rows"].append({"step": 5, "step_duration": 1.0, "step_end_time": 5.0})
+    calculate.validate_required_ray_metrics(**rows)
+
+
+def test_epoch_bounded_run_rejects_a_step_tail_lost_past_the_last_checkpoint(capsys):
+    """Without this the surviving records would define their own expectation."""
+    rows = complete_metrics()
+    rows["expected_steps"] = -1
+    # Steps 4+ lost, but the step-4 checkpoint proves the run got that far.
+    rows["step_rows"] = [row for row in rows["step_rows"] if row["step"] < 4]
+    with pytest.raises(SystemExit) as exc:
+        calculate.validate_required_ray_metrics(**rows)
+    assert exc.value.code == 1
+    assert "step records end at 3" in capsys.readouterr().err
+
+
+def test_epoch_bounded_run_rejects_steps_a_full_interval_past_the_last_checkpoint(
+    capsys,
+):
+    rows = complete_metrics()
+    rows["expected_steps"] = -1
+    rows["step_rows"].extend(
+        {"step": step, "step_duration": 1.0, "step_end_time": float(step)}
+        for step in (5, 6)
+    )
+    with pytest.raises(SystemExit) as exc:
+        calculate.validate_required_ray_metrics(**rows)
+    assert exc.value.code == 1
+    assert "step records end at 6" in capsys.readouterr().err

--- a/cloudbuild/macrobenchmarks/metrics/tests/test_calculate_summary.py
+++ b/cloudbuild/macrobenchmarks/metrics/tests/test_calculate_summary.py
@@ -1395,6 +1395,10 @@ def test_main_writes_complete_strict_ray_summary(tmp_path):
             "--out-file",
             str(output),
             "--require-ray-metrics",
+            # The strict Ray profile owns checkpoint completeness; the generic
+            # minimum is intentionally impossible for this two-checkpoint run.
+            "--min-write-datapoints",
+            "3",
             "--expected-steps",
             "4",
             "--nodes",

--- a/cloudbuild/macrobenchmarks/metrics/tests/test_calculate_summary.py
+++ b/cloudbuild/macrobenchmarks/metrics/tests/test_calculate_summary.py
@@ -1,7 +1,7 @@
 import csv
 
 import pytest
-from metrics import calculate
+from metrics import calculate, raw_store, schema, summary_schema
 
 
 def test_data_loading_passthrough_uses_run_wide_row():
@@ -855,6 +855,86 @@ def test_main_emits_model_parallel_training_strategy(tmp_path):
     assert "data_parallel_size" in calculate.SUMMARY_FIELDNAMES
 
 
+def test_model_parallel_global_batch_counts_data_parallel_replicas(tmp_path):
+    in_dir = tmp_path / "raw"
+    _write_step_csv(in_dir)
+    _write_data_loading_csv(in_dir)
+    out_file = tmp_path / "summary.csv"
+    calculate.main(
+        [
+            "--run-id",
+            "r",
+            "--workload-name",
+            "ray-data-ray-train-pytorch",
+            "--requirements",
+            "gcsfs==1.0",
+            "--in-dir",
+            str(in_dir),
+            "--out-file",
+            str(out_file),
+            "--require-data-loading-metrics",
+            "--training-strategy",
+            "model_parallel_sharded",
+            "--nodes",
+            "2",
+            "--ranks-per-node",
+            "4",
+            "--tensor-parallel-size",
+            "4",
+            "--data-parallel-size",
+            "2",
+            "--per-device-batch",
+            "8",
+            "--grad-accum",
+            "1",
+        ]
+    )
+
+    with open(out_file) as f:
+        rows = list(csv.DictReader(f))
+    assert rows[0]["global_batch_size"] == "16"
+
+
+def test_non_model_parallel_global_batch_counts_every_world_rank(tmp_path):
+    """The DP-replica formula applies to model_parallel only; ddp/fsdp keep
+    every world rank as a data replica."""
+    in_dir = tmp_path / "raw"
+    _write_step_csv(in_dir)
+    _write_data_loading_csv(in_dir)
+    out_file = tmp_path / "summary.csv"
+    calculate.main(
+        [
+            "--run-id",
+            "r",
+            "--workload-name",
+            "ray-data-ray-train-pytorch",
+            "--requirements",
+            "gcsfs==1.0",
+            "--in-dir",
+            str(in_dir),
+            "--out-file",
+            str(out_file),
+            "--require-data-loading-metrics",
+            "--training-strategy",
+            "ddp",
+            "--nodes",
+            "2",
+            "--ranks-per-node",
+            "4",
+            "--data-parallel-size",
+            "2",
+            "--per-device-batch",
+            "8",
+            "--grad-accum",
+            "1",
+        ]
+    )
+
+    with open(out_file) as f:
+        rows = list(csv.DictReader(f))
+    assert rows[0]["global_batch_size"] == "64"
+
+
 def test_tp_dp_are_na_for_non_model_parallel_run(tmp_path):
     # ddp run must not be labeled TP=4.
     in_dir = tmp_path / "raw"
@@ -1225,3 +1305,114 @@ def test_summary_restore_throughput_na_without_restored_bytes(tmp_path):
     with open(out_file) as f:
         rows = list(csv.DictReader(f))
     assert rows[0]["checkpoint_restore_throughput_avg_bytes_per_sec"] == "N/A"
+
+
+def test_main_writes_complete_strict_ray_summary(tmp_path):
+    checkpoint_2 = "gs://bucket/checkpoints/checkpoint_000002"
+    checkpoint_4 = "gs://bucket/checkpoints/checkpoint_000004"
+    parsed = type(
+        "Parsed",
+        (),
+        {
+            "step_metrics": [
+                schema.StepMetrics(
+                    step=step,
+                    step_duration=1.0,
+                    step_end_time=float(step),
+                    samples_per_second=8.0,
+                )
+                for step in range(1, 5)
+            ],
+            "write_metrics": {
+                0: [
+                    schema.WriteDurationMetrics(
+                        checkpoint_step=step,
+                        checkpoint_location=location,
+                        start_time=float(step),
+                        end_time=float(step) + 1.0,
+                        global_rank=0,
+                    )
+                    for step, location in ((2, checkpoint_2), (4, checkpoint_4))
+                ]
+            },
+            "restore_metrics": {},
+            "delete_metrics": {
+                0: [
+                    schema.DeleteDurationMetrics(
+                        checkpoint_step=2,
+                        checkpoint_location=checkpoint_2,
+                        start_time=5.0,
+                        end_time=6.0,
+                        global_rank=0,
+                    )
+                ]
+            },
+            "data_loading_metrics": [],
+            "checkpoint_sizes": [
+                schema.CheckpointSizeMetrics(
+                    checkpoint_step=step,
+                    checkpoint_location=location,
+                    size_bytes=1000,
+                    global_rank=0,
+                )
+                for step, location in ((2, checkpoint_2), (4, checkpoint_4))
+            ],
+            "data_wait_metrics": [],
+            "dataset_build_metrics": [
+                schema.DatasetBuildMetrics(
+                    global_rank=0,
+                    duration=2.0,
+                    dataset_path="gs://bucket/dataset",
+                )
+            ],
+            "ray_data_iteration_metrics": [
+                schema.RayDataIterationMetrics(
+                    run_id="run-1",
+                    global_rank=0,
+                    split_index=0,
+                    total_blocked_s=3.0,
+                    total_s=10.0,
+                    time_to_first_batch_s=1.0,
+                    blocked_calls=3,
+                )
+            ],
+        },
+    )()
+    in_dir = tmp_path / "raw"
+    output = tmp_path / "summary.csv"
+    raw_store.write_raw_metrics(parsed, str(in_dir))
+
+    calculate.main(
+        [
+            "--run-id",
+            "run-1",
+            "--workload-name",
+            "ray-data-ray-train-pytorch",
+            "--requirements",
+            "ray @ wheel.whl",
+            "--in-dir",
+            str(in_dir),
+            "--out-file",
+            str(output),
+            "--require-ray-metrics",
+            "--expected-steps",
+            "4",
+            "--nodes",
+            "1",
+            "--ranks-per-node",
+            "1",
+            "--checkpoint-interval",
+            "2",
+            "--checkpoints-to-keep",
+            "1",
+            "--training-strategy",
+            "ddp",
+        ]
+    )
+
+    with output.open(newline="") as stream:
+        reader = csv.DictReader(stream)
+        assert reader.fieldnames == summary_schema.fieldnames()
+        row = next(reader)
+    assert row["accelerator_blocked_time"] == "3.0"
+    assert row["accelerator_blocked_percent"] == "30.0"

--- a/cloudbuild/macrobenchmarks/metrics/tests/test_calculate_throughput.py
+++ b/cloudbuild/macrobenchmarks/metrics/tests/test_calculate_throughput.py
@@ -38,6 +38,32 @@ def test_write_throughput_joins_size_by_step():
     assert m["checkpoint_write_throughput_avg_bytes_per_sec"] == 100.0
 
 
+def test_ray_write_throughput_uses_the_slowest_rank_duration():
+    write_rows = [
+        {
+            "checkpoint_step": 25,
+            "checkpoint_location": "gs://b/ckpt",
+            "start_time": 28.0,
+            "end_time": 30.0,
+        },
+        {
+            "checkpoint_step": 25,
+            "checkpoint_location": "gs://b/ckpt",
+            "start_time": 93.0,
+            "end_time": 100.0,
+        },
+    ]
+    size_rows = [{"checkpoint_step": 25, "size_bytes": 700}]
+
+    m = calculate.calc_throughput_metrics(
+        write_rows,
+        size_rows,
+        maximum_rank_duration=True,
+    )
+
+    assert m["checkpoint_write_throughput_avg_bytes_per_sec"] == 100.0
+
+
 def test_restore_throughput_from_restored_bytes_and_duration():
     assert calculate._restore_throughput(2000, 5.0) == 400.0
 

--- a/cloudbuild/macrobenchmarks/metrics/tests/test_raw_store_sizes.py
+++ b/cloudbuild/macrobenchmarks/metrics/tests/test_raw_store_sizes.py
@@ -12,6 +12,7 @@ class _FakeParsed:
     delete_metrics: dict = field(default_factory=dict)
     data_loading_metrics: List = field(default_factory=list)
     checkpoint_sizes: List = field(default_factory=list)
+    ray_data_iteration_metrics: List = field(default_factory=list)
 
 
 def test_checkpoint_sizes_roundtrip(tmp_path):
@@ -37,6 +38,30 @@ def test_checkpoint_sizes_roundtrip(tmp_path):
     ]
 
 
-def test_absent_sizes_read_as_empty(tmp_path):
+def test_ray_data_iteration_roundtrip(tmp_path):
+    parsed = _FakeParsed(
+        ray_data_iteration_metrics=[
+            schema.RayDataIterationMetrics(
+                run_id="run-1",
+                global_rank=0,
+                split_index=0,
+                total_blocked_s=10.0,
+                total_s=20.0,
+                time_to_first_batch_s=3.0,
+                blocked_calls=5,
+            )
+        ]
+    )
+    raw_store.write_raw_metrics(parsed, str(tmp_path))
     tables = raw_store.read_raw_metrics(str(tmp_path))
-    assert tables.size_rows == []
+    assert tables.ray_data_iteration_rows == [
+        {
+            "run_id": "run-1",
+            "global_rank": 0,
+            "split_index": 0,
+            "total_blocked_s": 10.0,
+            "total_s": 20.0,
+            "time_to_first_batch_s": 3.0,
+            "blocked_calls": 5,
+        }
+    ]

--- a/cloudbuild/macrobenchmarks/metrics/tests/test_ray_train.py
+++ b/cloudbuild/macrobenchmarks/metrics/tests/test_ray_train.py
@@ -237,6 +237,54 @@ def test_malformed_metric_records_fail(message):
 
 
 @pytest.mark.parametrize(
+    "payload,missing_field",
+    [
+        ({}, "event"),
+        (
+            {
+                "event": "step",
+                "duration_s": 1.0,
+                "samples_per_second": 2.0,
+            },
+            "step",
+        ),
+        (
+            {
+                "event": "step",
+                "step": 1,
+                "samples_per_second": 2.0,
+            },
+            "duration_s",
+        ),
+        (
+            {
+                "event": "dataset_build",
+                "global_rank": 0,
+                "duration_s": 1.0,
+            },
+            "dataset_path",
+        ),
+        (
+            {
+                "event": "checkpoint_deleted",
+                "checkpoint_step": 1,
+                "checkpoint_location": "gs://bucket/checkpoint",
+                "duration_s": 1.0,
+            },
+            "success",
+        ),
+    ],
+)
+def test_missing_structured_event_fields_raise_metric_event_error(
+    payload, missing_field
+):
+    with pytest.raises(
+        ray_train.MetricEventError, match=rf"^Missing field {missing_field}$"
+    ):
+        ray_train._validate_event_fields(payload)
+
+
+@pytest.mark.parametrize(
     "entries,match",
     [
         (

--- a/cloudbuild/macrobenchmarks/metrics/tests/test_ray_train.py
+++ b/cloudbuild/macrobenchmarks/metrics/tests/test_ray_train.py
@@ -1,0 +1,365 @@
+import pytest
+from metrics.parsers import ray_train
+
+RUN_ID = "run-1"
+CHECKPOINT_ROOT = "gs://bucket/checkpoints"
+
+
+def parse(entries):
+    return ray_train.parse_entries(
+        entries,
+        run_id=RUN_ID,
+        checkpoint_location=CHECKPOINT_ROOT,
+    )
+
+
+def test_parse_all_lightning_style_ray_metric_records():
+    checkpoint = f"{CHECKPOINT_ROOT}/step-25.ckpt"
+    parsed = parse(
+        [
+            ray_train.LogEntry(
+                timestamp=12.5,
+                message=(
+                    "Global Rank: 0 | Step: 25 | Loss: 1.2500 | "
+                    "Step Time: 1.5s | Throughput: 42 samples/s"
+                ),
+            ),
+            ray_train.LogEntry(
+                timestamp=20.0,
+                message=(
+                    "Dataset Build : Rank : 0 : Duration : 3.25 seconds : "
+                    "Path: gs://bucket/dataset"
+                ),
+            ),
+            ray_train.LogEntry(
+                timestamp=26.0,
+                message=(
+                    "Checkpoint Save : Rank: 0 : Step: 25 : "
+                    f"Start time: 26.0 seconds: Path: {checkpoint}"
+                ),
+            ),
+            ray_train.LogEntry(
+                timestamp=30.0,
+                message=(
+                    f"Finished saving checkpoint to {checkpoint} in 4.0 seconds "
+                    "for global_step 25 from rank 0"
+                ),
+            ),
+            ray_train.LogEntry(
+                timestamp=30.0,
+                message=(
+                    "Checkpoint Size : Rank : 0 : Step : 25 : Bytes : 1234 : "
+                    f"Path: {checkpoint}"
+                ),
+            ),
+            ray_train.LogEntry(
+                timestamp=50.0,
+                message=(
+                    "Checkpoint Restore Start : Rank : 0 : "
+                    f"Start time: 50.0 seconds : Path: {checkpoint}"
+                ),
+            ),
+            ray_train.LogEntry(
+                timestamp=57.5,
+                message=(
+                    "Finished restoring checkpoint : Rank : 0 : "
+                    "Duration: 7.5 seconds : End Time: 57.5 seconds : "
+                    f"Path: {checkpoint}"
+                ),
+            ),
+            ray_train.LogEntry(
+                timestamp=80.0,
+                message=(
+                    f"Finished deleting checkpoint {checkpoint} in 2.0 seconds "
+                    "for global_step 25 from rank 0"
+                ),
+            ),
+            ray_train.LogEntry(
+                timestamp=81.0,
+                message=(
+                    "Ray Data Iteration : Rank : 0 : Split : 0 : "
+                    "Blocked : 10.0 seconds : Total : 20.0 seconds : "
+                    "First Batch : 3.0 seconds : Blocked Calls : 5"
+                ),
+            ),
+        ]
+    )
+
+    assert parsed.dataset_build_metrics[0].duration == 3.25
+    assert parsed.write_metrics[0][0].start_time == 26.0
+    assert parsed.write_metrics[0][0].end_time == 30.0
+    assert parsed.checkpoint_sizes[0].size_bytes == 1234
+    assert parsed.restore_metrics[0][0].start_time == 50.0
+    assert parsed.restore_metrics[0][0].end_time == 57.5
+    assert parsed.delete_metrics[0][0].start_time == 78.0
+    assert parsed.delete_metrics[0][0].end_time == 80.0
+    assert parsed.ray_data_iteration_metrics[0].blocked_calls == 5
+
+
+def test_sharded_commit_preserves_every_rank_for_each_step():
+    checkpoint = f"{CHECKPOINT_ROOT}/step-25.ckpt"
+    durations = [2.0, 7.0, 3.0]
+    starts = [28.0, 34.0, 52.0]
+    entries = []
+    for rank, (start, duration) in enumerate(zip(starts, durations)):
+        entries.extend(
+            [
+                ray_train.LogEntry(
+                    timestamp=start,
+                    message=(
+                        f"Checkpoint Save : Rank: {rank} : Step: 25 : "
+                        f"Start time: {start} seconds: Path: {checkpoint}"
+                    ),
+                ),
+                ray_train.LogEntry(
+                    timestamp=start + duration,
+                    message=(
+                        f"Finished saving checkpoint to {checkpoint} in {duration} "
+                        f"seconds for global_step 25 from rank {rank}"
+                    ),
+                ),
+            ]
+        )
+    rows = parse(entries)
+
+    assert set(rows.write_metrics) == {0, 1, 2}
+    written = [rows.write_metrics[rank][0] for rank in range(3)]
+    assert [row.global_rank for row in written] == [0, 1, 2]
+    assert [row.end_time - row.start_time for row in written] == durations
+    assert [row.end_time for row in written] == [30.0, 41.0, 55.0]
+
+
+@pytest.mark.parametrize(
+    "record_order",
+    [
+        ("start", "end", "end"),
+        ("end", "start"),
+    ],
+)
+def test_checkpoint_halves_are_order_independent_and_idempotent(record_order):
+    checkpoint = f"{CHECKPOINT_ROOT}/step-25.ckpt"
+    records = {
+        "start": ray_train.LogEntry(
+            timestamp=26.0,
+            message=(
+                "Checkpoint Save : Rank: 0 : Step: 25 : "
+                f"Start time: 26.0 seconds: Path: {checkpoint}"
+            ),
+        ),
+        "end": ray_train.LogEntry(
+            timestamp=30.0,
+            message=(
+                f"Finished saving checkpoint to {checkpoint} in 4.0 seconds "
+                "for global_step 25 from rank 0"
+            ),
+        ),
+    }
+
+    parsed = parse([records[kind] for kind in record_order])
+
+    assert len(parsed.write_metrics[0]) == 1
+    assert parsed.write_metrics[0][0].start_time == 26.0
+    assert parsed.write_metrics[0][0].end_time == 30.0
+
+
+def test_conflicting_duplicate_checkpoint_half_fails():
+    checkpoint = f"{CHECKPOINT_ROOT}/step-25.ckpt"
+    with pytest.raises(ray_train.MetricEventError, match="conflicting checkpoint"):
+        parse(
+            [
+                ray_train.LogEntry(
+                    timestamp=26.0,
+                    message=(
+                        "Checkpoint Save : Rank: 0 : Step: 25 : "
+                        f"Start time: 26.0 seconds: Path: {checkpoint}"
+                    ),
+                ),
+                ray_train.LogEntry(
+                    timestamp=27.0,
+                    message=(
+                        "Checkpoint Save : Rank: 0 : Step: 25 : "
+                        f"Start time: 27.0 seconds: Path: {checkpoint}"
+                    ),
+                ),
+            ]
+        )
+
+
+def test_identical_duplicate_event_is_idempotent():
+    item = ray_train.LogEntry(
+        timestamp=10.0,
+        message=(
+            "Global Rank: 0 | Step: 1 | Loss: 1.0000 | "
+            "Step Time: 1.0s | Throughput: 2.0 samples/s"
+        ),
+    )
+    parsed = parse([item, item])
+    assert len(parsed.step_metrics) == 1
+
+
+def test_conflicting_duplicate_event_fails():
+    with pytest.raises(ray_train.MetricEventError, match="conflicting duplicate"):
+        parse(
+            [
+                ray_train.LogEntry(
+                    timestamp=10.0,
+                    message=(
+                        "Global Rank: 0 | Step: 1 | Loss: 1.0000 | "
+                        "Step Time: 1.0s | Throughput: 2.0 samples/s"
+                    ),
+                ),
+                ray_train.LogEntry(
+                    timestamp=11.0,
+                    message=(
+                        "Global Rank: 0 | Step: 1 | Loss: 1.0000 | "
+                        "Step Time: 2.0s | Throughput: 2.0 samples/s"
+                    ),
+                ),
+            ]
+        )
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Global Rank: x | Step: 1 | Loss: 1.0 | Step Time: 1.0s | Throughput: 2.0 samples/s",
+        "Global Rank: 0 | Step: 1",
+        (
+            "Global Rank: 0 | Step: 1 | Loss: 1.0 | Step Time: 1.0s | "
+            "Throughput: 2.0 samples/s trailing-junk"
+        ),
+        "unmarked",
+    ],
+)
+def test_malformed_metric_records_fail(message):
+    with pytest.raises(ray_train.MetricEventError, match="unrecognized"):
+        parse([ray_train.LogEntry(timestamp=0.0, message=message)])
+
+
+@pytest.mark.parametrize(
+    "entries,match",
+    [
+        (
+            [
+                ray_train.LogEntry(
+                    timestamp=1.0,
+                    message=(
+                        "Checkpoint Restore Start : Rank : 0 : Start time: 1.0 "
+                        "seconds : Path: gs://bucket/checkpoint"
+                    ),
+                )
+            ],
+            "unmatched restore start",
+        ),
+        (
+            [
+                ray_train.LogEntry(
+                    timestamp=2.0,
+                    message=(
+                        "Finished restoring checkpoint : Rank : 0 : Duration: 1.0 "
+                        "seconds : End Time: 2.0 seconds : Path: gs://bucket/checkpoint"
+                    ),
+                )
+            ],
+            "unmatched restore completion",
+        ),
+    ],
+)
+def test_unmatched_restore_halves_fail(entries, match):
+    with pytest.raises(ray_train.MetricEventError, match=match):
+        parse(entries)
+
+
+@pytest.mark.parametrize("changed", ["global_rank", "checkpoint_location"])
+def test_restore_pair_identity_must_match(changed):
+    completion_rank = 1 if changed == "global_rank" else 0
+    completion_path = (
+        "gs://bucket/other"
+        if changed == "checkpoint_location"
+        else "gs://bucket/checkpoint"
+    )
+    with pytest.raises(ray_train.MetricEventError, match="unmatched restore"):
+        parse(
+            [
+                ray_train.LogEntry(
+                    timestamp=1.0,
+                    message=(
+                        "Checkpoint Restore Start : Rank : 0 : Start time: 1.0 "
+                        "seconds : Path: gs://bucket/checkpoint"
+                    ),
+                ),
+                ray_train.LogEntry(
+                    timestamp=2.0,
+                    message=(
+                        "Finished restoring checkpoint : Rank : "
+                        f"{completion_rank} : Duration: 1.0 seconds : End Time: "
+                        f"2.0 seconds : Path: {completion_path}"
+                    ),
+                ),
+            ]
+        )
+
+
+def test_build_filter_scopes_to_the_run_pods_and_time_window():
+    filter_string = ray_train.build_filter(
+        project="proj",
+        run_id="run-1",
+        start_time="2026-01-01T00:00:00Z",
+        end_time="2026-01-01T01:00:00Z",
+    )
+    assert 'resource.labels.project_id="proj"' in filter_string
+    assert 'resource.labels.pod_name:"run-1-workload-0-"' in filter_string
+    assert 'timestamp>="2026-01-01T00:00:00Z"' in filter_string
+    assert 'timestamp<="2026-01-01T01:00:00Z"' in filter_string
+
+
+def test_build_filter_selects_metric_prefixes_for_strict_parser_validation():
+    filter_string = ray_train.build_filter(
+        project="proj",
+        run_id="run-1",
+        start_time="2026-01-01T00:00:00Z",
+        end_time="2026-01-01T01:00:00Z",
+    )
+
+    for prefix in ray_train.METRIC_PREFIXES:
+        assert f'textPayload:"{prefix}"' in filter_string
+    assert "textPayload =~" not in filter_string
+    assert "GCSFS_METRIC" not in filter_string
+
+
+def test_checkpoint_events_must_sit_under_the_supplied_checkpoint_root():
+    entries = [
+        ray_train.LogEntry(
+            timestamp=1.0,
+            message=(
+                "Checkpoint Size : Rank : 0 : Step : 1 : Bytes : 10 : "
+                "Path: other-bucket/elsewhere/step-1.ckpt"
+            ),
+        )
+    ]
+    with pytest.raises(ray_train.MetricEventError, match="not under the run's"):
+        parse(entries)
+
+
+def test_restore_locations_are_exempt_from_the_checkpoint_root():
+    """A warm start reads a seed checkpoint written outside the run's root."""
+    seed = "bucket/seed/other-run/step-1.ckpt"
+    parsed = parse(
+        [
+            ray_train.LogEntry(
+                timestamp=1.0,
+                message=(
+                    "Checkpoint Restore Start : Rank : 0 : Start time: 1.0 "
+                    f"seconds : Path: {seed}"
+                ),
+            ),
+            ray_train.LogEntry(
+                timestamp=2.0,
+                message=(
+                    "Finished restoring checkpoint : Rank : 0 : Duration: 1.0 "
+                    f"seconds : End Time: 2.0 seconds : Path: {seed}"
+                ),
+            ),
+        ]
+    )
+    assert parsed.restore_metrics[0][0].start_time == 1.0


### PR DESCRIPTION
Add metric parsers, calculation logic, and schema definitions for processing Ray Data and Ray Train benchmark outputs:
- Parsers for Ray Train and Ray Data log events, iteration wait times, and checkpoint durations.
- Calculation engine support for Ray Train step latency, throughput, and summary metrics.
- BigQuery schema updates and raw store serialization for Ray workload metrics.
- Unit test suite covering parser extraction, calculation calculations, and schema validations.