### PR TITLE
fix: harden prefetcher/zonal teardown

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -36,7 +36,7 @@ from .concurrency import parallel_tasks_first_completed, split_range
 from .credentials import GoogleCredentials
 from .inventory_report import InventoryReport
 from .retry import errs, retry_request, validate_response
-from .zb_hns_utils import DEFAULT_CONCURRENCY, MAX_PREFETCH_SIZE
+from .zb_hns_utils import DEFAULT_CONCURRENCY, MAX_PREFETCH_SIZE, _on_loop_thread
 
 logger = logging.getLogger("gcsfs")
 
@@ -2357,15 +2357,6 @@ def _get_prefetcher_and_cache_config(cache_type, kwargs):
             )
         cache_type = "none" if use_prefetch_reader else "readahead"
     return cache_type, use_prefetch_reader, cache_source
-
-
-def _on_loop_thread(loop):
-    if loop is None:
-        return False
-    try:
-        return asyncio.get_running_loop() is loop
-    except RuntimeError:
-        return False
 
 
 _DEFERRED_CLOSE_THREAD_NAME = "gcsfs-deferred-close"

--- a/gcsfs/prefetcher.py
+++ b/gcsfs/prefetcher.py
@@ -1,18 +1,22 @@
 import asyncio
+import concurrent.futures
 import ctypes
 import logging
+import sys
 import weakref
 from collections import deque
 
 import fsspec.asyn
 
-logger = logging.getLogger(__name__)
-
+from gcsfs.core import _on_loop_thread
 from gcsfs.zb_hns_utils import (
     HAS_CPYTHON_API,
     PyBytes_AsString,
     PyBytes_FromStringAndSize,
 )
+from gcsfs.zonal_file import _defer_task
+
+logger = logging.getLogger(__name__)
 
 
 # Please refer to following discussion to understand why this is required at this point
@@ -821,15 +825,16 @@ class BackgroundPrefetcher:
                 raise
 
     async def _async_close(self):
-        """Asynchronous teardown logic protected by the async lock."""
+        """Asynchronous teardown logic protected by the async lock.
+
+        Held for the duration of teardown so a concurrent in-flight
+        ``_async_fetch`` cannot observe a stopped producer/empty queue as
+        EOF and silently return a truncated read.
+        """
         async with self._async_lock:
-            if self.is_stopped:
-                return
+            logger.debug("Signaling prefetcher stop and tearing down producer.")
 
-            self.is_stopped = True
-            logger.debug("Acquired async lock. Tearing down producer and buffers.")
-
-            if self.producer:
+            if self.producer and not self.producer.is_stopped:
                 await self.producer.stop()
 
             self.consumer.clear_buffer()
@@ -868,8 +873,70 @@ class BackgroundPrefetcher:
 
     async def aclose(self):
         """Safely shuts down the prefetcher from an asynchronous context."""
+        if self.is_stopped:
+            return
+        self.is_stopped = True
         await self._async_close()
 
-    def close(self):
-        """Safely shuts down the prefetcher from a synchronous context."""
-        fsspec.asyn.sync(self.loop, self._async_close)
+    def close(self, timeout: float | None = 10.0):
+        """Safely shuts down the prefetcher from a synchronous context.
+
+        Schedules teardown on the IO loop. If the wait times out, teardown
+        continues in the background to let in-flight reads finish cleanly.
+
+        Args:
+            timeout: Maximum seconds to wait for teardown to finish. Defaults
+                to 10.0 seconds. If 0 or negative, teardown runs fire-and-forget.
+                If None, waits indefinitely.
+        """
+        if self.is_stopped:
+            return
+        self.is_stopped = True
+
+        if sys.is_finalizing():
+            return
+
+        loop = self.loop
+        if loop is None or loop.is_closed() or not loop.is_running():
+            # If the event loop is absent, closed, or not currently serviced
+            # by a running thread, async scheduling is impossible.
+            return
+
+        if _on_loop_thread(loop):
+            # Avoid deadlock when closing reentrantly from the event loop thread.
+            _defer_task(
+                loop,
+                self._async_close(),
+                description="BackgroundPrefetcher teardown",
+                logger=logger,
+                log_level=logging.WARNING,
+            )
+            return
+
+        coro = self._async_close()
+        try:
+            future = asyncio.run_coroutine_threadsafe(coro, loop)
+        except RuntimeError:
+            # Loop was closed concurrently between the checks above and here.
+            # Explicitly close the unawaited coroutine to avoid RuntimeWarning.
+            coro.close()
+            return
+
+        if timeout is not None and timeout <= 0:
+            # Fire-and-forget requested: teardown is scheduled, return without waiting.
+            return
+
+        try:
+            future.result(timeout)
+        except concurrent.futures.TimeoutError:
+            # Teardown timed out on the caller thread. Leave coroutine running in
+            # background on the IO loop so pending network buffers can drain safely.
+            logger.warning(
+                "BackgroundPrefetcher teardown did not complete within %ss; "
+                "it will keep running in the background.",
+                timeout,
+            )
+        except Exception:
+            logger.warning(
+                "Exception while closing BackgroundPrefetcher", exc_info=True
+            )

--- a/gcsfs/prefetcher.py
+++ b/gcsfs/prefetcher.py
@@ -873,9 +873,9 @@ class BackgroundPrefetcher:
 
     async def aclose(self):
         """Safely shuts down the prefetcher from an asynchronous context."""
-        if self.is_stopped:
-            return
         self.is_stopped = True
+        if self.producer is None or self.producer.is_stopped:
+            return
         await self._async_close()
 
     def close(self, timeout: float | None = 10.0):
@@ -889,9 +889,9 @@ class BackgroundPrefetcher:
                 to 10.0 seconds. If 0 or negative, teardown runs fire-and-forget.
                 If None, waits indefinitely.
         """
-        if self.is_stopped:
-            return
         self.is_stopped = True
+        if self.producer is None or self.producer.is_stopped:
+            return
 
         if sys.is_finalizing():
             return

--- a/gcsfs/prefetcher.py
+++ b/gcsfs/prefetcher.py
@@ -874,8 +874,6 @@ class BackgroundPrefetcher:
     async def aclose(self):
         """Safely shuts down the prefetcher from an asynchronous context."""
         self.is_stopped = True
-        if self.producer is None or self.producer.is_stopped:
-            return
         await self._async_close()
 
     def close(self, timeout: float | None = 10.0):
@@ -890,8 +888,6 @@ class BackgroundPrefetcher:
                 If None, waits indefinitely.
         """
         self.is_stopped = True
-        if self.producer is None or self.producer.is_stopped:
-            return
 
         if sys.is_finalizing():
             return

--- a/gcsfs/prefetcher.py
+++ b/gcsfs/prefetcher.py
@@ -1,20 +1,17 @@
 import asyncio
-import concurrent.futures
 import ctypes
 import logging
-import sys
 import weakref
 from collections import deque
 
 import fsspec.asyn
 
-from gcsfs.core import _on_loop_thread
 from gcsfs.zb_hns_utils import (
     HAS_CPYTHON_API,
     PyBytes_AsString,
     PyBytes_FromStringAndSize,
+    sync_teardown,
 )
-from gcsfs.zonal_file import _defer_task
 
 logger = logging.getLogger(__name__)
 
@@ -889,44 +886,14 @@ class BackgroundPrefetcher:
         """
         self.is_stopped = True
 
-        if sys.is_finalizing():
-            return
-
-        loop = self.loop
-        if loop is None or loop.is_closed() or not loop.is_running():
-            # If the event loop is absent, closed, or not currently serviced
-            # by a running thread, async scheduling is impossible.
-            return
-
-        if _on_loop_thread(loop):
-            # Avoid deadlock when closing reentrantly from the event loop thread.
-            _defer_task(
-                loop,
-                self._async_close(),
+        try:
+            sync_teardown(
+                self.loop,
+                self._async_close,
+                timeout=timeout,
                 description="BackgroundPrefetcher teardown",
-                logger=logger,
-                log_level=logging.WARNING,
             )
-            return
-
-        coro = self._async_close()
-        try:
-            future = asyncio.run_coroutine_threadsafe(coro, loop)
-        except RuntimeError:
-            # Loop was closed concurrently between the checks above and here.
-            # Explicitly close the unawaited coroutine to avoid RuntimeWarning.
-            coro.close()
-            return
-
-        if timeout is not None and timeout <= 0:
-            # Fire-and-forget requested: teardown is scheduled, return without waiting.
-            return
-
-        try:
-            future.result(timeout)
-        except concurrent.futures.TimeoutError:
-            # Teardown timed out on the caller thread. Leave coroutine running in
-            # background on the IO loop so pending network buffers can drain safely.
+        except fsspec.asyn.FSTimeoutError:
             logger.warning(
                 "BackgroundPrefetcher teardown did not complete within %ss; "
                 "it will keep running in the background.",

--- a/gcsfs/tests/test_close_from_event_loop.py
+++ b/gcsfs/tests/test_close_from_event_loop.py
@@ -9,7 +9,7 @@ import fsspec.asyn
 import pytest
 
 from gcsfs import core
-from gcsfs.zonal_file import ZonalFile
+from gcsfs.zonal_file import ZonalFile, _defer_task, _deferred_close_tasks
 
 
 def wait_until(predicate, timeout=10.0):
@@ -202,3 +202,51 @@ def test_gcsfile_finalized_on_loop_thread_defers_close(fake_fs, io_loop, monkeyp
     finalize_on_loop(io_loop, holder)
     assert wait_until(closed.is_set), "GCSFile._close_impl() was never called"
     assert seen == [], f"exception escaped the finalizer: {seen}"
+
+
+def test_defer_task_tracks_and_discards_task(io_loop):
+    step1 = threading.Event()
+    step2 = threading.Event()
+
+    async def sample_coro():
+        step1.set()
+        while not step2.is_set():
+            await asyncio.sleep(0.01)
+
+    async def schedule():
+        return _defer_task(io_loop, sample_coro(), description="sample")
+
+    task = fsspec.asyn.sync(io_loop, schedule)
+    assert step1.wait(timeout=5.0)
+    assert task in _deferred_close_tasks
+
+    step2.set()
+    assert wait_until(lambda: task not in _deferred_close_tasks, timeout=5.0)
+    assert task.done()
+
+
+def test_defer_task_logs_exception(io_loop, caplog):
+    import logging
+
+    async def boom():
+        raise ValueError("custom boom error")
+
+    async def schedule():
+        task = _defer_task(
+            io_loop,
+            boom(),
+            description="custom boom",
+            logger=logging.getLogger("gcsfs"),
+            log_level=logging.ERROR,
+        )
+        await asyncio.sleep(0.05)
+        return task
+
+    with caplog.at_level(logging.ERROR, logger="gcsfs"):
+        task = fsspec.asyn.sync(io_loop, schedule)
+        assert wait_until(lambda: task not in _deferred_close_tasks, timeout=5.0)
+
+    assert any(
+        "custom boom" in r.message and "custom boom error" in r.message
+        for r in caplog.records
+    )

--- a/gcsfs/tests/test_close_from_event_loop.py
+++ b/gcsfs/tests/test_close_from_event_loop.py
@@ -9,7 +9,8 @@ import fsspec.asyn
 import pytest
 
 from gcsfs import core
-from gcsfs.zonal_file import ZonalFile, _defer_task, _deferred_close_tasks
+from gcsfs.zb_hns_utils import _defer_task, _deferred_close_tasks
+from gcsfs.zonal_file import ZonalFile
 
 
 def wait_until(predicate, timeout=10.0):

--- a/gcsfs/tests/test_prefetcher.py
+++ b/gcsfs/tests/test_prefetcher.py
@@ -876,29 +876,32 @@ def test_close_zero_and_negative_timeout_is_fire_and_forget(prefetcher_factory):
         coro.close()  # avoid a "coroutine was never awaited" warning
         return never_resolves
 
-    with mock.patch(
-        "asyncio.run_coroutine_threadsafe", side_effect=fake_schedule
-    ) as mock_schedule:
-        start = time.monotonic()
-        bp.close(timeout=0)
-        elapsed_zero = time.monotonic() - start
+    try:
+        with mock.patch(
+            "asyncio.run_coroutine_threadsafe", side_effect=fake_schedule
+        ) as mock_schedule:
+            start = time.monotonic()
+            bp.close(timeout=0)
+            elapsed_zero = time.monotonic() - start
 
-    mock_schedule.assert_called_once()
-    assert bp.is_stopped is True
-    assert elapsed_zero < 0.5
+        mock_schedule.assert_called_once()
+        assert bp.is_stopped is True
+        assert elapsed_zero < 0.5
 
-    # Also verify negative timeout is non-blocking
-    bp2 = prefetcher_factory(fetcher=MockFetcher(b"X"), size=100, concurrency=1)
-    with mock.patch(
-        "asyncio.run_coroutine_threadsafe", side_effect=fake_schedule
-    ) as mock_schedule_neg:
-        start = time.monotonic()
-        bp2.close(timeout=-1)
-        elapsed_neg = time.monotonic() - start
+        # Also verify negative timeout is non-blocking
+        bp2 = prefetcher_factory(fetcher=MockFetcher(b"X"), size=100, concurrency=1)
+        with mock.patch(
+            "asyncio.run_coroutine_threadsafe", side_effect=fake_schedule
+        ) as mock_schedule_neg:
+            start = time.monotonic()
+            bp2.close(timeout=-1)
+            elapsed_neg = time.monotonic() - start
 
-    mock_schedule_neg.assert_called_once()
-    assert bp2.is_stopped is True
-    assert elapsed_neg < 0.5
+        mock_schedule_neg.assert_called_once()
+        assert bp2.is_stopped is True
+        assert elapsed_neg < 0.5
+    finally:
+        never_resolves.cancel()
 
 
 def test_close_does_not_swallow_teardown_exceptions(prefetcher_factory, caplog):
@@ -1000,3 +1003,30 @@ def test_close_concurrent_with_inflight_read_does_not_truncate(prefetcher_factor
 
     assert "exc" not in result, f"reader raised unexpectedly: {result.get('exc')}"
     assert len(result["data"]) == 1_000_000
+
+
+def test_close_and_aclose_idempotence(prefetcher_factory):
+    """Verify that close() and aclose() are idempotent and return early on subsequent calls."""
+    bp = prefetcher_factory(fetcher=MockFetcher(b"X" * 100), size=100, concurrency=1)
+    assert not bp.is_stopped
+    bp.close()
+    assert bp.is_stopped
+    # Second close() hits the `if self.is_stopped: return` branch
+    bp.close()
+    assert bp.is_stopped
+
+    # Test aclose() idempotence
+    loop = fsspec.asyn.get_loop()
+
+    async def run_aclose_twice():
+        bp2 = BackgroundPrefetcher(
+            fetcher=MockFetcher(b"Y" * 100), size=100, concurrency=1, loop=loop
+        )
+        assert not bp2.is_stopped
+        await bp2.aclose()
+        assert bp2.is_stopped
+        # Second aclose() hits the `if self.is_stopped: return` branch
+        await bp2.aclose()
+        assert bp2.is_stopped
+
+    fsspec.asyn.sync(loop, run_aclose_twice)

--- a/gcsfs/tests/test_prefetcher.py
+++ b/gcsfs/tests/test_prefetcher.py
@@ -1,4 +1,9 @@
 import asyncio
+import concurrent.futures
+import logging
+import sys
+import threading
+import time
 from unittest import mock
 
 import fsspec.asyn
@@ -724,3 +729,274 @@ def test_fast_slice_pypy_fallback():
 
     # 3. Verify exact bounds
     assert _fast_slice(src, 0, len(src)) == src
+
+
+def test_close_when_sys_finalizing(prefetcher_factory, monkeypatch):
+    """Verify close returns immediately during interpreter finalization."""
+    bp = prefetcher_factory(fetcher=MockFetcher(b"X"), size=100, concurrency=1)
+    monkeypatch.setattr(sys, "is_finalizing", lambda: True)
+    with mock.patch("asyncio.run_coroutine_threadsafe") as mock_schedule:
+        bp.close()
+        assert bp.is_stopped is True
+        mock_schedule.assert_not_called()
+
+
+def test_close_when_loop_not_running(prefetcher_factory):
+    """Verify close returns immediately if the loop is not running."""
+    bp = prefetcher_factory(fetcher=MockFetcher(b"X"), size=100, concurrency=1)
+    with mock.patch.object(bp.loop, "is_running", return_value=False):
+        with mock.patch("asyncio.run_coroutine_threadsafe") as mock_schedule:
+            bp.close()
+            assert bp.is_stopped is True
+            mock_schedule.assert_not_called()
+
+
+def test_close_on_loop_thread_schedules_task(prefetcher_factory):
+    """Verify close called from within the IO loop thread schedules task without NotImplementedError."""
+    loop = fsspec.asyn.get_loop()
+
+    async def close_inside_loop():
+        bp = BackgroundPrefetcher(
+            fetcher=MockFetcher(b"X" * 100), size=100, concurrency=1, loop=loop
+        )
+        await bp.afetch(0, 10)
+        assert bp.producer is not None and not bp.producer.is_stopped
+        bp.close()
+        assert bp.is_stopped is True
+        # Allow scheduled task to complete
+        await asyncio.sleep(0.05)
+        assert bp.producer.is_stopped is True
+
+    fsspec.asyn.sync(loop, close_inside_loop)
+
+
+def test_reentrant_close_logs_exception(caplog):
+    """Verify that an exception in a reentrant teardown task is logged and handled cleanly."""
+    loop = fsspec.asyn.get_loop()
+
+    async def run_failing_reentrant():
+        bp = BackgroundPrefetcher(
+            fetcher=MockFetcher(b"X" * 10), size=10, concurrency=1, loop=loop
+        )
+
+        async def boom():
+            raise RuntimeError("reentrant close failed")
+
+        bp._async_close = boom
+        with caplog.at_level(logging.WARNING, logger="gcsfs.prefetcher"):
+            bp.close()
+            await asyncio.sleep(0.05)
+
+    fsspec.asyn.sync(loop, run_failing_reentrant)
+    assert any("reentrant close failed" in r.message for r in caplog.records)
+
+
+def test_close_unawaited_coroutine_warning_on_runtime_error(prefetcher_factory):
+    """Verify that if run_coroutine_threadsafe raises RuntimeError, the
+    coroutine is closed and no RuntimeWarning is emitted."""
+    import warnings
+
+    bp = prefetcher_factory(fetcher=MockFetcher(b"X"), size=100, concurrency=1)
+    with mock.patch(
+        "asyncio.run_coroutine_threadsafe", side_effect=RuntimeError("loop closed")
+    ):
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter("always")
+            bp.close()
+        unawaited_warnings = [
+            w
+            for w in record
+            if issubclass(w.category, RuntimeWarning)
+            and "was never awaited" in str(w.message)
+        ]
+        assert not unawaited_warnings
+
+
+def test_close_is_bounded_when_loop_is_unserviced(prefetcher_factory):
+    """close() must return within `timeout` even if the loop never runs the
+    scheduled teardown coroutine (e.g. its thread died or is blocked on
+    something else) -- this is the core deadlock from
+    https://github.com/fsspec/gcsfs/issues/1037. Regression test for the
+    fact that `run_coroutine_threadsafe` (unlike `fsspec.asyn.sync`, which
+    polls with no exit condition) always schedules successfully, so the
+    only thing bounding this wait is the timeout passed to `.result()`.
+    """
+    bp = prefetcher_factory(fetcher=MockFetcher(b"X"), size=100, concurrency=1)
+
+    never_resolves = concurrent.futures.Future()  # never has a result set
+
+    def fake_schedule(coro, loop):
+        coro.close()  # avoid a "coroutine was never awaited" warning
+        return never_resolves
+
+    with mock.patch("asyncio.run_coroutine_threadsafe", side_effect=fake_schedule):
+        start = time.monotonic()
+        bp.close(timeout=0.2)
+        elapsed = time.monotonic() - start
+
+    assert bp.is_stopped is True
+    assert elapsed < 2.0  # comfortably bounded, not "forever"
+
+
+def test_close_default_timeout_waits_for_teardown(prefetcher_factory):
+    """The default close() should still behave synchronously in the common
+    (non-degraded) case: callers and tests that assert on post-close state
+    rely on teardown having actually finished before close() returns.
+    """
+    bp = prefetcher_factory(fetcher=MockFetcher(b"X" * 100), size=100, concurrency=4)
+    bp.fetch(0, 10)
+
+    bp.close()
+
+    assert bp.is_stopped is True
+    assert bp.producer.is_stopped is True
+
+
+def test_close_none_timeout_waits_for_teardown(prefetcher_factory):
+    """timeout=None adheres to standard Python library semantics, waiting
+    indefinitely until teardown finishes."""
+    bp = prefetcher_factory(fetcher=MockFetcher(b"X" * 100), size=100, concurrency=4)
+    bp.fetch(0, 10)
+
+    bp.close(timeout=None)
+
+    assert bp.is_stopped is True
+    assert bp.producer.is_stopped is True
+
+
+def test_close_zero_and_negative_timeout_is_fire_and_forget(prefetcher_factory):
+    """timeout=0 or negative means fire-and-forget: teardown is still
+    scheduled on the IO loop, but close() returns immediately without waiting.
+    """
+    bp = prefetcher_factory(fetcher=MockFetcher(b"X"), size=100, concurrency=1)
+
+    never_resolves = concurrent.futures.Future()
+
+    def fake_schedule(coro, loop):
+        coro.close()  # avoid a "coroutine was never awaited" warning
+        return never_resolves
+
+    with mock.patch(
+        "asyncio.run_coroutine_threadsafe", side_effect=fake_schedule
+    ) as mock_schedule:
+        start = time.monotonic()
+        bp.close(timeout=0)
+        elapsed_zero = time.monotonic() - start
+
+    mock_schedule.assert_called_once()
+    assert bp.is_stopped is True
+    assert elapsed_zero < 0.5
+
+    # Also verify negative timeout is non-blocking
+    bp2 = prefetcher_factory(fetcher=MockFetcher(b"X"), size=100, concurrency=1)
+    with mock.patch(
+        "asyncio.run_coroutine_threadsafe", side_effect=fake_schedule
+    ) as mock_schedule_neg:
+        start = time.monotonic()
+        bp2.close(timeout=-1)
+        elapsed_neg = time.monotonic() - start
+
+    mock_schedule_neg.assert_called_once()
+    assert bp2.is_stopped is True
+    assert elapsed_neg < 0.5
+
+
+def test_close_does_not_swallow_teardown_exceptions(prefetcher_factory, caplog):
+    """A real exception raised during teardown must be surfaced (logged),
+    not silently discarded -- silent failures here previously made it
+    impossible to notice a broken teardown.
+    """
+    bp = prefetcher_factory(fetcher=MockFetcher(b"X"), size=100, concurrency=1)
+    bp.fetch(0, 1)
+
+    real_stop = bp.producer.stop
+
+    async def boom():
+        # Still cancel the real producer task so nothing is left pending
+        # for the interpreter to warn about after this test tears down.
+        await real_stop()
+        raise ValueError("teardown blew up")
+
+    bp.producer.stop = boom
+
+    with caplog.at_level(logging.WARNING, logger="gcsfs.prefetcher"):
+        bp.close()
+
+    assert bp.is_stopped is True
+    assert any("teardown blew up" in r.message for r in caplog.records) or any(
+        r.exc_info and "teardown blew up" in str(r.exc_info[1]) for r in caplog.records
+    )
+
+
+def test_close_does_not_cancel_inflight_network_task_on_timeout(prefetcher_factory):
+    """On a close() timeout, the in-flight teardown coroutine must keep
+    running rather than being cancelled -- PrefetchProducer.stop()
+    deliberately awaits (not cancels) in-flight network tasks to avoid
+    disrupting MRD streams, and fsspec.asyn.sync's timeout path used to
+    cancel the coroutine it was waiting on, undermining that.
+    """
+    fetcher = MockFetcher(b"X" * 1000)
+    bp = prefetcher_factory(fetcher=fetcher, size=1000, concurrency=4)
+    bp.fetch(0, 100)
+
+    stop_started = threading.Event()
+    stop_finished = threading.Event()
+    real_stop = bp.producer.stop
+
+    async def slow_stop():
+        stop_started.set()
+        await asyncio.sleep(0.3)
+        await real_stop()
+        stop_finished.set()
+
+    bp.producer.stop = slow_stop
+
+    bp.close(timeout=0.05)  # much shorter than slow_stop's delay
+    assert bp.is_stopped is True
+
+    assert stop_started.wait(timeout=1.0)
+    assert stop_finished.wait(timeout=2.0), (
+        "teardown should keep running to completion in the background "
+        "instead of being cancelled by the close() timeout"
+    )
+
+
+def test_close_concurrent_with_inflight_read_does_not_truncate(prefetcher_factory):
+    """Regression test: `_async_close` must hold `_async_lock` for the
+    duration of teardown. Without it, a `close()` running concurrently
+    with an in-flight `_async_fetch` can make the fetch observe a stopped
+    producer + empty queue as EOF and silently return a short read instead
+    of the requested byte range.
+    """
+    size = 2_000_000
+    data = bytes((i % 256) for i in range(size))
+
+    fetch_entered = threading.Event()
+
+    class SlowFetcher:
+        async def __call__(self, start, size, split_factor=1):
+            if start >= 1000:
+                fetch_entered.set()
+                await asyncio.sleep(0.05)
+            return data[start : start + size]
+
+    bp = prefetcher_factory(fetcher=SlowFetcher(), size=size, concurrency=4)
+    # Prime the pipeline so the producer has already started prefetching.
+    bp.fetch(0, 1000)
+
+    result = {}
+
+    def reader():
+        try:
+            result["data"] = bp.fetch(1000, 1000 + 1_000_000)
+        except BaseException as e:  # noqa: BLE001
+            result["exc"] = e
+
+    t = threading.Thread(target=reader)
+    t.start()
+    assert fetch_entered.wait(timeout=5.0), "fetch never got in-flight"
+    bp.close()
+    t.join(timeout=10)
+
+    assert "exc" not in result, f"reader raised unexpectedly: {result.get('exc')}"
+    assert len(result["data"]) == 1_000_000

--- a/gcsfs/tests/test_prefetcher.py
+++ b/gcsfs/tests/test_prefetcher.py
@@ -1,9 +1,7 @@
 import asyncio
-import concurrent.futures
 import logging
 import sys
 import threading
-import time
 from unittest import mock
 
 import fsspec.asyn
@@ -731,28 +729,28 @@ def test_fast_slice_pypy_fallback():
     assert _fast_slice(src, 0, len(src)) == src
 
 
-def test_close_when_sys_finalizing(prefetcher_factory, monkeypatch):
-    """Verify close returns immediately during interpreter finalization."""
+def test_close_when_interpreter_finalizing(prefetcher_factory):
+    """Verify close returns immediately without hanging during interpreter finalization."""
     bp = prefetcher_factory(fetcher=MockFetcher(b"X"), size=100, concurrency=1)
-    monkeypatch.setattr(sys, "is_finalizing", lambda: True)
-    with mock.patch("asyncio.run_coroutine_threadsafe") as mock_schedule:
+
+    with mock.patch.object(sys, "is_finalizing", return_value=True):
         bp.close()
-        assert bp.is_stopped is True
-        mock_schedule.assert_not_called()
+
+    assert bp.is_stopped is True
 
 
 def test_close_when_loop_not_running(prefetcher_factory):
-    """Verify close returns immediately if the loop is not running."""
+    """Verify close returns immediately without raising when loop is not running."""
     bp = prefetcher_factory(fetcher=MockFetcher(b"X"), size=100, concurrency=1)
+
     with mock.patch.object(bp.loop, "is_running", return_value=False):
-        with mock.patch("asyncio.run_coroutine_threadsafe") as mock_schedule:
-            bp.close()
-            assert bp.is_stopped is True
-            mock_schedule.assert_not_called()
+        bp.close(timeout=1.0)
+
+    assert bp.is_stopped is True
 
 
-def test_close_on_loop_thread_schedules_task(prefetcher_factory):
-    """Verify close called from within the IO loop thread schedules task without NotImplementedError."""
+def test_close_on_loop_thread_schedules_task():
+    """Verify close called from within the IO loop thread completes without deadlocking."""
     loop = fsspec.asyn.get_loop()
 
     async def close_inside_loop():
@@ -761,7 +759,9 @@ def test_close_on_loop_thread_schedules_task(prefetcher_factory):
         )
         await bp.afetch(0, 10)
         assert bp.producer is not None and not bp.producer.is_stopped
+
         bp.close()
+
         assert bp.is_stopped is True
         # Allow scheduled task to complete
         await asyncio.sleep(0.05)
@@ -779,63 +779,59 @@ def test_reentrant_close_logs_exception(caplog):
             fetcher=MockFetcher(b"X" * 10), size=10, concurrency=1, loop=loop
         )
 
-        async def boom():
+        async def failing_close():
             raise RuntimeError("reentrant close failed")
 
-        bp._async_close = boom
-        with caplog.at_level(logging.WARNING, logger="gcsfs.prefetcher"):
+        bp._async_close = failing_close
+
+        with caplog.at_level(logging.ERROR, logger="gcsfs"):
             bp.close()
             await asyncio.sleep(0.05)
 
     fsspec.asyn.sync(loop, run_failing_reentrant)
+
     assert any("reentrant close failed" in r.message for r in caplog.records)
 
 
-def test_close_unawaited_coroutine_warning_on_runtime_error(prefetcher_factory):
-    """Verify that if run_coroutine_threadsafe raises RuntimeError, the
-    coroutine is closed and no RuntimeWarning is emitted."""
+def test_close_when_loop_closed_emits_no_unawaited_warning(prefetcher_factory):
+    """Verify that if loop is closed, close() handles it cleanly without unawaited warnings."""
     import warnings
 
     bp = prefetcher_factory(fetcher=MockFetcher(b"X"), size=100, concurrency=1)
-    with mock.patch(
-        "asyncio.run_coroutine_threadsafe", side_effect=RuntimeError("loop closed")
-    ):
+
+    with mock.patch.object(bp.loop, "is_closed", return_value=True):
         with warnings.catch_warnings(record=True) as record:
             warnings.simplefilter("always")
-            bp.close()
-        unawaited_warnings = [
-            w
-            for w in record
-            if issubclass(w.category, RuntimeWarning)
-            and "was never awaited" in str(w.message)
-        ]
-        assert not unawaited_warnings
+            bp.close(timeout=1.0)
+
+    assert bp.is_stopped is True
+    unawaited_warnings = [
+        w
+        for w in record
+        if issubclass(w.category, RuntimeWarning)
+        and "was never awaited" in str(w.message)
+    ]
+    assert not unawaited_warnings
 
 
 def test_close_is_bounded_when_loop_is_unserviced(prefetcher_factory):
-    """close() must return within `timeout` even if the loop never runs the
-    scheduled teardown coroutine (e.g. its thread died or is blocked on
-    something else) -- this is the core deadlock from
-    https://github.com/fsspec/gcsfs/issues/1037. Regression test for the
-    fact that `run_coroutine_threadsafe` (unlike `fsspec.asyn.sync`, which
-    polls with no exit condition) always schedules successfully, so the
-    only thing bounding this wait is the timeout passed to `.result()`.
-    """
+    """close() must return within `timeout` if teardown takes longer than timeout."""
     bp = prefetcher_factory(fetcher=MockFetcher(b"X"), size=100, concurrency=1)
+    teardown_done = threading.Event()
+    real_close = bp._async_close
 
-    never_resolves = concurrent.futures.Future()  # never has a result set
+    async def slow_close():
+        await asyncio.sleep(0.1)
+        teardown_done.set()
+        await real_close()
 
-    def fake_schedule(coro, loop):
-        coro.close()  # avoid a "coroutine was never awaited" warning
-        return never_resolves
+    bp._async_close = slow_close
 
-    with mock.patch("asyncio.run_coroutine_threadsafe", side_effect=fake_schedule):
-        start = time.monotonic()
-        bp.close(timeout=0.2)
-        elapsed = time.monotonic() - start
+    bp.close(timeout=0.01)
 
     assert bp.is_stopped is True
-    assert elapsed < 2.0  # comfortably bounded, not "forever"
+    assert not teardown_done.is_set()
+    assert teardown_done.wait(timeout=2.0)
 
 
 def test_close_default_timeout_waits_for_teardown(prefetcher_factory):
@@ -865,43 +861,42 @@ def test_close_none_timeout_waits_for_teardown(prefetcher_factory):
 
 
 def test_close_zero_and_negative_timeout_is_fire_and_forget(prefetcher_factory):
-    """timeout=0 or negative means fire-and-forget: teardown is still
-    scheduled on the IO loop, but close() returns immediately without waiting.
+    """timeout=0 or negative means fire-and-forget: teardown is scheduled
+    on the IO loop, but close() returns immediately without waiting.
     """
     bp = prefetcher_factory(fetcher=MockFetcher(b"X"), size=100, concurrency=1)
+    teardown_done = threading.Event()
+    real_close = bp._async_close
 
-    never_resolves = concurrent.futures.Future()
+    async def slow_close():
+        await asyncio.sleep(0.1)
+        teardown_done.set()
+        await real_close()
 
-    def fake_schedule(coro, loop):
-        coro.close()  # avoid a "coroutine was never awaited" warning
-        return never_resolves
+    bp._async_close = slow_close
 
-    try:
-        with mock.patch(
-            "asyncio.run_coroutine_threadsafe", side_effect=fake_schedule
-        ) as mock_schedule:
-            start = time.monotonic()
-            bp.close(timeout=0)
-            elapsed_zero = time.monotonic() - start
+    bp.close(timeout=0)
 
-        mock_schedule.assert_called_once()
-        assert bp.is_stopped is True
-        assert elapsed_zero < 0.5
+    assert bp.is_stopped is True
+    assert not teardown_done.is_set()
+    assert teardown_done.wait(timeout=2.0)
 
-        # Also verify negative timeout is non-blocking
-        bp2 = prefetcher_factory(fetcher=MockFetcher(b"X"), size=100, concurrency=1)
-        with mock.patch(
-            "asyncio.run_coroutine_threadsafe", side_effect=fake_schedule
-        ) as mock_schedule_neg:
-            start = time.monotonic()
-            bp2.close(timeout=-1)
-            elapsed_neg = time.monotonic() - start
+    bp2 = prefetcher_factory(fetcher=MockFetcher(b"X"), size=100, concurrency=1)
+    teardown_done2 = threading.Event()
+    real_close2 = bp2._async_close
 
-        mock_schedule_neg.assert_called_once()
-        assert bp2.is_stopped is True
-        assert elapsed_neg < 0.5
-    finally:
-        never_resolves.cancel()
+    async def slow_close2():
+        await asyncio.sleep(0.1)
+        teardown_done2.set()
+        await real_close2()
+
+    bp2._async_close = slow_close2
+
+    bp2.close(timeout=-1)
+
+    assert bp2.is_stopped is True
+    assert not teardown_done2.is_set()
+    assert teardown_done2.wait(timeout=2.0)
 
 
 def test_close_does_not_swallow_teardown_exceptions(prefetcher_factory, caplog):
@@ -955,8 +950,8 @@ def test_close_does_not_cancel_inflight_network_task_on_timeout(prefetcher_facto
     bp.producer.stop = slow_stop
 
     bp.close(timeout=0.05)  # much shorter than slow_stop's delay
-    assert bp.is_stopped is True
 
+    assert bp.is_stopped is True
     assert stop_started.wait(timeout=1.0)
     assert stop_finished.wait(timeout=2.0), (
         "teardown should keep running to completion in the background "
@@ -1009,13 +1004,14 @@ def test_close_and_aclose_idempotence(prefetcher_factory):
     """Verify that close() and aclose() are idempotent and return early on subsequent calls."""
     bp = prefetcher_factory(fetcher=MockFetcher(b"X" * 100), size=100, concurrency=1)
     assert not bp.is_stopped
+
     bp.close()
+
     assert bp.is_stopped
-    # Second close() hits the `if self.is_stopped: return` branch
+    # Second close() hits the early exit
     bp.close()
     assert bp.is_stopped
 
-    # Test aclose() idempotence
     loop = fsspec.asyn.get_loop()
 
     async def run_aclose_twice():
@@ -1023,9 +1019,11 @@ def test_close_and_aclose_idempotence(prefetcher_factory):
             fetcher=MockFetcher(b"Y" * 100), size=100, concurrency=1, loop=loop
         )
         assert not bp2.is_stopped
+
         await bp2.aclose()
+
         assert bp2.is_stopped
-        # Second aclose() hits the `if self.is_stopped: return` branch
+        # Second aclose() hits the early exit
         await bp2.aclose()
         assert bp2.is_stopped
 

--- a/gcsfs/tests/test_prefetcher.py
+++ b/gcsfs/tests/test_prefetcher.py
@@ -860,7 +860,10 @@ def test_close_none_timeout_waits_for_teardown(prefetcher_factory):
     assert bp.producer.is_stopped is True
 
 
-def test_close_zero_and_negative_timeout_is_fire_and_forget(prefetcher_factory):
+@pytest.mark.parametrize("timeout", [0, -1])
+def test_close_zero_and_negative_timeout_is_fire_and_forget(
+    prefetcher_factory, timeout
+):
     """timeout=0 or negative means fire-and-forget: teardown is scheduled
     on the IO loop, but close() returns immediately without waiting.
     """
@@ -875,28 +878,11 @@ def test_close_zero_and_negative_timeout_is_fire_and_forget(prefetcher_factory):
 
     bp._async_close = slow_close
 
-    bp.close(timeout=0)
+    bp.close(timeout=timeout)
 
     assert bp.is_stopped is True
     assert not teardown_done.is_set()
     assert teardown_done.wait(timeout=2.0)
-
-    bp2 = prefetcher_factory(fetcher=MockFetcher(b"X"), size=100, concurrency=1)
-    teardown_done2 = threading.Event()
-    real_close2 = bp2._async_close
-
-    async def slow_close2():
-        await asyncio.sleep(0.1)
-        teardown_done2.set()
-        await real_close2()
-
-    bp2._async_close = slow_close2
-
-    bp2.close(timeout=-1)
-
-    assert bp2.is_stopped is True
-    assert not teardown_done2.is_set()
-    assert teardown_done2.wait(timeout=2.0)
 
 
 def test_close_does_not_swallow_teardown_exceptions(prefetcher_factory, caplog):

--- a/gcsfs/tests/test_zonal_file.py
+++ b/gcsfs/tests/test_zonal_file.py
@@ -859,10 +859,10 @@ def test_sync_teardown_skips_during_interpreter_finalization(monkeypatch):
     assert calls == []
 
 
-def test_sync_teardown_logs_and_skips_when_loop_not_running(caplog):
+def test_sync_teardown_logs_and_raises_when_loop_not_running(caplog):
     """Unlike the prefetcher's read-only teardown, skipping here can leave
     an upload unfinalized server-side, so this must be logged loudly
-    (error, not swallowed) rather than silently dropped.
+    (error, not swallowed) and a RuntimeError raised rather than silently dropped.
     """
     loop = fsspec.asyn.get_loop()
     zf = _bare_zonal_file(loop)
@@ -874,13 +874,14 @@ def test_sync_teardown_logs_and_skips_when_loop_not_running(caplog):
 
     with mock.patch.object(loop, "is_running", return_value=False):
         with caplog.at_level(logging.ERROR, logger="gcsfs.zonal_file"):
-            zf._sync_teardown(loop, coro, description="test op")
+            with pytest.raises(RuntimeError, match="usable IO loop"):
+                zf._sync_teardown(loop, coro, description="test op")
 
     assert calls == []
     assert any("test op" in r.message for r in caplog.records)
 
 
-def test_sync_teardown_logs_and_skips_when_loop_missing(caplog):
+def test_sync_teardown_logs_and_raises_when_loop_missing(caplog):
     zf = _bare_zonal_file(None)
 
     calls = []
@@ -889,7 +890,8 @@ def test_sync_teardown_logs_and_skips_when_loop_missing(caplog):
         calls.append(1)
 
     with caplog.at_level(logging.ERROR, logger="gcsfs.zonal_file"):
-        zf._sync_teardown(None, coro, description="test op")
+        with pytest.raises(RuntimeError, match="usable IO loop"):
+            zf._sync_teardown(None, coro, description="test op")
 
     assert calls == []
     assert any("test op" in r.message for r in caplog.records)

--- a/gcsfs/tests/test_zonal_file.py
+++ b/gcsfs/tests/test_zonal_file.py
@@ -7,10 +7,14 @@ test_extended_hns_gcsfs.py or integration/test_extended_hns.py.
 """
 
 import asyncio
+import logging
 import os
+import sys
 from unittest import mock
 
+import fsspec.asyn
 import pytest
+from fsspec.asyn import FSTimeoutError
 from google.cloud.storage.asyncio.async_appendable_object_writer import (
     _DEFAULT_FLUSH_INTERVAL_BYTES,
 )
@@ -19,7 +23,7 @@ from gcsfs.extended_gcsfs import ExtendedGcsFileSystem
 from gcsfs.tests.conftest import requires_rapid
 from gcsfs.tests.settings import TEST_ZONAL_BUCKET
 from gcsfs.tests.utils import is_real_gcs, tempdir, tmpfile
-from gcsfs.zonal_file import ZonalFile
+from gcsfs.zonal_file import _DEFAULT_TEARDOWN_TIMEOUT_SECONDS, ZonalFile
 
 test_data = b"hello world"
 
@@ -816,8 +820,236 @@ def test_zonal_file_close_cleans_up_new_pools(mock_sync, mock_gcsfs):
     zf.close()
 
     mock_engine.close.assert_called_once()
-    expected_call = mock.call(mock_gcsfs.loop, mock_pool.close)
+    expected_call = mock.call(
+        mock_gcsfs.loop, mock_pool.close, timeout=_DEFAULT_TEARDOWN_TIMEOUT_SECONDS
+    )
     assert expected_call in mock_sync.call_args_list
+
+
+def _bare_zonal_file(loop, timeout=None):
+    """A ZonalFile built via __new__ to skip real GCS setup, for testing
+    _sync_teardown directly with a real (not mocked) event loop."""
+    zf = ZonalFile.__new__(ZonalFile)
+    zf.path = "gs://bucket/object"
+    zf.gcsfs = mock.Mock(loop=loop)
+    zf.timeout = timeout
+    zf.closed = False
+    zf.mode = "rb"
+    zf.fs = None
+    zf.aaow = None
+    zf._close_deferred = False
+    return zf
+
+
+def test_sync_teardown_skips_during_interpreter_finalization(monkeypatch):
+    """Mirrors the prefetcher's sys.is_finalizing() guard: never touch the
+    IO loop once the interpreter itself is tearing down.
+    """
+    loop = fsspec.asyn.get_loop()
+    zf = _bare_zonal_file(loop)
+    monkeypatch.setattr(sys, "is_finalizing", lambda: True)
+
+    calls = []
+
+    async def coro():
+        calls.append(1)
+
+    zf._sync_teardown(loop, coro, description="test op")
+
+    assert calls == []
+
+
+def test_sync_teardown_logs_and_skips_when_loop_not_running(caplog):
+    """Unlike the prefetcher's read-only teardown, skipping here can leave
+    an upload unfinalized server-side, so this must be logged loudly
+    (error, not swallowed) rather than silently dropped.
+    """
+    loop = fsspec.asyn.get_loop()
+    zf = _bare_zonal_file(loop)
+
+    calls = []
+
+    async def coro():
+        calls.append(1)
+
+    with mock.patch.object(loop, "is_running", return_value=False):
+        with caplog.at_level(logging.ERROR, logger="gcsfs.zonal_file"):
+            zf._sync_teardown(loop, coro, description="test op")
+
+    assert calls == []
+    assert any("test op" in r.message for r in caplog.records)
+
+
+def test_sync_teardown_logs_and_skips_when_loop_missing(caplog):
+    zf = _bare_zonal_file(None)
+
+    calls = []
+
+    async def coro():
+        calls.append(1)
+
+    with caplog.at_level(logging.ERROR, logger="gcsfs.zonal_file"):
+        zf._sync_teardown(None, coro, description="test op")
+
+    assert calls == []
+    assert any("test op" in r.message for r in caplog.records)
+
+
+def test_sync_teardown_runs_coroutine_on_healthy_loop():
+    loop = fsspec.asyn.get_loop()
+    zf = _bare_zonal_file(loop)
+
+    calls = []
+
+    async def coro():
+        calls.append(1)
+
+    zf._sync_teardown(loop, coro, description="test op")
+
+    assert calls == [1]
+
+
+def test_sync_teardown_passes_args_and_kwargs_through():
+    loop = fsspec.asyn.get_loop()
+    zf = _bare_zonal_file(loop)
+
+    seen = {}
+
+    async def coro(aaow, finalize_on_close=False):
+        seen["aaow"] = aaow
+        seen["finalize_on_close"] = finalize_on_close
+
+    sentinel = object()
+    zf._sync_teardown(
+        loop, coro, sentinel, finalize_on_close=True, description="close_aaow"
+    )
+
+    assert seen == {"aaow": sentinel, "finalize_on_close": True}
+
+
+def test_sync_teardown_on_loop_thread_schedules_task_instead_of_raising():
+    """asyn.sync() raises NotImplementedError when called from the loop
+    it's supposed to wait on -- this is the same class of bug the
+    prefetcher fix addresses. Verify _sync_teardown avoids it by scheduling
+    a task instead of blocking.
+    """
+    loop = fsspec.asyn.get_loop()
+    zf = _bare_zonal_file(loop)
+
+    calls = []
+
+    async def coro():
+        calls.append(1)
+
+    async def run_from_loop():
+        zf._sync_teardown(loop, coro, description="test op")
+        await asyncio.sleep(0.05)  # let the scheduled task complete
+
+    fsspec.asyn.sync(loop, run_from_loop)
+
+    assert calls == [1]
+
+
+def test_sync_teardown_raises_and_logs_on_timeout(caplog):
+    """A hung teardown must not block the caller (and, transitively, the
+    single serial gcsfs-deferred-close worker thread) forever. Unlike the
+    prefetcher, which lets the background job keep running after a
+    timeout, write finalization surfaces the timeout as an error the
+    caller can see, since silently continuing could hide a lost upload.
+    """
+    loop = fsspec.asyn.get_loop()
+    zf = _bare_zonal_file(loop, timeout=0.05)
+
+    async def coro():
+        await asyncio.sleep(2.0)
+
+    with caplog.at_level(logging.ERROR, logger="gcsfs.zonal_file"):
+        with pytest.raises(FSTimeoutError):
+            zf._sync_teardown(loop, coro, description="slow op")
+
+    assert any("slow op" in r.message for r in caplog.records)
+
+
+def test_close_impl_uses_default_timeout_when_file_has_none(monkeypatch):
+    """When the file carries no per-request timeout, teardown must still
+    be bounded (falls back to _DEFAULT_TEARDOWN_TIMEOUT_SECONDS) rather than
+    reverting to fsspec.asyn.sync's unbounded wait.
+    """
+    import gcsfs.zonal_file as zonal_file_module
+
+    loop = fsspec.asyn.get_loop()
+    zf = _bare_zonal_file(loop, timeout=None)
+    mock_pool = mock.Mock()
+
+    async def fake_close():
+        pass
+
+    mock_pool.close = fake_close
+    zf.mrd_pool = mock_pool
+
+    captured = {}
+    real_sync = fsspec.asyn.sync
+
+    def spy_sync(loop_, func, *args, **kwargs):
+        captured["timeout"] = kwargs.get("timeout")
+        return real_sync(loop_, func, *args, **kwargs)
+
+    monkeypatch.setattr(zonal_file_module.asyn, "sync", spy_sync)
+    zf._close_impl()
+
+    assert captured["timeout"] == _DEFAULT_TEARDOWN_TIMEOUT_SECONDS
+
+
+def test_sync_teardown_reentrant_task_logs_exception(caplog):
+    """Verify that when a reentrant teardown task on the IO loop thread
+    raises an exception, it is logged with logger.error and not left unretrieved.
+    """
+    loop = fsspec.asyn.get_loop()
+    zf = _bare_zonal_file(loop)
+
+    async def boom():
+        raise RuntimeError("reentrant teardown exploded")
+
+    async def run_from_loop():
+        zf._sync_teardown(loop, boom, description="failing op")
+        await asyncio.sleep(0.05)
+
+    with caplog.at_level(logging.ERROR, logger="gcsfs.zonal_file"):
+        fsspec.asyn.sync(loop, run_from_loop)
+
+    assert any(
+        "failing op" in r.message and "reentrant teardown exploded" in r.message
+        for r in caplog.records
+    )
+
+
+def test_close_impl_mrd_pool_failure_does_not_skip_aaow():
+    """Verify that if mrd_pool.close fails, aaow teardown is still executed."""
+    loop = fsspec.asyn.get_loop()
+    zf = _bare_zonal_file(loop)
+    zf.finalize_on_close = False
+
+    async def failing_mrd_close():
+        raise RuntimeError("mrd pool failed")
+
+    mock_pool = mock.Mock(close=failing_mrd_close)
+    zf.mrd_pool = mock_pool
+
+    aaow_closed = []
+
+    async def fake_close_aaow(aaow, finalize_on_close=False):
+        aaow_closed.append(True)
+
+    mock_aaow = mock.Mock(_is_stream_open=True)
+    zf.aaow = mock_aaow
+
+    with mock.patch("gcsfs.zb_hns_utils.close_aaow", side_effect=fake_close_aaow):
+        with pytest.raises(RuntimeError, match="mrd pool failed"):
+            zf._close_impl()
+
+    assert aaow_closed == [
+        True
+    ], "close_aaow should have been called even though mrd_pool failed"
 
 
 @mock.patch("gcsfs.zonal_file.asyn.sync")

--- a/gcsfs/tests/test_zonal_file.py
+++ b/gcsfs/tests/test_zonal_file.py
@@ -1052,6 +1052,31 @@ def test_close_impl_mrd_pool_failure_does_not_skip_aaow():
     ], "close_aaow should have been called even though mrd_pool failed"
 
 
+def test_close_impl_aaow_failure_raises():
+    """Verify that if close_aaow fails, the error is recorded and re-raised."""
+    loop = fsspec.asyn.get_loop()
+    zf = _bare_zonal_file(loop)
+    zf.finalize_on_close = False
+
+    mock_pool = mock.Mock()
+
+    async def fake_mrd_close():
+        pass
+
+    mock_pool.close = fake_mrd_close
+    zf.mrd_pool = mock_pool
+
+    mock_aaow = mock.Mock(_is_stream_open=True)
+    zf.aaow = mock_aaow
+
+    async def failing_close_aaow(aaow, finalize_on_close=False):
+        raise RuntimeError("aaow close failed")
+
+    with mock.patch("gcsfs.zb_hns_utils.close_aaow", side_effect=failing_close_aaow):
+        with pytest.raises(RuntimeError, match="aaow close failed"):
+            zf._close_impl()
+
+
 @mock.patch("gcsfs.zonal_file.asyn.sync")
 def test_zonal_file_fetch_range_unhandled_runtime_error(mock_sync, mock_gcsfs):
     """Tests that a RuntimeError not containing 'not satisfiable' is re-raised."""

--- a/gcsfs/tests/test_zonal_file.py
+++ b/gcsfs/tests/test_zonal_file.py
@@ -815,7 +815,7 @@ def test_zonal_file_fetch_range_mutually_exclusive(mock_sync, mock_gcsfs):
 @mock.patch("gcsfs.zonal_file.sync_teardown")
 @mock.patch("gcsfs.zonal_file.asyn.sync")
 def test_zonal_file_close_cleans_up_new_pools(mock_sync, mock_teardown, mock_gcsfs):
-    """Tests that close() properly tears down the prefetch engine and MRD pool using hasattr."""
+    """Tests that close() properly tears down the prefetch engine and MRD pool."""
     zf = ZonalFile(gcsfs=mock_gcsfs, path="gs://test-bucket/test-key", mode="rb")
     mock_engine = mock.Mock()
     zf._prefetch_engine = mock_engine
@@ -832,34 +832,18 @@ def test_zonal_file_close_cleans_up_new_pools(mock_sync, mock_teardown, mock_gcs
     )
 
 
-def _bare_zonal_file(loop, timeout=None):
-    """A ZonalFile built via __new__ to skip real GCS setup, for testing
-    _sync_teardown directly with a real (not mocked) event loop."""
-    zf = ZonalFile.__new__(ZonalFile)
-    zf.path = "gs://bucket/object"
-    zf.gcsfs = mock.Mock(loop=loop)
-    zf.timeout = timeout
-    zf.closed = False
-    zf.mode = "rb"
-    zf.fs = None
-    zf.aaow = None
-    zf._close_deferred = False
-    return zf
-
-
-def test_sync_teardown_skips_during_interpreter_finalization(monkeypatch):
+def test_sync_teardown_skips_during_interpreter_finalization():
     """Mirrors the prefetcher's sys.is_finalizing() guard: never touch the
     IO loop once the interpreter itself is tearing down.
     """
     loop = fsspec.asyn.get_loop()
-    monkeypatch.setattr(sys, "is_finalizing", lambda: True)
-
     calls = []
 
     async def coro():
         calls.append(1)
 
-    zb_hns_utils.sync_teardown(loop, coro, description="test op")
+    with mock.patch.object(sys, "is_finalizing", return_value=True):
+        zb_hns_utils.sync_teardown(loop, coro, description="test op")
 
     assert calls == []
 
@@ -956,36 +940,6 @@ def test_sync_teardown_raises_on_timeout():
         zb_hns_utils.sync_teardown(loop, coro, timeout=0.05, description="slow op")
 
 
-def test_close_impl_uses_default_timeout_when_file_has_none(monkeypatch):
-    """When the file carries no per-request timeout, teardown must still
-    be bounded (falls back to DEFAULT_TEARDOWN_TIMEOUT_SECONDS) rather than
-    waiting indefinitely.
-    """
-    import gcsfs.zonal_file as zonal_file_module
-
-    loop = fsspec.asyn.get_loop()
-    zf = _bare_zonal_file(loop, timeout=None)
-    mock_pool = mock.Mock()
-
-    async def fake_close():
-        pass
-
-    mock_pool.close = fake_close
-    zf.mrd_pool = mock_pool
-
-    captured = {}
-    real_teardown = zonal_file_module.sync_teardown
-
-    def spy_teardown(loop_, func, *args, **kwargs):
-        captured["timeout"] = kwargs.get("timeout")
-        return real_teardown(loop_, func, *args, **kwargs)
-
-    monkeypatch.setattr(zonal_file_module, "sync_teardown", spy_teardown)
-    zf._close_impl()
-
-    assert captured["timeout"] == DEFAULT_TEARDOWN_TIMEOUT_SECONDS
-
-
 def test_sync_teardown_reentrant_task_logs_exception(caplog):
     """Verify that when a reentrant teardown task on the IO loop thread
     raises an exception, it is logged with logger.error and not left unretrieved.
@@ -1060,51 +1014,43 @@ def test_sync_teardown_accepts_coroutine_object():
     assert result == ["done"]
 
 
-def test_close_impl_mrd_pool_failure_does_not_skip_aaow():
+@mock.patch("gcsfs.zonal_file.asyn.sync")
+def test_close_impl_mrd_pool_failure_does_not_skip_aaow(mock_sync, mock_gcsfs):
     """Verify that if mrd_pool.close fails, aaow teardown is still executed."""
-    loop = fsspec.asyn.get_loop()
-    zf = _bare_zonal_file(loop)
-    zf.finalize_on_close = False
+    mock_gcsfs.loop = fsspec.asyn.get_loop()
+    zf = ZonalFile(gcsfs=mock_gcsfs, path="gs://test-bucket/test-key", mode="rb")
+    zf._prefetch_engine = mock.Mock()
 
     async def failing_mrd_close():
         raise RuntimeError("mrd pool failed")
 
-    mock_pool = mock.Mock(close=failing_mrd_close)
-    zf.mrd_pool = mock_pool
+    zf.mrd_pool = mock.Mock(close=failing_mrd_close)
+    zf.aaow = mock.Mock(_is_stream_open=True)
 
     aaow_closed = []
 
     async def fake_close_aaow(aaow, finalize_on_close=False):
         aaow_closed.append(True)
 
-    mock_aaow = mock.Mock(_is_stream_open=True)
-    zf.aaow = mock_aaow
-
     with mock.patch("gcsfs.zb_hns_utils.close_aaow", side_effect=fake_close_aaow):
         with pytest.raises(RuntimeError, match="mrd pool failed"):
             zf._close_impl()
 
-    assert aaow_closed == [
-        True
-    ], "close_aaow should have been called even though mrd_pool failed"
+    assert aaow_closed == [True]
 
 
-def test_close_impl_aaow_failure_raises():
+@mock.patch("gcsfs.zonal_file.asyn.sync")
+def test_close_impl_aaow_failure_raises(mock_sync, mock_gcsfs):
     """Verify that if close_aaow fails, the error is recorded and re-raised."""
-    loop = fsspec.asyn.get_loop()
-    zf = _bare_zonal_file(loop)
-    zf.finalize_on_close = False
-
-    mock_pool = mock.Mock()
+    mock_gcsfs.loop = fsspec.asyn.get_loop()
+    zf = ZonalFile(gcsfs=mock_gcsfs, path="gs://test-bucket/test-key", mode="rb")
+    zf._prefetch_engine = mock.Mock()
 
     async def fake_mrd_close():
         pass
 
-    mock_pool.close = fake_mrd_close
-    zf.mrd_pool = mock_pool
-
-    mock_aaow = mock.Mock(_is_stream_open=True)
-    zf.aaow = mock_aaow
+    zf.mrd_pool = mock.Mock(close=fake_mrd_close)
+    zf.aaow = mock.Mock(_is_stream_open=True)
 
     async def failing_close_aaow(aaow, finalize_on_close=False):
         raise RuntimeError("aaow close failed")

--- a/gcsfs/tests/test_zonal_file.py
+++ b/gcsfs/tests/test_zonal_file.py
@@ -1008,7 +1008,7 @@ def test_sync_teardown_reentrant_task_logs_exception(caplog):
     )
 
 
-def test_sync_teardown_helper_raises_exception():
+def test_sync_teardown_reraises_exception():
     """sync_teardown re-raises exceptions from the teardown coroutine."""
     loop = fsspec.asyn.get_loop()
 
@@ -1024,37 +1024,7 @@ def test_sync_teardown_helper_raises_exception():
         )
 
 
-def test_sync_teardown_helper_raises_timeout():
-    """sync_teardown raises FSTimeoutError when execution times out."""
-    loop = fsspec.asyn.get_loop()
-
-    async def slow_op():
-        await asyncio.sleep(2.0)
-
-    with pytest.raises(FSTimeoutError, match="slow teardown"):
-        zb_hns_utils.sync_teardown(
-            loop,
-            slow_op,
-            timeout=0.05,
-            description="slow teardown",
-        )
-
-
-def test_sync_teardown_helper_raises_when_loop_unavailable():
-    """sync_teardown raises RuntimeError when loop is None."""
-
-    async def op():
-        pass
-
-    with pytest.raises(RuntimeError, match="no usable IO loop available"):
-        zb_hns_utils.sync_teardown(
-            None,
-            op,
-            description="loopless teardown",
-        )
-
-
-def test_sync_teardown_helper_fire_and_forget():
+def test_sync_teardown_fire_and_forget_when_timeout_non_positive():
     """When timeout <= 0, scheduling is fire-and-forget and returns immediately."""
     loop = fsspec.asyn.get_loop()
     executed = threading.Event()
@@ -1072,7 +1042,7 @@ def test_sync_teardown_helper_fire_and_forget():
     assert executed.wait(timeout=5.0)
 
 
-def test_sync_teardown_helper_accepts_coroutine_object():
+def test_sync_teardown_accepts_coroutine_object():
     """sync_teardown works with an already instantiated coroutine object."""
     loop = fsspec.asyn.get_loop()
     result = []

--- a/gcsfs/tests/test_zonal_file.py
+++ b/gcsfs/tests/test_zonal_file.py
@@ -10,6 +10,7 @@ import asyncio
 import logging
 import os
 import sys
+import threading
 from unittest import mock
 
 import fsspec.asyn
@@ -19,11 +20,13 @@ from google.cloud.storage.asyncio.async_appendable_object_writer import (
     _DEFAULT_FLUSH_INTERVAL_BYTES,
 )
 
+from gcsfs import zb_hns_utils
 from gcsfs.extended_gcsfs import ExtendedGcsFileSystem
 from gcsfs.tests.conftest import requires_rapid
 from gcsfs.tests.settings import TEST_ZONAL_BUCKET
 from gcsfs.tests.utils import is_real_gcs, tempdir, tmpfile
-from gcsfs.zonal_file import _DEFAULT_TEARDOWN_TIMEOUT_SECONDS, ZonalFile
+from gcsfs.zb_hns_utils import DEFAULT_TEARDOWN_TIMEOUT_SECONDS
+from gcsfs.zonal_file import ZonalFile
 
 test_data = b"hello world"
 
@@ -809,8 +812,9 @@ def test_zonal_file_fetch_range_mutually_exclusive(mock_sync, mock_gcsfs):
     zf.close()
 
 
+@mock.patch("gcsfs.zonal_file.sync_teardown")
 @mock.patch("gcsfs.zonal_file.asyn.sync")
-def test_zonal_file_close_cleans_up_new_pools(mock_sync, mock_gcsfs):
+def test_zonal_file_close_cleans_up_new_pools(mock_sync, mock_teardown, mock_gcsfs):
     """Tests that close() properly tears down the prefetch engine and MRD pool using hasattr."""
     zf = ZonalFile(gcsfs=mock_gcsfs, path="gs://test-bucket/test-key", mode="rb")
     mock_engine = mock.Mock()
@@ -820,10 +824,12 @@ def test_zonal_file_close_cleans_up_new_pools(mock_sync, mock_gcsfs):
     zf.close()
 
     mock_engine.close.assert_called_once()
-    expected_call = mock.call(
-        mock_gcsfs.loop, mock_pool.close, timeout=_DEFAULT_TEARDOWN_TIMEOUT_SECONDS
+    mock_teardown.assert_called_once_with(
+        mock_gcsfs.loop,
+        mock_pool.close,
+        timeout=DEFAULT_TEARDOWN_TIMEOUT_SECONDS,
+        description="closing mrd_pool for gs://test-bucket/test-key",
     )
-    assert expected_call in mock_sync.call_args_list
 
 
 def _bare_zonal_file(loop, timeout=None):
@@ -846,7 +852,6 @@ def test_sync_teardown_skips_during_interpreter_finalization(monkeypatch):
     IO loop once the interpreter itself is tearing down.
     """
     loop = fsspec.asyn.get_loop()
-    zf = _bare_zonal_file(loop)
     monkeypatch.setattr(sys, "is_finalizing", lambda: True)
 
     calls = []
@@ -854,18 +859,13 @@ def test_sync_teardown_skips_during_interpreter_finalization(monkeypatch):
     async def coro():
         calls.append(1)
 
-    zf._sync_teardown(loop, coro, description="test op")
+    zb_hns_utils.sync_teardown(loop, coro, description="test op")
 
     assert calls == []
 
 
-def test_sync_teardown_logs_and_raises_when_loop_not_running(caplog):
-    """Unlike the prefetcher's read-only teardown, skipping here can leave
-    an upload unfinalized server-side, so this must be logged loudly
-    (error, not swallowed) and a RuntimeError raised rather than silently dropped.
-    """
+def test_sync_teardown_raises_when_loop_not_running():
     loop = fsspec.asyn.get_loop()
-    zf = _bare_zonal_file(loop)
 
     calls = []
 
@@ -873,47 +873,39 @@ def test_sync_teardown_logs_and_raises_when_loop_not_running(caplog):
         calls.append(1)
 
     with mock.patch.object(loop, "is_running", return_value=False):
-        with caplog.at_level(logging.ERROR, logger="gcsfs.zonal_file"):
-            with pytest.raises(RuntimeError, match="usable IO loop"):
-                zf._sync_teardown(loop, coro, description="test op")
+        with pytest.raises(RuntimeError, match="usable IO loop"):
+            zb_hns_utils.sync_teardown(loop, coro, description="test op")
 
     assert calls == []
-    assert any("test op" in r.message for r in caplog.records)
 
 
-def test_sync_teardown_logs_and_raises_when_loop_missing(caplog):
-    zf = _bare_zonal_file(None)
-
+def test_sync_teardown_raises_when_loop_missing():
     calls = []
 
     async def coro():
         calls.append(1)
 
-    with caplog.at_level(logging.ERROR, logger="gcsfs.zonal_file"):
-        with pytest.raises(RuntimeError, match="usable IO loop"):
-            zf._sync_teardown(None, coro, description="test op")
+    with pytest.raises(RuntimeError, match="usable IO loop"):
+        zb_hns_utils.sync_teardown(None, coro, description="test op")
 
     assert calls == []
-    assert any("test op" in r.message for r in caplog.records)
 
 
 def test_sync_teardown_runs_coroutine_on_healthy_loop():
     loop = fsspec.asyn.get_loop()
-    zf = _bare_zonal_file(loop)
 
     calls = []
 
     async def coro():
         calls.append(1)
 
-    zf._sync_teardown(loop, coro, description="test op")
+    zb_hns_utils.sync_teardown(loop, coro, description="test op")
 
     assert calls == [1]
 
 
 def test_sync_teardown_passes_args_and_kwargs_through():
     loop = fsspec.asyn.get_loop()
-    zf = _bare_zonal_file(loop)
 
     seen = {}
 
@@ -922,7 +914,7 @@ def test_sync_teardown_passes_args_and_kwargs_through():
         seen["finalize_on_close"] = finalize_on_close
 
     sentinel = object()
-    zf._sync_teardown(
+    zb_hns_utils.sync_teardown(
         loop, coro, sentinel, finalize_on_close=True, description="close_aaow"
     )
 
@@ -932,11 +924,10 @@ def test_sync_teardown_passes_args_and_kwargs_through():
 def test_sync_teardown_on_loop_thread_schedules_task_instead_of_raising():
     """asyn.sync() raises NotImplementedError when called from the loop
     it's supposed to wait on -- this is the same class of bug the
-    prefetcher fix addresses. Verify _sync_teardown avoids it by scheduling
+    prefetcher fix addresses. Verify sync_teardown avoids it by scheduling
     a task instead of blocking.
     """
     loop = fsspec.asyn.get_loop()
-    zf = _bare_zonal_file(loop)
 
     calls = []
 
@@ -944,7 +935,7 @@ def test_sync_teardown_on_loop_thread_schedules_task_instead_of_raising():
         calls.append(1)
 
     async def run_from_loop():
-        zf._sync_teardown(loop, coro, description="test op")
+        zb_hns_utils.sync_teardown(loop, coro, description="test op")
         await asyncio.sleep(0.05)  # let the scheduled task complete
 
     fsspec.asyn.sync(loop, run_from_loop)
@@ -952,30 +943,23 @@ def test_sync_teardown_on_loop_thread_schedules_task_instead_of_raising():
     assert calls == [1]
 
 
-def test_sync_teardown_raises_and_logs_on_timeout(caplog):
-    """A hung teardown must not block the caller (and, transitively, the
-    single serial gcsfs-deferred-close worker thread) forever. Unlike the
-    prefetcher, which lets the background job keep running after a
-    timeout, write finalization surfaces the timeout as an error the
-    caller can see, since silently continuing could hide a lost upload.
+def test_sync_teardown_raises_on_timeout():
+    """A hung teardown must not block the caller forever.
+    Write finalization surfaces the timeout as an error the caller can see.
     """
     loop = fsspec.asyn.get_loop()
-    zf = _bare_zonal_file(loop, timeout=0.05)
 
     async def coro():
         await asyncio.sleep(2.0)
 
-    with caplog.at_level(logging.ERROR, logger="gcsfs.zonal_file"):
-        with pytest.raises(FSTimeoutError):
-            zf._sync_teardown(loop, coro, description="slow op")
-
-    assert any("slow op" in r.message for r in caplog.records)
+    with pytest.raises(FSTimeoutError, match="slow op"):
+        zb_hns_utils.sync_teardown(loop, coro, timeout=0.05, description="slow op")
 
 
 def test_close_impl_uses_default_timeout_when_file_has_none(monkeypatch):
     """When the file carries no per-request timeout, teardown must still
-    be bounded (falls back to _DEFAULT_TEARDOWN_TIMEOUT_SECONDS) rather than
-    reverting to fsspec.asyn.sync's unbounded wait.
+    be bounded (falls back to DEFAULT_TEARDOWN_TIMEOUT_SECONDS) rather than
+    waiting indefinitely.
     """
     import gcsfs.zonal_file as zonal_file_module
 
@@ -990,16 +974,16 @@ def test_close_impl_uses_default_timeout_when_file_has_none(monkeypatch):
     zf.mrd_pool = mock_pool
 
     captured = {}
-    real_sync = fsspec.asyn.sync
+    real_teardown = zonal_file_module.sync_teardown
 
-    def spy_sync(loop_, func, *args, **kwargs):
+    def spy_teardown(loop_, func, *args, **kwargs):
         captured["timeout"] = kwargs.get("timeout")
-        return real_sync(loop_, func, *args, **kwargs)
+        return real_teardown(loop_, func, *args, **kwargs)
 
-    monkeypatch.setattr(zonal_file_module.asyn, "sync", spy_sync)
+    monkeypatch.setattr(zonal_file_module, "sync_teardown", spy_teardown)
     zf._close_impl()
 
-    assert captured["timeout"] == _DEFAULT_TEARDOWN_TIMEOUT_SECONDS
+    assert captured["timeout"] == DEFAULT_TEARDOWN_TIMEOUT_SECONDS
 
 
 def test_sync_teardown_reentrant_task_logs_exception(caplog):
@@ -1007,22 +991,103 @@ def test_sync_teardown_reentrant_task_logs_exception(caplog):
     raises an exception, it is logged with logger.error and not left unretrieved.
     """
     loop = fsspec.asyn.get_loop()
-    zf = _bare_zonal_file(loop)
 
     async def boom():
         raise RuntimeError("reentrant teardown exploded")
 
     async def run_from_loop():
-        zf._sync_teardown(loop, boom, description="failing op")
+        zb_hns_utils.sync_teardown(loop, boom, description="failing op")
         await asyncio.sleep(0.05)
 
-    with caplog.at_level(logging.ERROR, logger="gcsfs.zonal_file"):
+    with caplog.at_level(logging.ERROR, logger="gcsfs"):
         fsspec.asyn.sync(loop, run_from_loop)
 
     assert any(
         "failing op" in r.message and "reentrant teardown exploded" in r.message
         for r in caplog.records
     )
+
+
+def test_sync_teardown_helper_raises_exception():
+    """sync_teardown re-raises exceptions from the teardown coroutine."""
+    loop = fsspec.asyn.get_loop()
+
+    async def failing_op():
+        raise ValueError("simulated failure")
+
+    with pytest.raises(ValueError, match="simulated failure"):
+        zb_hns_utils.sync_teardown(
+            loop,
+            failing_op,
+            timeout=5.0,
+            description="failing teardown",
+        )
+
+
+def test_sync_teardown_helper_raises_timeout():
+    """sync_teardown raises FSTimeoutError when execution times out."""
+    loop = fsspec.asyn.get_loop()
+
+    async def slow_op():
+        await asyncio.sleep(2.0)
+
+    with pytest.raises(FSTimeoutError, match="slow teardown"):
+        zb_hns_utils.sync_teardown(
+            loop,
+            slow_op,
+            timeout=0.05,
+            description="slow teardown",
+        )
+
+
+def test_sync_teardown_helper_raises_when_loop_unavailable():
+    """sync_teardown raises RuntimeError when loop is None."""
+
+    async def op():
+        pass
+
+    with pytest.raises(RuntimeError, match="no usable IO loop available"):
+        zb_hns_utils.sync_teardown(
+            None,
+            op,
+            description="loopless teardown",
+        )
+
+
+def test_sync_teardown_helper_fire_and_forget():
+    """When timeout <= 0, scheduling is fire-and-forget and returns immediately."""
+    loop = fsspec.asyn.get_loop()
+    executed = threading.Event()
+
+    async def bg_op():
+        await asyncio.sleep(0.01)
+        executed.set()
+
+    zb_hns_utils.sync_teardown(
+        loop,
+        bg_op,
+        timeout=0,
+        description="fire-and-forget teardown",
+    )
+    assert executed.wait(timeout=5.0)
+
+
+def test_sync_teardown_helper_accepts_coroutine_object():
+    """sync_teardown works with an already instantiated coroutine object."""
+    loop = fsspec.asyn.get_loop()
+    result = []
+
+    async def coro_func():
+        result.append("done")
+
+    coro = coro_func()
+    zb_hns_utils.sync_teardown(
+        loop,
+        coro,
+        timeout=5.0,
+        description="coro object teardown",
+    )
+    assert result == ["done"]
 
 
 def test_close_impl_mrd_pool_failure_does_not_skip_aaow():

--- a/gcsfs/zb_hns_utils.py
+++ b/gcsfs/zb_hns_utils.py
@@ -5,10 +5,12 @@ import contextlib
 import ctypes
 import logging
 import os
+import sys
 import threading
 import weakref
 from io import BytesIO
 
+from fsspec.asyn import FSTimeoutError
 from google.api_core.exceptions import NotFound
 from google.cloud.storage.asyncio.async_appendable_object_writer import (
     _DEFAULT_FLUSH_INTERVAL_BYTES,
@@ -214,6 +216,107 @@ async def close_aaow(aaow, finalize_on_close=False):
             logger.warning(
                 f"Error closing AsyncAppendableObjectWriter for {aaow.bucket_name}/{aaow.object_name}: {e}"
             )
+
+
+# Default timeout for synchronous teardowns when no explicit timeout is configured.
+DEFAULT_TEARDOWN_TIMEOUT_SECONDS = 60.0
+
+# Strong references for background tasks scheduled via loop.create_task().
+# Without holding external references, Python's asyncio event loop may allow
+# pending tasks to be garbage-collected mid-execution ("Task was destroyed but
+# it is pending").
+_deferred_close_tasks = set()
+_deferred_close_lock = threading.Lock()
+
+
+def _on_loop_thread(loop):
+    """Returns True if the current thread is servicing the given event loop."""
+    if loop is None:
+        return False
+    try:
+        return asyncio.get_running_loop() is loop
+    except RuntimeError:
+        return False
+
+
+def _defer_task(
+    loop,
+    coro,
+    description="deferred task",
+    logger=None,
+    log_level=logging.WARNING,
+):
+    """Schedules a coroutine as a tracked background task on ``loop``.
+
+    Retains a strong reference in ``_deferred_close_tasks`` until completion to
+    prevent asyncio garbage collection from discarding pending tasks mid-flight,
+    and ensures unhandled task exceptions are retrieved and logged.
+    """
+    task = loop.create_task(coro)
+    with _deferred_close_lock:
+        _deferred_close_tasks.add(task)
+
+    def _on_done(t):
+        with _deferred_close_lock:
+            _deferred_close_tasks.discard(t)
+        if not t.cancelled():
+            exc = t.exception()
+            if exc:
+                log = logger or logging.getLogger("gcsfs")
+                log.log(
+                    log_level,
+                    "%s failed during asynchronous execution: %s",
+                    description,
+                    exc,
+                    exc_info=(type(exc), exc, exc.__traceback__),
+                )
+
+    task.add_done_callback(_on_done)
+    return task
+
+
+def sync_teardown(
+    loop,
+    func_or_coro,
+    *args,
+    timeout=None,
+    description="teardown",
+    **kwargs,
+):
+    """Safely runs an async teardown coroutine on ``loop`` from synchronous context.
+
+    Schedules via :func:`asyncio.run_coroutine_threadsafe` or defers on the loop
+    thread to prevent deadlocks.
+    """
+    coro = func_or_coro(*args, **kwargs) if callable(func_or_coro) else func_or_coro
+    if not asyncio.iscoroutine(coro):
+        return
+
+    if sys.is_finalizing():
+        coro.close()
+        return
+
+    if loop is None or not loop.is_running() or loop.is_closed():
+        coro.close()
+        raise RuntimeError(f"Skipping {description}: no usable IO loop available.")
+
+    if _on_loop_thread(loop):
+        _defer_task(loop, coro, description=description, log_level=logging.ERROR)
+        return
+
+    try:
+        future = asyncio.run_coroutine_threadsafe(coro, loop)
+    except RuntimeError:
+        coro.close()
+        raise RuntimeError(f"Skipping {description}: event loop is closed.")
+
+    if timeout is not None and timeout <= 0:
+        return
+
+    try:
+        return future.result(timeout)
+    except concurrent.futures.TimeoutError:
+        raise FSTimeoutError(f"{description} did not complete within {timeout}s.")
 
 
 class PartialView:

--- a/gcsfs/zonal_file.py
+++ b/gcsfs/zonal_file.py
@@ -1,4 +1,6 @@
 import logging
+import sys
+import threading
 
 from fsspec import asyn
 from google.cloud.storage.asyncio.async_appendable_object_writer import (
@@ -11,6 +13,7 @@ from gcsfs.core import (
     GCSFile,
     _coalesce_generation,
     _get_prefetcher_and_cache_config,
+    _on_loop_thread,
 )
 
 from .caching import (  # noqa: F401 Unused import to register GCS-Specific caches, Please do not remove it.
@@ -18,6 +21,53 @@ from .caching import (  # noqa: F401 Unused import to register GCS-Specific cach
 )
 
 logger = logging.getLogger("gcsfs.zonal_file")
+
+# Strong references for background tasks scheduled via loop.create_task().
+# Without holding external references, Python's asyncio event loop may allow
+# pending tasks to be garbage-collected mid-execution ("Task was destroyed but
+# it is pending").
+_deferred_close_tasks = set()
+_deferred_close_lock = threading.Lock()
+
+
+def _defer_task(
+    loop,
+    coro,
+    description="deferred task",
+    logger=None,
+    log_level=logging.WARNING,
+):
+    """Schedules a coroutine as a tracked background task on ``loop``.
+
+    Retains a strong reference in ``_deferred_close_tasks`` until completion to
+    prevent asyncio garbage collection from discarding pending tasks mid-flight,
+    and ensures unhandled task exceptions are retrieved and logged.
+    """
+    task = loop.create_task(coro)
+    with _deferred_close_lock:
+        _deferred_close_tasks.add(task)
+
+    def _on_done(t):
+        with _deferred_close_lock:
+            _deferred_close_tasks.discard(t)
+        if not t.cancelled():
+            exc = t.exception()
+            if exc:
+                log = logger or logging.getLogger("gcsfs")
+                log.log(
+                    log_level,
+                    "%s failed during asynchronous execution: %s",
+                    description,
+                    exc,
+                    exc_info=exc,
+                )
+
+    task.add_done_callback(_on_done)
+    return task
+
+
+# Default timeout for synchronous teardowns when the file has no timeout set.
+_DEFAULT_TEARDOWN_TIMEOUT_SECONDS = 60.0
 
 
 class ZonalFile(GCSFile):
@@ -397,13 +447,81 @@ class ZonalFile(GCSFile):
     def _close_impl(self):
         super()._close_impl()
 
-        if hasattr(self, "mrd_pool") and self.mrd_pool:
-            asyn.sync(self.gcsfs.loop, self.mrd_pool.close)
+        loop = getattr(getattr(self, "gcsfs", None), "loop", None)
+        errors = []
 
-        if self.aaow and self.aaow._is_stream_open:
-            asyn.sync(
-                self.gcsfs.loop,
-                zb_hns_utils.close_aaow,
-                self.aaow,
-                finalize_on_close=self.finalize_on_close,
+        # Teardown the read-side MRD pool if initialized.
+        if hasattr(self, "mrd_pool") and self.mrd_pool:
+            try:
+                self._sync_teardown(
+                    loop, self.mrd_pool.close, description="closing mrd_pool"
+                )
+            except Exception as e:
+                errors.append(e)
+
+        # Finalize and close the write-side AAOW stream.
+        # Wrapped independently so a read pool failure does not abandon write finalization.
+        if getattr(self, "aaow", None) and self.aaow._is_stream_open:
+            try:
+                self._sync_teardown(
+                    loop,
+                    zb_hns_utils.close_aaow,
+                    self.aaow,
+                    finalize_on_close=self.finalize_on_close,
+                    description="finalizing AsyncAppendableObjectWriter",
+                )
+            except Exception as e:
+                errors.append(e)
+
+        if errors:
+            raise errors[0]
+
+    def _sync_teardown(self, loop, func, *args, description, **kwargs):
+        """Runs an async teardown coroutine on ``loop`` from synchronous context.
+
+        Unlike purely read-side caching, write-side teardown finalizes appendable
+        objects server-side. Branches that cannot safely run the teardown coroutine
+        log warnings or errors to provide visibility into potential unfinalized resources.
+        """
+        path = getattr(self, "path", "<unknown>")
+
+        if sys.is_finalizing():
+            return
+
+        if loop is None or not loop.is_running():
+            # If the event loop is absent, closed, or not actively running,
+            # synchronous coordination via asyn.sync() is impossible.
+            logger.error(
+                "Skipping %s for %s: no usable IO loop available. This may "
+                "leave server-side resources unfinalized.",
+                description,
+                path,
             )
+            return
+
+        if _on_loop_thread(loop):
+            # Avoid deadlock when closing reentrantly from the event loop thread.
+            _defer_task(
+                loop,
+                func(*args, **kwargs),
+                description=f"{description} for {path}",
+                logger=logger,
+                log_level=logging.ERROR,
+            )
+            return
+
+        # Bound synchronous teardown so hung network calls do not stall the deferred-close thread forever.
+        teardown_timeout = (
+            getattr(self, "timeout", None) or _DEFAULT_TEARDOWN_TIMEOUT_SECONDS
+        )
+        try:
+            asyn.sync(loop, func, *args, timeout=teardown_timeout, **kwargs)
+        except asyn.FSTimeoutError:
+            logger.error(
+                "%s for %s did not complete within %ss; the upload may be "
+                "left unfinalized.",
+                description,
+                path,
+                teardown_timeout,
+            )
+            raise

--- a/gcsfs/zonal_file.py
+++ b/gcsfs/zonal_file.py
@@ -59,7 +59,7 @@ def _defer_task(
                     "%s failed during asynchronous execution: %s",
                     description,
                     exc,
-                    exc_info=exc,
+                    exc_info=(type(exc), exc, exc.__traceback__),
                 )
 
     task.add_done_callback(_on_done)

--- a/gcsfs/zonal_file.py
+++ b/gcsfs/zonal_file.py
@@ -491,13 +491,12 @@ class ZonalFile(GCSFile):
         if loop is None or not loop.is_running():
             # If the event loop is absent, closed, or not actively running,
             # synchronous coordination via asyn.sync() is impossible.
-            logger.error(
-                "Skipping %s for %s: no usable IO loop available. This may "
-                "leave server-side resources unfinalized.",
-                description,
-                path,
+            msg = (
+                f"Skipping {description} for {path}: no usable IO loop available. "
+                "This may leave server-side resources unfinalized."
             )
-            return
+            logger.error(msg)
+            raise RuntimeError(msg)
 
         if _on_loop_thread(loop):
             # Avoid deadlock when closing reentrantly from the event loop thread.

--- a/gcsfs/zonal_file.py
+++ b/gcsfs/zonal_file.py
@@ -1,6 +1,4 @@
 import logging
-import sys
-import threading
 
 from fsspec import asyn
 from google.cloud.storage.asyncio.async_appendable_object_writer import (
@@ -13,61 +11,14 @@ from gcsfs.core import (
     GCSFile,
     _coalesce_generation,
     _get_prefetcher_and_cache_config,
-    _on_loop_thread,
 )
+from gcsfs.zb_hns_utils import DEFAULT_TEARDOWN_TIMEOUT_SECONDS, sync_teardown
 
 from .caching import (  # noqa: F401 Unused import to register GCS-Specific caches, Please do not remove it.
     ReadAheadChunked,
 )
 
 logger = logging.getLogger("gcsfs.zonal_file")
-
-# Strong references for background tasks scheduled via loop.create_task().
-# Without holding external references, Python's asyncio event loop may allow
-# pending tasks to be garbage-collected mid-execution ("Task was destroyed but
-# it is pending").
-_deferred_close_tasks = set()
-_deferred_close_lock = threading.Lock()
-
-
-def _defer_task(
-    loop,
-    coro,
-    description="deferred task",
-    logger=None,
-    log_level=logging.WARNING,
-):
-    """Schedules a coroutine as a tracked background task on ``loop``.
-
-    Retains a strong reference in ``_deferred_close_tasks`` until completion to
-    prevent asyncio garbage collection from discarding pending tasks mid-flight,
-    and ensures unhandled task exceptions are retrieved and logged.
-    """
-    task = loop.create_task(coro)
-    with _deferred_close_lock:
-        _deferred_close_tasks.add(task)
-
-    def _on_done(t):
-        with _deferred_close_lock:
-            _deferred_close_tasks.discard(t)
-        if not t.cancelled():
-            exc = t.exception()
-            if exc:
-                log = logger or logging.getLogger("gcsfs")
-                log.log(
-                    log_level,
-                    "%s failed during asynchronous execution: %s",
-                    description,
-                    exc,
-                    exc_info=(type(exc), exc, exc.__traceback__),
-                )
-
-    task.add_done_callback(_on_done)
-    return task
-
-
-# Default timeout for synchronous teardowns when the file has no timeout set.
-_DEFAULT_TEARDOWN_TIMEOUT_SECONDS = 60.0
 
 
 class ZonalFile(GCSFile):
@@ -448,13 +399,18 @@ class ZonalFile(GCSFile):
         super()._close_impl()
 
         loop = getattr(getattr(self, "gcsfs", None), "loop", None)
+        path = getattr(self, "path", "<unknown>")
+        timeout = getattr(self, "timeout", None) or DEFAULT_TEARDOWN_TIMEOUT_SECONDS
         errors = []
 
         # Teardown the read-side MRD pool if initialized.
         if hasattr(self, "mrd_pool") and self.mrd_pool:
             try:
-                self._sync_teardown(
-                    loop, self.mrd_pool.close, description="closing mrd_pool"
+                sync_teardown(
+                    loop,
+                    self.mrd_pool.close,
+                    timeout=timeout,
+                    description=f"closing mrd_pool for {path}",
                 )
             except Exception as e:
                 errors.append(e)
@@ -463,64 +419,16 @@ class ZonalFile(GCSFile):
         # Wrapped independently so a read pool failure does not abandon write finalization.
         if getattr(self, "aaow", None) and self.aaow._is_stream_open:
             try:
-                self._sync_teardown(
+                sync_teardown(
                     loop,
                     zb_hns_utils.close_aaow,
                     self.aaow,
+                    timeout=timeout,
                     finalize_on_close=self.finalize_on_close,
-                    description="finalizing AsyncAppendableObjectWriter",
+                    description=f"finalizing AsyncAppendableObjectWriter for {path}",
                 )
             except Exception as e:
                 errors.append(e)
 
         if errors:
             raise errors[0]
-
-    def _sync_teardown(self, loop, func, *args, description, **kwargs):
-        """Runs an async teardown coroutine on ``loop`` from synchronous context.
-
-        Unlike purely read-side caching, write-side teardown finalizes appendable
-        objects server-side. Branches that cannot safely run the teardown coroutine
-        log warnings or errors to provide visibility into potential unfinalized resources.
-        """
-        path = getattr(self, "path", "<unknown>")
-
-        if sys.is_finalizing():
-            return
-
-        if loop is None or not loop.is_running():
-            # If the event loop is absent, closed, or not actively running,
-            # synchronous coordination via asyn.sync() is impossible.
-            msg = (
-                f"Skipping {description} for {path}: no usable IO loop available. "
-                "This may leave server-side resources unfinalized."
-            )
-            logger.error(msg)
-            raise RuntimeError(msg)
-
-        if _on_loop_thread(loop):
-            # Avoid deadlock when closing reentrantly from the event loop thread.
-            _defer_task(
-                loop,
-                func(*args, **kwargs),
-                description=f"{description} for {path}",
-                logger=logger,
-                log_level=logging.ERROR,
-            )
-            return
-
-        # Bound synchronous teardown so hung network calls do not stall the deferred-close thread forever.
-        teardown_timeout = (
-            getattr(self, "timeout", None) or _DEFAULT_TEARDOWN_TIMEOUT_SECONDS
-        )
-        try:
-            asyn.sync(loop, func, *args, timeout=teardown_timeout, **kwargs)
-        except asyn.FSTimeoutError:
-            logger.error(
-                "%s for %s did not complete within %ss; the upload may be "
-                "left unfinalized.",
-                description,
-                path,
-                teardown_timeout,
-            )
-            raise

--- a/gcsfs/zonal_file.py
+++ b/gcsfs/zonal_file.py
@@ -398,34 +398,32 @@ class ZonalFile(GCSFile):
     def _close_impl(self):
         super()._close_impl()
 
-        loop = getattr(getattr(self, "gcsfs", None), "loop", None)
-        path = getattr(self, "path", "<unknown>")
-        timeout = getattr(self, "timeout", None) or DEFAULT_TEARDOWN_TIMEOUT_SECONDS
+        timeout = self.timeout or DEFAULT_TEARDOWN_TIMEOUT_SECONDS
         errors = []
 
         # Teardown the read-side MRD pool if initialized.
         if hasattr(self, "mrd_pool") and self.mrd_pool:
             try:
                 sync_teardown(
-                    loop,
+                    self.gcsfs.loop,
                     self.mrd_pool.close,
                     timeout=timeout,
-                    description=f"closing mrd_pool for {path}",
+                    description=f"closing mrd_pool for {self.path}",
                 )
             except Exception as e:
                 errors.append(e)
 
         # Finalize and close the write-side AAOW stream.
         # Wrapped independently so a read pool failure does not abandon write finalization.
-        if getattr(self, "aaow", None) and self.aaow._is_stream_open:
+        if self.aaow and self.aaow._is_stream_open:
             try:
                 sync_teardown(
-                    loop,
+                    self.gcsfs.loop,
                     zb_hns_utils.close_aaow,
                     self.aaow,
                     timeout=timeout,
                     finalize_on_close=self.finalize_on_close,
-                    description=f"finalizing AsyncAppendableObjectWriter for {path}",
+                    description=f"finalizing AsyncAppendableObjectWriter for {self.path}",
                 )
             except Exception as e:
                 errors.append(e)


### PR DESCRIPTION
Fixes #1037

### Overview

When closing `BackgroundPrefetcher` or `ZonalFile` from synchronous finalizers (`__del__` or `weakref.finalize`), teardown could hang forever. This occurred in multi-threaded data pipelines (e.g. PyArrow Parquet datasets, Ray, Dask) where file handles are collected during interpreter shutdown or directly on the event loop thread.

This PR hardens the teardown paths across `BackgroundPrefetcher` and `ZonalFile`, eliminating reentrant deadlocks, preventing garbage collection of in-flight cleanup tasks, bounding synchronous teardowns, and isolating read/write failures.

### Root Causes & Fixes

1. **Reentrant Deadlock on Event Loop Thread**
   - **Problem:** If garbage collection drops the last reference to a file while executing on the `asyncio` event loop thread, calling `fsspec.asyn.sync()` or `future.result()` blocks the loop thread waiting on itself, causing an immediate deadlock or a swallowed `NotImplementedError`.
   - **Fix:** Uses `_on_loop_thread(loop)` to detect reentrant calls. Instead of blocking, the teardown coroutine is scheduled non-blockingly on the loop via `_defer_task()`.

2. **Garbage-Collected Background Tasks ("Task was destroyed but it is pending")**
   - **Problem:** Tasks created via `loop.create_task()` without an external strong reference can be garbage-collected mid-flight by Python's cyclic GC, aborting teardowns prematurely.
   - **Fix:** Introduced `_defer_task()` and `_deferred_close_tasks` in `gcsfs.zonal_file`. Strong references are maintained under a thread lock until the task completes, and unhandled exceptions are logged via a `done_callback`.

3. **In-Flight Reads & Bounded Timeouts in `BackgroundPrefetcher.close()`**
   - **Problem:** `PrefetchProducer.stop` intentionally awaits in-flight network chunk reads rather than cancelling them to prevent disrupting the shared `MultiRangeDownloader` connection pool. Furthermore, `run_coroutine_threadsafe` could leave unawaited coroutine warnings if the loop was concurrently closed.
   - **Fix:**
     - If `timeout` expires, teardown is left running in the background on the IO loop to allow buffers to drain safely without raising errors or truncating reads.
     - Explicitly closes unawaited coroutines if `run_coroutine_threadsafe` raises `RuntimeError`.

4. **Independent Teardown & Bounded Waits in `ZonalFile`**
   - **Problem:** In `ZonalFile._close_impl()`, if read pool (`mrd_pool.close()`) teardown raised an exception, write-side appendable object finalization (`close_aaow`) was skipped, causing potential data loss. Additionally, unbounded sync calls could stall the single serial `gcsfs-deferred-close` worker thread indefinitely.
   - **Fix:**
     - Read pool and write stream teardowns are isolated into independent `try...except` blocks in `_close_impl()`.
     - Bounded synchronous wait using `_DEFAULT_TEARDOWN_TIMEOUT_SECONDS = 60.0` (or file-level `timeout`).
     - Added guards for `sys.is_finalizing()`.