### PR TITLE
perf: optimize directory reconstruction in recursive find/walk

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1908,46 +1908,58 @@ class GCSFileSystem(DirCacheUpdater, asyn.AsyncFileSystem):
         if prefix:
             full_prefix = path.rstrip("/") + "/" + prefix
 
+        root_len = len(path.rstrip("/"))
+        should_update_cache = bool(not prefix and update_cache)
+
         for obj in objects:
             # For native HNS empty folders, which are returned as directory types
             # but are not placeholders, we need to ensure they have an entry in the cache.
-            if not prefix and update_cache and obj.get("type") == "directory":
+            if should_update_cache and obj.get("type") == "directory":
                 cache_entries.setdefault(obj["name"], {})
 
             parent = self._parent(obj["name"])
             previous = obj
 
             while parent:
-                dir_key = self.split_path(parent)[1]
-                if len(parent) < len(path.rstrip("/")):
+                if len(parent) < root_len:
                     break
 
                 if prefix and not parent.startswith(full_prefix):
                     # If this parent doesn't match the prefix, neither will its parents.
                     break
 
-                if dir_key:
-                    dirs[parent] = {
-                        "Key": dir_key,
-                        "Size": 0,
-                        "name": parent,
-                        "StorageClass": "DIRECTORY",
-                        "type": "directory",
-                        "size": 0,
-                    }
+                parent_already_seen = parent in dirs
+                if not parent_already_seen:
+                    dir_key = self.split_path(parent)[1]
+                    if dir_key:
+                        dirs[parent] = {
+                            "Key": dir_key,
+                            "Size": 0,
+                            "name": parent,
+                            "StorageClass": "DIRECTORY",
+                            "type": "directory",
+                            "size": 0,
+                        }
 
-                if not prefix and update_cache:
+                if should_update_cache:
                     listing = cache_entries.setdefault(parent, {})
                     name = previous["name"]
                     if name not in listing:
                         listing[name] = previous
+                    elif parent_already_seen:
+                        break
+                elif parent_already_seen:
+                    # When cache is not updated or prefix is used, once parent is in dirs,
+                    # all ancestors are already guaranteed to be in dirs. Break immediately.
+                    break
 
                 if parent in dirs:
                     previous = dirs[parent]
                 parent = self._parent(parent)
-        if not prefix and update_cache:
-            cache_entries_list = {k: list(v.values()) for k, v in cache_entries.items()}
-            self.dircache.update(cache_entries_list)
+        if should_update_cache:
+            self.dircache.update(
+                {k: list(v.values()) for k, v in cache_entries.items()}
+            )
         return dirs
 
     @retry_request(retries=retries)

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -3757,3 +3757,50 @@ def test_process_object_leading_slash(gcs):
     assert processed["name"] == "my-bucket//leading_slash_file.txt"
     assert parsed_bucket == "my-bucket"
     assert parsed_key == "/leading_slash_file.txt"
+
+
+def test_get_dirs_and_update_cache_nested(gcs):
+    bucket = "test-bucket"
+    objects = [
+        {"name": f"{bucket}/dir1/sub1/file1.txt", "size": 100, "type": "file"},
+        {"name": f"{bucket}/dir1/sub1/file2.txt", "size": 200, "type": "file"},
+        {"name": f"{bucket}/dir1/sub2/file3.txt", "size": 300, "type": "file"},
+        {"name": f"{bucket}/dir2/file4.txt", "size": 400, "type": "file"},
+    ]
+
+    gcs.dircache.clear()
+    dirs = gcs._get_dirs_and_update_cache(bucket, objects, prefix="", update_cache=True)
+
+    assert f"{bucket}/dir1" in dirs
+    assert f"{bucket}/dir1/sub1" in dirs
+    assert f"{bucket}/dir1/sub2" in dirs
+    assert f"{bucket}/dir2" in dirs
+    assert f"{bucket}" in gcs.dircache
+    assert f"{bucket}/dir1" in gcs.dircache
+    assert f"{bucket}/dir1/sub1" in gcs.dircache
+    assert f"{bucket}/dir1/sub2" in gcs.dircache
+    assert f"{bucket}/dir2" in gcs.dircache
+    root_children = [c["name"] for c in gcs.dircache[bucket]]
+    assert f"{bucket}/dir1" in root_children
+    assert f"{bucket}/dir2" in root_children
+    sub1_children = [c["name"] for c in gcs.dircache[f"{bucket}/dir1/sub1"]]
+    assert f"{bucket}/dir1/sub1/file1.txt" in sub1_children
+    assert f"{bucket}/dir1/sub1/file2.txt" in sub1_children
+
+
+def test_get_dirs_and_update_cache_with_directories_and_prefix(gcs):
+    bucket = "test-bucket"
+    objects = [
+        {"name": f"{bucket}/a/b/c/file1.txt", "size": 100, "type": "file"},
+        {"name": f"{bucket}/a/b/empty_folder", "size": 0, "type": "directory"},
+    ]
+
+    gcs.dircache.clear()
+    dirs = gcs._get_dirs_and_update_cache(
+        bucket, objects, prefix="a/b", update_cache=False
+    )
+
+    assert f"{bucket}/a/b" in dirs
+    assert f"{bucket}/a/b/c" in dirs
+    # Cache should remain empty because update_cache=False and prefix is used
+    assert len(gcs.dircache) == 0


### PR DESCRIPTION
**Summary**
Optimizes `GCSFileSystem._get_dirs_and_update_cache` (used in `find()`, `walk()`, and recursive listings) by creating directory metadata dictionaries only once per unique folder and short-circuiting ancestor traversal when a directory branch is already registered.

Reduces time complexity from $\mathcal{O}(N \times \text{Depth})$ to $\mathcal{O}(N + U \times \text{Depth})$  (N: total files, U: unique directories), yielding up to a **14.2x speedup (93% less CPU time)** and eliminating **>99% of heap dictionary allocations**.

**Benchmark Results (similar to `gcsfs/tests/perf/microbenchmarks/` but hierarchy generated in memory - no network calls)**

| Scenario (from `configs.yaml`) | Geometry | Legacy | Optimized | Speedup |
| :--- | :--- | ---: | ---: | ---: |
| `find_flat_folders` | 65k files, 256 folders, depth 0 | 73.54 ms | **28.66 ms** | **2.57x** (61% less CPU) |
| `find_recursive_folders` | 65k files, 256 folders, depth 8 | 191.11 ms | **30.16 ms** | **6.34x** (84% less CPU) |
| `find_recursive_folders_deep` | 65k files, 256 folders, depth 24 | 458.42 ms | **33.48 ms** | **13.69x** (93% less CPU) |
| `find_recursive_folders_deep` | 131k files, 256 folders, depth 24 | 940.39 ms | **65.98 ms** | **14.25x** (93% less CPU) |

**Changes**
1. Allocate Directory Dicts Once: Check `parent_already_seen = parent in dirs` to avoid recreating duplicate dicts for every sibling file.
2. Short-Circuit Visited Ancestors: Break early once a child is in `listing` and its parent's ancestors are established.
3. Immediate Break on Prefix/No-Cache: Exit on iteration 1 for already-seen folders when `prefix` is set or `update_cache=False`.
4. Pre-computed Variables: Calculate `root_len` and `should_update_cache` outside loops.

**Testing**
- Passes all existing tests in `test_core.py` and `test_extended_hns.py`.
- Pre-commit (`black`, `flake8`, `isort`) clean.