### PR TITLE
Feat: Automatic upstream framework telemetry detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,17 @@ GCSFS plays nicely with the rest of the Python data ecosystem.
 
 -----
 
+## Telemetry
+
+GCSFS includes lightweight caller framework detection to identify upstream libraries (such as Pandas, PyTorch, Ray, and Dask) interacting with Google Cloud Storage. This helps prioritize performance optimizations and maintain ecosystem compatibility.
+
+- **Privacy Guaranteed:** Only open-source library names are detected. No user data, object keys, file paths, credentials, or code logic are ever collected or transmitted.
+- **Opt-out:** Telemetry can be disabled at any time by setting the environment variable `GCSFS_NO_TELEMETRY=true` (or `1` / `yes`).
+
+For full details, see the [Telemetry Documentation](https://gcsfs.readthedocs.io/en/latest/telemetry.html).
+
+-----
+
 ## Support
 
 Work on this repository is supported in part by:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -242,6 +242,7 @@ Contents
    retries
    fuse
    Read Optimization: Prefetching <prefetcher>
+   telemetry
    release
    changelog
    code-of-conduct

--- a/docs/source/telemetry.rst
+++ b/docs/source/telemetry.rst
@@ -1,0 +1,80 @@
+Telemetry & Usage Attribution
+=============================
+
+``gcsfs`` includes lightweight, automatic caller framework detection to identify the upstream data science and machine learning libraries that interact with Google Cloud Storage (GCS).
+
+Purpose
+-------
+
+The Python data ecosystem comprises a rich variety of frameworks—including Pandas, PyTorch, Ray, Dask, Hugging Face, and PyArrow. Telemetry attribution helps the maintainers and Google Cloud Storage understand real-world usage patterns, identify performance bottlenecks for specific workloads, and prioritize compatibility improvements across popular open-source libraries.
+
+What is Collected
+-----------------
+
+When an operation is executed, ``gcsfs`` identifies the name of the top-level calling framework and appends an anonymous brand identifier token to the HTTP ``User-Agent`` header of outgoing requests to Google Cloud Storage.
+
+Example Header
+~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+   User-Agent: gcsfs/2026.3.0 fsspec/2026.3.0 fw/pandas
+
+Recognized Frameworks
+~~~~~~~~~~~~~~~~~~~~~
+
+The detector recognizes major ecosystem libraries, including:
+
+- **Data Processing & Analytics:** ``pandas`` (``fw/pandas``), ``dask`` (``fw/dask``), ``ray`` (``fw/ray``), ``pyspark`` (``fw/spark``), ``pyarrow`` (``fw/pyarrow``), ``duckdb`` (``fw/duckdb``), ``xarray`` (``fw/xarray``), ``fastparquet`` (``fw/fastparquet``).
+- **Machine Learning & Deep Learning:** ``torch`` (``fw/torch``), ``torchdata`` (``fw/torchdata``), ``lightning`` / ``pytorch_lightning`` (``fw/lightning``), ``datasets`` (``fw/datasets``), ``transformers`` (``fw/transformers``), ``orbax`` (``fw/orbax``), ``tensorstore`` (``fw/tensorstore``), ``tensorflow`` (``fw/tensorflow``), ``jax`` (``fw/jax``).
+
+If no recognized framework is present on the call stack (e.g. pure Python scripts or unrecognized utilities), no framework token is added to the header.
+
+Privacy & Security Guarantees
+-----------------------------
+
+Telemetry collection is strictly limited to open-source library names and respects user privacy and security:
+
+- **No User Data or Payloads:** Object contents read or written are never inspected or recorded.
+- **No File Paths or Bucket Names:** Bucket names, object keys, folder hierarchies, and URIs are never collected.
+- **No User Code or Logic:** Variable names, function arguments, and script logic are never accessed.
+- **No Credentials or Identifiers:** API keys, service account credentials, IAM identities, project IDs, and IP addresses are never collected.
+- **Header Injection Safety:** All tokens are sanitized strictly against RFC 9110 HTTP token specifications (alphanumeric characters, hyphens, underscores, and dots only).
+
+How It Works
+------------
+
+1. **Zero Configuration:** Upstream libraries do not need any code changes or special configuration. Detection occurs transparently when filesystem methods (e.g. ``fs.ls``, ``fs.cat_file``, ``fs.open``, ``df.to_parquet``, ``torch.load``) are called.
+2. **Thread Boundary Crossing:** In ``fsspec``, synchronous operations dispatch coroutines to a background asyncio event loop thread. ``gcsfs`` captures caller identity on the user's thread and safely propagates it to the background event loop via Python ``contextvars``.
+3. **Performance & Caching:** Detection uses lightweight stack frame inspection (via ``sys._getframe()``) capped at shallow depths. Active ``GCSFile`` instances cache their framework attribution so subsequent chunk downloads and background prefetching operations execute with zero stack-walking overhead (:math:`O(1)`).
+
+Disabling Telemetry
+-------------------
+
+Telemetry collection is enabled by default, but you can opt out at any time by setting an environment variable.
+
+Using Environment Variables
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Set ``GCSFS_NO_TELEMETRY=true`` in your shell environment:
+
+.. code-block:: bash
+
+   export GCSFS_NO_TELEMETRY=true
+
+In Python Code
+~~~~~~~~~~~~~~
+
+Set the environment variable before importing ``gcsfs`` or executing storage calls:
+
+.. code-block:: python
+
+   import os
+   os.environ["GCSFS_NO_TELEMETRY"] = "true"
+
+   import gcsfs
+
+When disabled:
+
+- All stack frame inspections and detector evaluations are skipped immediately.
+- Outgoing requests contain only standard ``gcsfs/<version>`` and ``fsspec/<version>`` headers.

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -528,15 +528,10 @@ class GCSFileSystem(DirCacheUpdater, asyn.AsyncFileSystem):
         async def _coro_with_context():
             token = set_telemetry_context(tokens_map)
             try:
-                if inspect.iscoroutinefunction(func):
-                    return await func(*args, **kwargs)
-                elif inspect.iscoroutine(func) or inspect.isawaitable(func):
-                    return await func
-                else:
-                    res = func(*args, **kwargs)
-                    if inspect.iscoroutine(res) or inspect.isawaitable(res):
-                        return await res
-                    return res
+                res = func(*args, **kwargs) if callable(func) else func
+                if inspect.isawaitable(res):
+                    return await res
+                return res
             finally:
                 reset_telemetry_context(token)
 

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -37,7 +37,12 @@ from .concurrency import parallel_tasks_first_completed, split_range
 from .credentials import GoogleCredentials
 from .inventory_report import InventoryReport
 from .retry import errs, retry_request, validate_response
-from .telemetry.context import Dimension, reset_telemetry_context, set_telemetry_context
+from .telemetry.context import (
+    Dimension,
+    get_telemetry_context,
+    reset_telemetry_context,
+    set_telemetry_context,
+)
 from .telemetry.manager import default_usage_tracker, mirror_gcs_sync_methods
 from .zb_hns_utils import DEFAULT_CONCURRENCY, MAX_PREFETCH_SIZE
 
@@ -2441,9 +2446,10 @@ def _start_deferred_close_worker():
 
 
 def _defer_close(file):
-    tokens_map = default_usage_tracker.collect_tokens_map()
-    if getattr(file, "caller_framework", None):
-        tokens_map[Dimension.FRAMEWORK.value] = file.caller_framework
+    tokens_map = get_telemetry_context()
+    fw = getattr(file, "caller_framework", None)
+    if fw:
+        tokens_map[Dimension.FRAMEWORK.value] = fw
 
     def _run():
         token = set_telemetry_context(tokens_map)
@@ -2801,7 +2807,7 @@ class GCSFile(fsspec.spec.AbstractBufferedFile):
 
     async def _async_fetch_range(self, start_offset, total_size, split_factor=1):
         """Async fetcher mapped to the Prefetcher engine for regional buckets."""
-        tokens_map = default_usage_tracker.collect_tokens_map()
+        tokens_map = get_telemetry_context()
         if self.caller_framework:
             tokens_map[Dimension.FRAMEWORK.value] = self.caller_framework
 

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -398,7 +398,6 @@ class GCSFileSystem(DirCacheUpdater, asyn.AsyncFileSystem):
         self.credentials = GoogleCredentials(
             project, access, token, on_google=self.on_google
         )
-        mirror_gcs_sync_methods(self)
 
     @property
     def _location(self):
@@ -2410,6 +2409,9 @@ def _on_loop_thread(loop):
         return asyncio.get_running_loop() is loop
     except RuntimeError:
         return False
+
+
+mirror_gcs_sync_methods(GCSFileSystem)
 
 
 _DEFERRED_CLOSE_THREAD_NAME = "gcsfs-deferred-close"

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -3,6 +3,7 @@ Google Cloud Storage pythonic interface
 """
 
 import asyncio
+import inspect
 import io
 import json
 import logging
@@ -36,6 +37,12 @@ from .concurrency import parallel_tasks_first_completed, split_range
 from .credentials import GoogleCredentials
 from .inventory_report import InventoryReport
 from .retry import errs, retry_request, validate_response
+from .telemetry.context import (
+    Dimension,
+    reset_telemetry_context,
+    set_telemetry_context,
+)
+from .telemetry.manager import default_usage_tracker, mirror_gcs_sync_methods
 from .zb_hns_utils import DEFAULT_CONCURRENCY, MAX_PREFETCH_SIZE
 
 logger = logging.getLogger("gcsfs")
@@ -193,6 +200,21 @@ def _get_cache_type_header_value(cache_type, cache_source=None):
     elif cache_source == "default":
         suffix = ":d"
     return f"cache_type/{cache_type}{suffix}"
+
+
+def _build_user_agent(cache_type=None, cache_source=None):
+    """Build the standard User-Agent header string for HTTP requests."""
+    tokens = [f"python-gcsfs/{version}"]
+
+    cache_val = _get_cache_type_header_value(cache_type, cache_source)
+    if cache_val:
+        tokens.append(cache_val)
+
+    telemetry_tokens = default_usage_tracker.get_tokens()
+    if telemetry_tokens:
+        tokens.extend(telemetry_tokens)
+
+    return " ".join(tokens)
 
 
 class GCSFileSystem(DirCacheUpdater, asyn.AsyncFileSystem):
@@ -375,6 +397,7 @@ class GCSFileSystem(DirCacheUpdater, asyn.AsyncFileSystem):
         self.credentials = GoogleCredentials(
             project, access, token, on_google=self.on_google
         )
+        mirror_gcs_sync_methods(self)
 
     @property
     def _location(self):
@@ -488,13 +511,36 @@ class GCSFileSystem(DirCacheUpdater, asyn.AsyncFileSystem):
         if headers is not None:
             out.update(headers)
         if "User-Agent" not in out:
-            ua = "python-gcsfs/" + version
-            cache_val = _get_cache_type_header_value(cache_type, cache_source)
-            if cache_val:
-                ua += f" {cache_val}"
-            out["User-Agent"] = ua
+            out["User-Agent"] = _build_user_agent(
+                cache_type=cache_type,
+                cache_source=cache_source,
+            )
         self.credentials.apply(out)
         return out
+
+    def _sync(self, func, *args, timeout=None, **kwargs):
+        """
+        GCSFS-specific synchronization bridge.
+        Bridges caller thread telemetry context to the background asyncio event loop thread.
+        """
+        tokens_map = default_usage_tracker.collect_tokens_map()
+
+        async def _coro_with_context():
+            token = set_telemetry_context(tokens_map)
+            try:
+                if inspect.iscoroutinefunction(func):
+                    return await func(*args, **kwargs)
+                elif inspect.iscoroutine(func) or inspect.isawaitable(func):
+                    return await func
+                else:
+                    res = func(*args, **kwargs)
+                    if inspect.iscoroutine(res) or inspect.isawaitable(res):
+                        return await res
+                    return res
+            finally:
+                reset_telemetry_context(token)
+
+        return asyn.sync(self.loop, _coro_with_context, timeout=timeout)
 
     def _format_path(self, path, args):
         if not path.startswith("http"):
@@ -560,7 +606,7 @@ class GCSFileSystem(DirCacheUpdater, asyn.AsyncFileSystem):
         """Return list of available project buckets."""
         return [
             b["name"]
-            for b in asyn.sync(self.loop, self._list_buckets, timeout=self.timeout)
+            for b in self._sync(self._list_buckets, timeout=self.timeout)
         ]
 
     def _process_object(self, bucket, object_metadata):
@@ -2402,11 +2448,18 @@ def _start_deferred_close_worker():
 
 
 def _defer_close(file):
+    tokens_map = default_usage_tracker.collect_tokens_map()
+    if getattr(file, "caller_framework", None):
+        tokens_map[Dimension.FRAMEWORK.value] = file.caller_framework
+
     def _run():
+        token = set_telemetry_context(tokens_map)
         try:
             file._close_impl()
         except Exception:
             logger.exception("deferred close of %s failed", file.path)
+        finally:
+            reset_telemetry_context(token)
 
     work = _deferred_close_queue
     if work is None:  # pragma: no cover
@@ -2512,6 +2565,9 @@ class GCSFile(fsspec.spec.AbstractBufferedFile):
             **kwargs,
         )
         self.cache_type = cache_type
+        self._caller_framework = default_usage_tracker.get_dimension(
+            Dimension.FRAMEWORK
+        )
         self.gcsfs = gcsfs
         self.bucket = bucket
         self.key = key
@@ -2564,6 +2620,19 @@ class GCSFile(fsspec.spec.AbstractBufferedFile):
             )
         else:
             self._prefetch_engine = None
+
+    @property
+    def caller_framework(self):
+        """Dynamically fetch caller if currently None, and cache once found."""
+        if not self._caller_framework:
+            self._caller_framework = default_usage_tracker.get_dimension(
+                Dimension.FRAMEWORK
+            )
+        return self._caller_framework
+
+    @caller_framework.setter
+    def caller_framework(self, value):
+        self._caller_framework = value
 
     @property
     def details(self):
@@ -2668,8 +2737,7 @@ class GCSFile(fsspec.spec.AbstractBufferedFile):
 
     def _initiate_upload(self):
         """Create multi-upload"""
-        self.location = asyn.sync(
-            self.gcsfs.loop,
+        self.location = self.gcsfs._sync(
             initiate_upload,
             self.gcsfs,
             self.bucket,
@@ -2700,8 +2768,7 @@ class GCSFile(fsspec.spec.AbstractBufferedFile):
         """One-shot upload, less than 5MB"""
         self.buffer.seek(0)
         data = self.buffer.read()
-        j = asyn.sync(
-            self.gcsfs.loop,
+        j = self.gcsfs._sync(
             simple_upload,
             self.gcsfs,
             self.bucket,
@@ -2741,14 +2808,22 @@ class GCSFile(fsspec.spec.AbstractBufferedFile):
 
     async def _async_fetch_range(self, start_offset, total_size, split_factor=1):
         """Async fetcher mapped to the Prefetcher engine for regional buckets."""
-        return await self.gcsfs._cat_file_concurrent(
-            self.path,
-            start=start_offset,
-            end=start_offset + total_size,
-            concurrency=split_factor,
-            cache_type=self.cache_type,
-            cache_source=self.cache_source,
-        )
+        tokens_map = default_usage_tracker.collect_tokens_map()
+        if self.caller_framework:
+            tokens_map[Dimension.FRAMEWORK.value] = self.caller_framework
+
+        token = set_telemetry_context(tokens_map)
+        try:
+            return await self.gcsfs._cat_file_concurrent(
+                self.path,
+                start=start_offset,
+                end=start_offset + total_size,
+                concurrency=split_factor,
+                cache_type=self.cache_type,
+                cache_source=self.cache_source,
+            )
+        finally:
+            reset_telemetry_context(token)
 
     def close(self):
         if self.closed or self._close_deferred:

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -2561,8 +2561,8 @@ class GCSFile(fsspec.spec.AbstractBufferedFile):
             **kwargs,
         )
         self.cache_type = cache_type
-        self._caller_framework = default_usage_tracker.get_dimension(
-            Dimension.FRAMEWORK
+        self._caller_framework = (
+            default_usage_tracker.get_dimension(Dimension.FRAMEWORK) or ""
         )
         self.gcsfs = gcsfs
         self.bucket = bucket
@@ -2620,9 +2620,9 @@ class GCSFile(fsspec.spec.AbstractBufferedFile):
     @property
     def caller_framework(self):
         """Dynamically fetch caller if currently None, and cache once found."""
-        if not self._caller_framework:
-            self._caller_framework = default_usage_tracker.get_dimension(
-                Dimension.FRAMEWORK
+        if self._caller_framework is None:
+            self._caller_framework = (
+                default_usage_tracker.get_dimension(Dimension.FRAMEWORK) or ""
             )
         return self._caller_framework
 

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -43,7 +43,7 @@ from .telemetry.context import (
     reset_telemetry_context,
     set_telemetry_context,
 )
-from .telemetry.manager import default_usage_tracker, mirror_gcs_sync_methods
+from .telemetry.manager import default_usage_tracker, mirror_gcs_methods
 from .zb_hns_utils import DEFAULT_CONCURRENCY, MAX_PREFETCH_SIZE
 
 logger = logging.getLogger("gcsfs")
@@ -2411,7 +2411,7 @@ def _on_loop_thread(loop):
         return False
 
 
-mirror_gcs_sync_methods(GCSFileSystem)
+mirror_gcs_methods(GCSFileSystem)
 
 
 _DEFERRED_CLOSE_THREAD_NAME = "gcsfs-deferred-close"

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -37,11 +37,7 @@ from .concurrency import parallel_tasks_first_completed, split_range
 from .credentials import GoogleCredentials
 from .inventory_report import InventoryReport
 from .retry import errs, retry_request, validate_response
-from .telemetry.context import (
-    Dimension,
-    reset_telemetry_context,
-    set_telemetry_context,
-)
+from .telemetry.context import Dimension, reset_telemetry_context, set_telemetry_context
 from .telemetry.manager import default_usage_tracker, mirror_gcs_sync_methods
 from .zb_hns_utils import DEFAULT_CONCURRENCY, MAX_PREFETCH_SIZE
 
@@ -604,10 +600,7 @@ class GCSFileSystem(DirCacheUpdater, asyn.AsyncFileSystem):
     @property
     def buckets(self):
         """Return list of available project buckets."""
-        return [
-            b["name"]
-            for b in self._sync(self._list_buckets, timeout=self.timeout)
-        ]
+        return [b["name"] for b in self._sync(self._list_buckets, timeout=self.timeout)]
 
     def _process_object(self, bucket, object_metadata):
         """Process object resource into gcsfs object information format.

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -2561,7 +2561,7 @@ class GCSFile(fsspec.spec.AbstractBufferedFile):
             **kwargs,
         )
         self.cache_type = cache_type
-        self._caller_framework = (
+        self.caller_framework = (
             default_usage_tracker.get_dimension(Dimension.FRAMEWORK) or ""
         )
         self.gcsfs = gcsfs
@@ -2616,19 +2616,6 @@ class GCSFile(fsspec.spec.AbstractBufferedFile):
             )
         else:
             self._prefetch_engine = None
-
-    @property
-    def caller_framework(self):
-        """Dynamically fetch caller if currently None, and cache once found."""
-        if self._caller_framework is None:
-            self._caller_framework = (
-                default_usage_tracker.get_dimension(Dimension.FRAMEWORK) or ""
-            )
-        return self._caller_framework
-
-    @caller_framework.setter
-    def caller_framework(self, value):
-        self._caller_framework = value
 
     @property
     def details(self):

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -37,12 +37,7 @@ from .concurrency import parallel_tasks_first_completed, split_range
 from .credentials import GoogleCredentials
 from .inventory_report import InventoryReport
 from .retry import errs, retry_request, validate_response
-from .telemetry.context import (
-    Dimension,
-    get_telemetry_context,
-    reset_telemetry_context,
-    set_telemetry_context,
-)
+from .telemetry.context import Dimension, reset_telemetry_context, set_telemetry_context
 from .telemetry.manager import default_usage_tracker, mirror_gcs_methods
 from .zb_hns_utils import DEFAULT_CONCURRENCY, MAX_PREFETCH_SIZE
 
@@ -2443,19 +2438,11 @@ def _start_deferred_close_worker():
 
 
 def _defer_close(file):
-    tokens_map = get_telemetry_context()
-    fw = getattr(file, "caller_framework", None)
-    if fw:
-        tokens_map[Dimension.FRAMEWORK.value] = fw
-
     def _run():
-        token = set_telemetry_context(tokens_map)
         try:
             file._close_impl()
         except Exception:
             logger.exception("deferred close of %s failed", file.path)
-        finally:
-            reset_telemetry_context(token)
 
     work = _deferred_close_queue
     if work is None:  # pragma: no cover
@@ -2791,22 +2778,14 @@ class GCSFile(fsspec.spec.AbstractBufferedFile):
 
     async def _async_fetch_range(self, start_offset, total_size, split_factor=1):
         """Async fetcher mapped to the Prefetcher engine for regional buckets."""
-        tokens_map = get_telemetry_context()
-        if self.caller_framework:
-            tokens_map[Dimension.FRAMEWORK.value] = self.caller_framework
-
-        token = set_telemetry_context(tokens_map)
-        try:
-            return await self.gcsfs._cat_file_concurrent(
-                self.path,
-                start=start_offset,
-                end=start_offset + total_size,
-                concurrency=split_factor,
-                cache_type=self.cache_type,
-                cache_source=self.cache_source,
-            )
-        finally:
-            reset_telemetry_context(token)
+        return await self.gcsfs._cat_file_concurrent(
+            self.path,
+            start=start_offset,
+            end=start_offset + total_size,
+            concurrency=split_factor,
+            cache_type=self.cache_type,
+            cache_source=self.cache_source,
+        )
 
     def close(self):
         if self.closed or self._close_deferred:
@@ -3025,3 +3004,8 @@ async def simple_upload(
     checker.update(datain)
     checker.validate_json_response(j)
     return j
+
+
+from .telemetry.manager import wrap_file_methods
+
+wrap_file_methods()

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -31,7 +31,7 @@ from gcsfs._dircache import HnsDirCacheUpdater
 from gcsfs.concurrency import split_range
 from gcsfs.core import GCSFile, GCSFileSystem, _get_prefetcher_and_cache_config
 from gcsfs.retry import DEFAULT_RETRY_CONFIG, get_storage_control_retry_config
-from gcsfs.telemetry.manager import _gcs_sync_wrapper, mirror_gcs_sync_methods
+from gcsfs.telemetry.manager import _gcs_sync_wrapper, mirror_gcs_methods
 from gcsfs.zb_hns_utils import DirectMemmoveBuffer, MRDPool
 from gcsfs.zonal_file import ZonalFile
 
@@ -2116,4 +2116,4 @@ async def simple_upload(
         await zb_hns_utils.close_aaow(writer, finalize_on_close=finalize_on_close)
 
 
-mirror_gcs_sync_methods(ExtendedGcsFileSystem)
+mirror_gcs_methods(ExtendedGcsFileSystem)

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -31,6 +31,7 @@ from gcsfs._dircache import HnsDirCacheUpdater
 from gcsfs.concurrency import split_range
 from gcsfs.core import GCSFile, GCSFileSystem, _get_prefetcher_and_cache_config
 from gcsfs.retry import DEFAULT_RETRY_CONFIG, get_storage_control_retry_config
+from gcsfs.telemetry.manager import _gcs_sync_wrapper, mirror_gcs_sync_methods
 from gcsfs.zb_hns_utils import DirectMemmoveBuffer, MRDPool
 from gcsfs.zonal_file import ZonalFile
 
@@ -284,7 +285,7 @@ class ExtendedGcsFileSystem(HnsDirCacheUpdater, GCSFileSystem):
         self._storage_layout_cache[bucket] = bucket_type
         return self._storage_layout_cache[bucket]
 
-    _sync_lookup_bucket_type = asyn.sync_wrapper(_lookup_bucket_type)
+    _sync_lookup_bucket_type = _gcs_sync_wrapper(_lookup_bucket_type)
 
     async def _get_bucket_type(self, bucket):
         try:
@@ -2113,3 +2114,6 @@ async def simple_upload(
         default_finalize = getattr(fs, "finalize_on_close", False)
         finalize_on_close = kwargs.get("finalize_on_close", default_finalize)
         await zb_hns_utils.close_aaow(writer, finalize_on_close=finalize_on_close)
+
+
+mirror_gcs_sync_methods(ExtendedGcsFileSystem)

--- a/gcsfs/telemetry/__init__.py
+++ b/gcsfs/telemetry/__init__.py
@@ -1,0 +1,1 @@
+"""Internal telemetry subsystem for gcsfs."""

--- a/gcsfs/telemetry/context.py
+++ b/gcsfs/telemetry/context.py
@@ -1,0 +1,52 @@
+"""Internal thread-safe and coroutine-safe context management for telemetry state."""
+from __future__ import annotations
+
+import contextvars
+from enum import Enum
+import os
+from typing import Dict, Optional
+
+
+class Dimension(str, Enum):
+    """Standard telemetry dimension keys."""
+    FRAMEWORK = "fw"
+
+
+# ContextVar for propagating multi-dimensional telemetry tokens across async event loop and thread boundaries
+_current_telemetry: contextvars.ContextVar[Dict[str, str]] = contextvars.ContextVar(
+    "gcsfs_current_telemetry", default={}
+)
+
+
+if hasattr(os, "register_at_fork"):
+    def _reset_telemetry_in_child():
+        _current_telemetry.set({})
+
+    os.register_at_fork(after_in_child=_reset_telemetry_in_child)
+
+
+def get_telemetry_context() -> Dict[str, str]:
+    """Retrieve active telemetry tokens mapping from context."""
+    return dict(_current_telemetry.get())
+
+
+def set_telemetry_context(tokens: Dict[str, str]) -> contextvars.Token:
+    """Set telemetry tokens mapping in context and return contextvars.Token for resetting."""
+    return _current_telemetry.set(dict(tokens))
+
+
+def reset_telemetry_context(token: contextvars.Token) -> None:
+    """Reset telemetry context to the state associated with the given token."""
+    _current_telemetry.reset(token)
+
+
+def get_dimension_context(dimension: Dimension) -> Optional[str]:
+    """Retrieve active telemetry token for a specific dimension from context."""
+    return get_telemetry_context().get(dimension.value)
+
+
+def set_dimension_context(dimension: Dimension, value: str) -> contextvars.Token:
+    """Set or update a specific dimension in context and return contextvars.Token for resetting."""
+    current = get_telemetry_context()
+    current[dimension.value] = str(value)
+    return set_telemetry_context(current)

--- a/gcsfs/telemetry/context.py
+++ b/gcsfs/telemetry/context.py
@@ -15,22 +15,23 @@ class Dimension(str, Enum):
 
 
 # ContextVar for propagating multi-dimensional telemetry tokens across async event loop and thread boundaries
-_current_telemetry: contextvars.ContextVar[Dict[str, str]] = contextvars.ContextVar(
-    "gcsfs_current_telemetry", default={}
+_current_telemetry: contextvars.ContextVar[Optional[Dict[str, str]]] = (
+    contextvars.ContextVar("gcsfs_current_telemetry", default=None)
 )
 
 
 if hasattr(os, "register_at_fork"):
 
     def _reset_telemetry_in_child():
-        _current_telemetry.set({})
+        _current_telemetry.set(None)
 
     os.register_at_fork(after_in_child=_reset_telemetry_in_child)
 
 
 def get_telemetry_context() -> Dict[str, str]:
     """Retrieve active telemetry tokens mapping from context."""
-    return dict(_current_telemetry.get())
+    val = _current_telemetry.get()
+    return dict(val) if val is not None else {}
 
 
 def set_telemetry_context(tokens: Dict[str, str]) -> contextvars.Token:

--- a/gcsfs/telemetry/context.py
+++ b/gcsfs/telemetry/context.py
@@ -1,14 +1,16 @@
 """Internal thread-safe and coroutine-safe context management for telemetry state."""
+
 from __future__ import annotations
 
 import contextvars
-from enum import Enum
 import os
+from enum import Enum
 from typing import Dict, Optional
 
 
 class Dimension(str, Enum):
     """Standard telemetry dimension keys."""
+
     FRAMEWORK = "fw"
 
 
@@ -19,6 +21,7 @@ _current_telemetry: contextvars.ContextVar[Dict[str, str]] = contextvars.Context
 
 
 if hasattr(os, "register_at_fork"):
+
     def _reset_telemetry_in_child():
         _current_telemetry.set({})
 

--- a/gcsfs/telemetry/context.py
+++ b/gcsfs/telemetry/context.py
@@ -28,11 +28,6 @@ if hasattr(os, "register_at_fork"):
     os.register_at_fork(after_in_child=_reset_telemetry_in_child)
 
 
-def has_telemetry_context() -> bool:
-    """Check if telemetry context is active without dict allocations (O(1))."""
-    return bool(_current_telemetry.get())
-
-
 def get_telemetry_context() -> Dict[str, str]:
     """Retrieve active telemetry tokens mapping from context."""
     val = _current_telemetry.get()
@@ -51,7 +46,8 @@ def reset_telemetry_context(token: contextvars.Token) -> None:
 
 def get_dimension_context(dimension: Dimension) -> Optional[str]:
     """Retrieve active telemetry token for a specific dimension from context."""
-    return get_telemetry_context().get(dimension.value)
+    val = _current_telemetry.get()
+    return val.get(dimension.value) if val is not None else None
 
 
 def set_dimension_context(dimension: Dimension, value: str) -> contextvars.Token:

--- a/gcsfs/telemetry/context.py
+++ b/gcsfs/telemetry/context.py
@@ -28,6 +28,11 @@ if hasattr(os, "register_at_fork"):
     os.register_at_fork(after_in_child=_reset_telemetry_in_child)
 
 
+def has_telemetry_context() -> bool:
+    """Check if telemetry context is active without dict allocations (O(1))."""
+    return bool(_current_telemetry.get())
+
+
 def get_telemetry_context() -> Dict[str, str]:
     """Retrieve active telemetry tokens mapping from context."""
     val = _current_telemetry.get()

--- a/gcsfs/telemetry/detectors/__init__.py
+++ b/gcsfs/telemetry/detectors/__init__.py
@@ -1,0 +1,8 @@
+"""Telemetry detectors package."""
+from gcsfs.telemetry.detectors.base import BaseDetector
+from gcsfs.telemetry.detectors.framework import FrameworkDetector
+
+__all__ = [
+    "BaseDetector",
+    "FrameworkDetector",
+]

--- a/gcsfs/telemetry/detectors/__init__.py
+++ b/gcsfs/telemetry/detectors/__init__.py
@@ -1,4 +1,5 @@
 """Telemetry detectors package."""
+
 from gcsfs.telemetry.detectors.base import BaseDetector
 from gcsfs.telemetry.detectors.framework import FrameworkDetector
 

--- a/gcsfs/telemetry/detectors/base.py
+++ b/gcsfs/telemetry/detectors/base.py
@@ -1,0 +1,30 @@
+"""Base class for telemetry detectors following gcsfs/fsspec conventions."""
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from gcsfs.telemetry.context import Dimension
+
+
+class BaseDetector:
+    """Base interface for extracting telemetry tokens."""
+
+    @property
+    def name(self) -> Dimension | str:
+        """Unique telemetry dimension identifier for this detector."""
+        raise NotImplementedError
+
+    def detect(self) -> Optional[str]:
+        """
+        Execute detection logic and return an RFC 9110 compliant telemetry token.
+
+        Returns
+        -------
+        Optional[str]: Formatted token string (e.g. 'fw/pandas') or None if not detected.
+        """
+        raise NotImplementedError
+
+    def is_enabled(self) -> bool:
+        """Check if telemetry opt-out environment variable is active."""
+        return os.environ.get("GCSFS_NO_TELEMETRY", "").lower() not in ("1", "true", "yes")

--- a/gcsfs/telemetry/detectors/base.py
+++ b/gcsfs/telemetry/detectors/base.py
@@ -1,4 +1,5 @@
 """Base class for telemetry detectors following gcsfs/fsspec conventions."""
+
 from __future__ import annotations
 
 import os
@@ -27,4 +28,8 @@ class BaseDetector:
 
     def is_enabled(self) -> bool:
         """Check if telemetry opt-out environment variable is active."""
-        return os.environ.get("GCSFS_NO_TELEMETRY", "").lower() not in ("1", "true", "yes")
+        return os.environ.get("GCSFS_NO_TELEMETRY", "").lower() not in (
+            "1",
+            "true",
+            "yes",
+        )

--- a/gcsfs/telemetry/detectors/framework.py
+++ b/gcsfs/telemetry/detectors/framework.py
@@ -70,16 +70,19 @@ class FrameworkDetector(BaseDetector):
         depth = 0
 
         while frame is not None and depth < self.max_depth:
-            # If any frame has a file instance with cached _caller_framework, use it immediately
-            try:
-                f_locals = getattr(frame, "f_locals", None)
-                if f_locals is not None:
-                    instance = f_locals.get("self")
-                    cached_fw = getattr(instance, "_caller_framework", None)
-                    if isinstance(cached_fw, str) and cached_fw:
-                        return cached_fw
-            except Exception:
-                pass
+            f_globals = getattr(frame, "f_globals", None) or {}
+            mod_name = f_globals.get("__name__", "")
+            if mod_name.startswith("gcsfs"):
+                # If any gcsfs frame has a file instance with cached _caller_framework, use it immediately
+                try:
+                    f_locals = getattr(frame, "f_locals", None)
+                    if f_locals is not None:
+                        instance = f_locals.get("self")
+                        cached_fw = getattr(instance, "_caller_framework", None)
+                        if isinstance(cached_fw, str) and cached_fw:
+                            return cached_fw
+                except Exception:
+                    pass
 
             frames.append(frame)
             frame = frame.f_back

--- a/gcsfs/telemetry/detectors/framework.py
+++ b/gcsfs/telemetry/detectors/framework.py
@@ -1,0 +1,100 @@
+"""Top-to-bottom stack frame detector for upstream caller frameworks (name-only)."""
+from __future__ import annotations
+
+import sys
+from typing import Dict, Optional
+
+from gcsfs.telemetry.context import Dimension
+from gcsfs.telemetry.detectors.base import BaseDetector
+from gcsfs.telemetry.sanitizer import sanitize_framework
+
+
+class FrameworkDetector(BaseDetector):
+    """
+    Detects the top-most initiating framework name on the call stack.
+
+    Traverses frames from outermost (closest to __main__) down to innermost (gcsfs)
+    to attribute high-level orchestrators (e.g., Dask, Ray) over lower-level serialization layers (PyArrow).
+    """
+
+    # Canonical mapping of top-level package name -> standard brand token
+    KNOWN_FRAMEWORKS: Dict[str, str] = {
+        # Data & Analytics
+        "pandas": "pandas",
+        "duckdb": "duckdb",
+        "pyspark": "spark",
+        "dask": "dask",
+        "ray": "ray",
+        "pyarrow": "pyarrow",
+        "xarray": "xarray",
+        "fastparquet": "fastparquet",
+        # ML & Deep Learning
+        "torch": "torch",
+        "torchdata": "torchdata",
+        "lightning": "lightning",
+        "pytorch_lightning": "lightning",
+        "datasets": "datasets",
+        "transformers": "transformers",
+        "orbax": "orbax",
+        "tensorstore": "tensorstore",
+        "tensorflow": "tensorflow",
+        "jax": "jax",
+    }
+
+    def __init__(self, max_depth: int = 64):
+        self.max_depth = max_depth
+
+    @property
+    def name(self) -> Dimension:
+        return Dimension.FRAMEWORK
+
+    def detect(self) -> Optional[str]:
+        if not self.is_enabled():
+            return None
+
+        try:
+            start_frame = sys._getframe()
+        except (ValueError, AttributeError):
+            return None
+
+        return self._walk_top_down(start_frame)
+
+    def _walk_top_down(self, start_frame) -> Optional[str]:
+        """
+        Traverses the frame chain from top (outermost / root) to bottom (innermost / gcsfs).
+        Returns the first recognized framework encountered from the top.
+        """
+        frames = []
+        frame = start_frame
+        depth = 0
+
+        while frame is not None and depth < self.max_depth:
+            # If any frame has a file instance with cached _caller_framework, use it immediately
+            try:
+                f_locals = getattr(frame, "f_locals", None)
+                if f_locals is not None:
+                    instance = f_locals.get("self")
+                    cached_fw = getattr(instance, "_caller_framework", None)
+                    if isinstance(cached_fw, str) and cached_fw:
+                        return cached_fw
+            except Exception:
+                pass
+
+            frames.append(frame)
+            frame = frame.f_back
+            depth += 1
+
+        # Scan in call order (outermost root -> innermost) to match the initiating framework first
+        for f in reversed(frames):
+            mod_name = f.f_globals.get("__name__")
+            if not mod_name:
+                continue
+
+            top_pkg = mod_name.partition(".")[0]
+            if top_pkg in self.KNOWN_FRAMEWORKS:
+                framework_name = self.KNOWN_FRAMEWORKS[top_pkg]
+                clean_name = sanitize_framework(framework_name)
+                if clean_name:
+                    return f"fw/{clean_name}"
+
+        return None

--- a/gcsfs/telemetry/detectors/framework.py
+++ b/gcsfs/telemetry/detectors/framework.py
@@ -65,7 +65,7 @@ class FrameworkDetector(BaseDetector):
         Traverses the frame chain from top (outermost / root) to bottom (innermost / gcsfs).
         Returns the first recognized framework encountered from the top.
         """
-        frames = []
+        module_names = []
         frame = start_frame
         depth = 0
 
@@ -84,16 +84,13 @@ class FrameworkDetector(BaseDetector):
                 except Exception:
                     pass
 
-            frames.append(frame)
+            if mod_name:
+                module_names.append(mod_name)
             frame = frame.f_back
             depth += 1
 
         # Scan in call order (outermost root -> innermost) to match the initiating framework first
-        for f in reversed(frames):
-            mod_name = f.f_globals.get("__name__")
-            if not mod_name:
-                continue
-
+        for mod_name in reversed(module_names):
             top_pkg = mod_name.partition(".")[0]
             if top_pkg in self.KNOWN_FRAMEWORKS:
                 framework_name = self.KNOWN_FRAMEWORKS[top_pkg]

--- a/gcsfs/telemetry/detectors/framework.py
+++ b/gcsfs/telemetry/detectors/framework.py
@@ -1,4 +1,5 @@
 """Top-to-bottom stack frame detector for upstream caller frameworks (name-only)."""
+
 from __future__ import annotations
 
 import sys

--- a/gcsfs/telemetry/detectors/framework.py
+++ b/gcsfs/telemetry/detectors/framework.py
@@ -73,18 +73,6 @@ class FrameworkDetector(BaseDetector):
         while frame is not None and depth < self.max_depth:
             f_globals = getattr(frame, "f_globals", None) or {}
             mod_name = f_globals.get("__name__", "")
-            if mod_name.startswith("gcsfs"):
-                # If any gcsfs frame has a file instance with cached caller_framework, use it immediately
-                try:
-                    f_locals = getattr(frame, "f_locals", None)
-                    if f_locals is not None:
-                        instance = f_locals.get("self")
-                        cached_fw = getattr(instance, "caller_framework", None)
-                        if isinstance(cached_fw, str) and cached_fw:
-                            return cached_fw
-                except Exception:
-                    pass
-
             if mod_name:
                 module_names.append(mod_name)
             frame = frame.f_back

--- a/gcsfs/telemetry/detectors/framework.py
+++ b/gcsfs/telemetry/detectors/framework.py
@@ -56,7 +56,7 @@ class FrameworkDetector(BaseDetector):
 
         try:
             start_frame = sys._getframe()
-        except (ValueError, AttributeError):
+        except (ValueError, AttributeError, RuntimeError, PermissionError):
             return None
 
         return self._walk_top_down(start_frame)

--- a/gcsfs/telemetry/detectors/framework.py
+++ b/gcsfs/telemetry/detectors/framework.py
@@ -29,6 +29,7 @@ class FrameworkDetector(BaseDetector):
         "pyarrow": "pyarrow",
         "xarray": "xarray",
         "fastparquet": "fastparquet",
+        "polars": "polars",
         # ML & Deep Learning
         "torch": "torch",
         "torchdata": "torchdata",
@@ -73,12 +74,12 @@ class FrameworkDetector(BaseDetector):
             f_globals = getattr(frame, "f_globals", None) or {}
             mod_name = f_globals.get("__name__", "")
             if mod_name.startswith("gcsfs"):
-                # If any gcsfs frame has a file instance with cached _caller_framework, use it immediately
+                # If any gcsfs frame has a file instance with cached caller_framework, use it immediately
                 try:
                     f_locals = getattr(frame, "f_locals", None)
                     if f_locals is not None:
                         instance = f_locals.get("self")
-                        cached_fw = getattr(instance, "_caller_framework", None)
+                        cached_fw = getattr(instance, "caller_framework", None)
                         if isinstance(cached_fw, str) and cached_fw:
                             return cached_fw
                 except Exception:

--- a/gcsfs/telemetry/manager.py
+++ b/gcsfs/telemetry/manager.py
@@ -1,14 +1,12 @@
 """Central Telemetry Coordinator managing detectors and context propagation."""
+
 from __future__ import annotations
 
 import functools
 import inspect
 from typing import Any, Callable, Dict, List, Optional
 
-from gcsfs.telemetry.context import (
-    Dimension,
-    get_telemetry_context,
-)
+from gcsfs.telemetry.context import Dimension, get_telemetry_context
 from gcsfs.telemetry.detectors.base import BaseDetector
 from gcsfs.telemetry.detectors.framework import FrameworkDetector
 
@@ -18,6 +16,7 @@ def _gcs_sync_wrapper(func: Callable, obj: Any = None) -> Callable:
     GCS-specific sync wrapper that captures caller thread telemetry
     and bridges it into the background asyncio loop thread via self._sync.
     """
+
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         self = obj or (args[0] if args else None)
@@ -25,6 +24,7 @@ def _gcs_sync_wrapper(func: Callable, obj: Any = None) -> Callable:
             return self._sync(func, *args, **kwargs)
         # Fallback if unbound
         import fsspec.asyn
+
         return fsspec.asyn.sync(self.loop, func, *args, **kwargs)
 
     return wrapper
@@ -35,6 +35,7 @@ def _gcs_async_gen_wrapper(func: Callable, obj: Any = None) -> Callable:
     GCS-specific async generator wrapper that routes each generator yield
     through self._sync to capture caller thread telemetry context.
     """
+
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         self = obj or (args[0] if args else None)
@@ -45,6 +46,7 @@ def _gcs_async_gen_wrapper(func: Callable, obj: Any = None) -> Callable:
                     yield self._sync(gen.__anext__)
                 else:
                     import fsspec.asyn
+
                     yield fsspec.asyn.sync(self.loop, gen.__anext__)
             except StopAsyncIteration:
                 break
@@ -58,7 +60,8 @@ def mirror_gcs_sync_methods(obj: Any) -> None:
     Uses __dict__ across AsyncFileSystem, GCSFileSystem, and the concrete type
     to find all async coroutines and async generators, avoiding object inspection.
     """
-    from fsspec.asyn import async_methods, AsyncFileSystem
+    from fsspec.asyn import AsyncFileSystem, async_methods
+
     from gcsfs.core import GCSFileSystem
 
     # Collect coroutine and async generator method names strictly from target class dictionaries
@@ -68,17 +71,25 @@ def mirror_gcs_sync_methods(obj: Any) -> None:
     for cls in target_classes:
         for name in cls.__dict__:
             # Only pick private methods that are NOT dunders (e.g. '_ls', '_cat_file', '_info')
-            if name.startswith("_") and not (name.startswith("__") and name.endswith("__")):
+            if name.startswith("_") and not (
+                name.startswith("__") and name.endswith("__")
+            ):
                 method_names.add(name)
 
     # Bind the sync wrapper only for valid public methods
     from fsspec.spec import AbstractFileSystem
 
     for method in method_names:
-        smethod = method[1:]  # e.g., "_ls" -> "ls", "_cat_file" -> "cat_file", "_walk" -> "walk"
+        smethod = method[
+            1:
+        ]  # e.g., "_ls" -> "ls", "_cat_file" -> "cat_file", "_walk" -> "walk"
 
         # Only mirror if smethod is a valid public method (in AbstractFileSystem, async_methods, or the class)
-        if not (hasattr(AbstractFileSystem, smethod) or method in async_methods or hasattr(type(obj), smethod)):
+        if not (
+            hasattr(AbstractFileSystem, smethod)
+            or method in async_methods
+            or hasattr(type(obj), smethod)
+        ):
             continue
 
         async_fn = getattr(obj, method, None)
@@ -101,7 +112,9 @@ class UsageMetricsTracker:
     """Coordinates multi-dimensional detectors and context propagation."""
 
     def __init__(self, detectors: Optional[List[BaseDetector]] = None):
-        self.detectors: List[BaseDetector] = list(detectors) if detectors is not None else []
+        self.detectors: List[BaseDetector] = (
+            list(detectors) if detectors is not None else []
+        )
 
     def register_detector(self, detector: BaseDetector) -> None:
         """Register a new detector for a telemetry dimension (e.g. env, op)."""
@@ -154,6 +167,8 @@ class UsageMetricsTracker:
 
 
 # Default singleton instance pre-configured with standard framework detector
-default_usage_tracker = UsageMetricsTracker(detectors=[
-    FrameworkDetector(),
-])
+default_usage_tracker = UsageMetricsTracker(
+    detectors=[
+        FrameworkDetector(),
+    ]
+)

--- a/gcsfs/telemetry/manager.py
+++ b/gcsfs/telemetry/manager.py
@@ -6,10 +6,40 @@ import functools
 import inspect
 from typing import Any, Callable, Dict, List, Optional
 
-from gcsfs.telemetry.context import Dimension, get_telemetry_context
+from gcsfs.telemetry.context import (
+    Dimension,
+    get_telemetry_context,
+    reset_telemetry_context,
+    set_telemetry_context,
+)
 from gcsfs.telemetry.detectors.base import BaseDetector
 from gcsfs.telemetry.detectors.framework import FrameworkDetector
 from gcsfs.telemetry.sanitizer import sanitize_token
+
+
+def _gcs_async_wrapper(func: Callable, obj: Any = None) -> Callable:
+    """
+    GCS-specific async wrapper that scopes telemetry context during native async execution,
+    avoiding repetitive stack-walking across internal coroutines or chunk fetches.
+    """
+    if getattr(func, "_is_gcs_async_wrapped", False):
+        return func
+
+    @functools.wraps(func)
+    async def wrapper(*args, **kwargs):
+        # Fast path: If telemetry context is already active (e.g. nested call or _sync), pass through in O(1)
+        if get_telemetry_context():
+            return await func(*args, **kwargs)
+
+        tokens_map = default_usage_tracker.collect_tokens_map()
+        token = set_telemetry_context(tokens_map)
+        try:
+            return await func(*args, **kwargs)
+        finally:
+            reset_telemetry_context(token)
+
+    wrapper._is_gcs_async_wrapped = True
+    return wrapper
 
 
 def _gcs_sync_wrapper(func: Callable, obj: Any = None) -> Callable:
@@ -17,6 +47,8 @@ def _gcs_sync_wrapper(func: Callable, obj: Any = None) -> Callable:
     GCS-specific sync wrapper that captures caller thread telemetry
     and bridges it into the background asyncio loop thread via self._sync.
     """
+    if getattr(func, "_is_gcs_sync_wrapped", False):
+        return func
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
@@ -28,6 +60,7 @@ def _gcs_sync_wrapper(func: Callable, obj: Any = None) -> Callable:
 
         return fsspec.asyn.sync(self.loop, func, *args, **kwargs)
 
+    wrapper._is_gcs_sync_wrapped = True
     return wrapper
 
 
@@ -36,6 +69,8 @@ def _gcs_async_gen_wrapper(func: Callable, obj: Any = None) -> Callable:
     GCS-specific async generator wrapper that routes each generator yield
     through self._sync to capture caller thread telemetry context.
     """
+    if getattr(func, "_is_gcs_gen_wrapped", False):
+        return func
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
@@ -61,12 +96,14 @@ def _gcs_async_gen_wrapper(func: Callable, obj: Any = None) -> Callable:
                 except Exception:
                     pass
 
+    wrapper._is_gcs_gen_wrapped = True
     return wrapper
 
 
-def mirror_gcs_sync_methods(obj: Any) -> None:
+def mirror_gcs_methods(obj: Any) -> None:
     """
-    Binds sync methods on a GCSFileSystem class or instance using _gcs_sync_wrapper.
+    Binds sync and native async methods on a GCSFileSystem class or instance using
+    telemetry-aware wrappers.
     Uses class __mro__ to find all async coroutines and async generators,
     avoiding eager property evaluation.
     """
@@ -91,7 +128,7 @@ def mirror_gcs_sync_methods(obj: Any) -> None:
                 ):
                     method_names.add(name)
 
-    # Bind the sync wrapper only for valid public methods
+    # Bind the wrappers for valid methods
     from fsspec.spec import AbstractFileSystem
 
     for method in method_names:
@@ -99,28 +136,35 @@ def mirror_gcs_sync_methods(obj: Any) -> None:
             1:
         ]  # e.g., "_ls" -> "ls", "_cat_file" -> "cat_file", "_walk" -> "walk"
 
-        # Only mirror if smethod is a valid public method (in AbstractFileSystem, async_methods, or the class)
-        if not (
+        async_fn = getattr(obj, method, None)
+        mth = None
+
+        if inspect.iscoroutinefunction(async_fn):
+            # Wrap native async method for scoped context in native async mode
+            wrapped_async = _gcs_async_wrapper(
+                async_fn, obj=None if is_class else obj
+            )
+            setattr(obj, method, wrapped_async)
+            mth = _gcs_sync_wrapper(async_fn, obj=None if is_class else obj)
+
+        elif inspect.isasyncgenfunction(async_fn):
+            mth = _gcs_async_gen_wrapper(async_fn, obj=None if is_class else obj)
+
+        # Only mirror sync method if smethod is a valid public method
+        if mth is not None and (
             hasattr(AbstractFileSystem, smethod)
             or method in async_methods
             or hasattr(target_type, smethod)
         ):
-            continue
+            if not getattr(mth, "__doc__", None):
+                mth.__doc__ = getattr(
+                    getattr(AbstractFileSystem, smethod, None), "__doc__", ""
+                )
+            setattr(obj, smethod, mth)
 
-        async_fn = getattr(obj, method, None)
-        if inspect.iscoroutinefunction(async_fn):
-            mth = _gcs_sync_wrapper(async_fn, obj=None if is_class else obj)
-        elif inspect.isasyncgenfunction(async_fn):
-            mth = _gcs_async_gen_wrapper(async_fn, obj=None if is_class else obj)
-        else:
-            continue
 
-        if not getattr(mth, "__doc__", None):
-            mth.__doc__ = getattr(
-                getattr(AbstractFileSystem, smethod, None), "__doc__", ""
-            )
-
-        setattr(obj, smethod, mth)
+# Alias for backward compatibility
+mirror_gcs_sync_methods = mirror_gcs_methods
 
 
 class UsageMetricsTracker:

--- a/gcsfs/telemetry/manager.py
+++ b/gcsfs/telemetry/manager.py
@@ -141,9 +141,7 @@ def mirror_gcs_methods(obj: Any) -> None:
 
         if inspect.iscoroutinefunction(async_fn):
             # Wrap native async method for scoped context in native async mode
-            wrapped_async = _gcs_async_wrapper(
-                async_fn, obj=None if is_class else obj
-            )
+            wrapped_async = _gcs_async_wrapper(async_fn, obj=None if is_class else obj)
             setattr(obj, method, wrapped_async)
             mth = _gcs_sync_wrapper(async_fn, obj=None if is_class else obj)
 

--- a/gcsfs/telemetry/manager.py
+++ b/gcsfs/telemetry/manager.py
@@ -57,16 +57,19 @@ def _gcs_async_gen_wrapper(func: Callable, obj: Any = None) -> Callable:
 
 def mirror_gcs_sync_methods(obj: Any) -> None:
     """
-    Binds sync methods on a GCSFileSystem instance using _gcs_sync_wrapper.
+    Binds sync methods on a GCSFileSystem class or instance using _gcs_sync_wrapper.
     Uses class __mro__ to find all async coroutines and async generators,
     avoiding eager property evaluation.
     """
     from fsspec.asyn import async_methods
 
+    is_class = isinstance(obj, type)
+    target_type = obj if is_class else type(obj)
+
     # Collect coroutine and async generator method names strictly from class dictionaries in MRO
     method_names = set(async_methods)
 
-    for cls in type(obj).__mro__:
+    for cls in target_type.__mro__:
         if cls is object:
             continue
         for name, attr in cls.__dict__.items():
@@ -91,15 +94,15 @@ def mirror_gcs_sync_methods(obj: Any) -> None:
         if not (
             hasattr(AbstractFileSystem, smethod)
             or method in async_methods
-            or hasattr(type(obj), smethod)
+            or hasattr(target_type, smethod)
         ):
             continue
 
         async_fn = getattr(obj, method, None)
         if inspect.iscoroutinefunction(async_fn):
-            mth = _gcs_sync_wrapper(async_fn, obj=obj)
+            mth = _gcs_sync_wrapper(async_fn, obj=None if is_class else obj)
         elif inspect.isasyncgenfunction(async_fn):
-            mth = _gcs_async_gen_wrapper(async_fn, obj=obj)
+            mth = _gcs_async_gen_wrapper(async_fn, obj=None if is_class else obj)
         else:
             continue
 

--- a/gcsfs/telemetry/manager.py
+++ b/gcsfs/telemetry/manager.py
@@ -140,9 +140,10 @@ def mirror_gcs_methods(obj: Any) -> None:
         mth = None
 
         if inspect.iscoroutinefunction(async_fn):
-            # Wrap native async method for scoped context in native async mode
-            wrapped_async = _gcs_async_wrapper(async_fn, obj=None if is_class else obj)
-            setattr(obj, method, wrapped_async)
+            # Only wrap private async methods defined directly on this class to preserve inheritance
+            if is_class and method in target_type.__dict__:
+                wrapped_async = _gcs_async_wrapper(async_fn)
+                setattr(obj, method, wrapped_async)
             mth = _gcs_sync_wrapper(async_fn, obj=None if is_class else obj)
 
         elif inspect.isasyncgenfunction(async_fn):

--- a/gcsfs/telemetry/manager.py
+++ b/gcsfs/telemetry/manager.py
@@ -1,0 +1,159 @@
+"""Central Telemetry Coordinator managing detectors and context propagation."""
+from __future__ import annotations
+
+import functools
+import inspect
+from typing import Any, Callable, Dict, List, Optional
+
+from gcsfs.telemetry.context import (
+    Dimension,
+    get_telemetry_context,
+)
+from gcsfs.telemetry.detectors.base import BaseDetector
+from gcsfs.telemetry.detectors.framework import FrameworkDetector
+
+
+def _gcs_sync_wrapper(func: Callable, obj: Any = None) -> Callable:
+    """
+    GCS-specific sync wrapper that captures caller thread telemetry
+    and bridges it into the background asyncio loop thread via self._sync.
+    """
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        self = obj or (args[0] if args else None)
+        if self is not None and hasattr(self, "_sync"):
+            return self._sync(func, *args, **kwargs)
+        # Fallback if unbound
+        import fsspec.asyn
+        return fsspec.asyn.sync(self.loop, func, *args, **kwargs)
+
+    return wrapper
+
+
+def _gcs_async_gen_wrapper(func: Callable, obj: Any = None) -> Callable:
+    """
+    GCS-specific async generator wrapper that routes each generator yield
+    through self._sync to capture caller thread telemetry context.
+    """
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        self = obj or (args[0] if args else None)
+        gen = func(*args, **kwargs)
+        while True:
+            try:
+                if self is not None and hasattr(self, "_sync"):
+                    yield self._sync(gen.__anext__)
+                else:
+                    import fsspec.asyn
+                    yield fsspec.asyn.sync(self.loop, gen.__anext__)
+            except StopAsyncIteration:
+                break
+
+    return wrapper
+
+
+def mirror_gcs_sync_methods(obj: Any) -> None:
+    """
+    Binds sync methods on a GCSFileSystem instance using _gcs_sync_wrapper.
+    Uses __dict__ across AsyncFileSystem, GCSFileSystem, and the concrete type
+    to find all async coroutines and async generators, avoiding object inspection.
+    """
+    from fsspec.asyn import async_methods, AsyncFileSystem
+    from gcsfs.core import GCSFileSystem
+
+    # Collect coroutine and async generator method names strictly from target class dictionaries
+    target_classes = [AsyncFileSystem, GCSFileSystem, type(obj)]
+    method_names = set(async_methods + ["_call"])
+
+    for cls in target_classes:
+        for name in cls.__dict__:
+            # Only pick private methods that are NOT dunders (e.g. '_ls', '_cat_file', '_info')
+            if name.startswith("_") and not (name.startswith("__") and name.endswith("__")):
+                method_names.add(name)
+
+    # Bind the sync wrapper only for valid public methods
+    from fsspec.spec import AbstractFileSystem
+
+    for method in method_names:
+        smethod = method[1:]  # e.g., "_ls" -> "ls", "_cat_file" -> "cat_file", "_walk" -> "walk"
+
+        # Only mirror if smethod is a valid public method (in AbstractFileSystem, async_methods, or the class)
+        if not (hasattr(AbstractFileSystem, smethod) or method in async_methods or hasattr(type(obj), smethod)):
+            continue
+
+        async_fn = getattr(obj, method, None)
+        if inspect.iscoroutinefunction(async_fn):
+            mth = _gcs_sync_wrapper(async_fn, obj=obj)
+        elif inspect.isasyncgenfunction(async_fn):
+            mth = _gcs_async_gen_wrapper(async_fn, obj=obj)
+        else:
+            continue
+
+        if not getattr(mth, "__doc__", None):
+            mth.__doc__ = getattr(
+                getattr(AbstractFileSystem, smethod, None), "__doc__", ""
+            )
+
+        setattr(obj, smethod, mth)
+
+
+class UsageMetricsTracker:
+    """Coordinates multi-dimensional detectors and context propagation."""
+
+    def __init__(self, detectors: Optional[List[BaseDetector]] = None):
+        self.detectors: List[BaseDetector] = list(detectors) if detectors is not None else []
+
+    def register_detector(self, detector: BaseDetector) -> None:
+        """Register a new detector for a telemetry dimension (e.g. env, op)."""
+        self.detectors.append(detector)
+
+    def collect_tokens_map(self) -> Dict[str, str]:
+        """
+        Collect active telemetry tokens across all registered detectors.
+
+        Returns
+        -------
+        Dict[str, str]: Mapping of dimension name to formatted token string.
+        """
+        tokens = get_telemetry_context()
+
+        # Run registered detectors for any dimensions not already set
+        for detector in self.detectors:
+            dim_key = (
+                detector.name.value
+                if isinstance(detector.name, Dimension)
+                else str(detector.name)
+            )
+            if detector.is_enabled() and dim_key not in tokens:
+                try:
+                    detected_val = detector.detect()
+                    if detected_val:
+                        tokens[dim_key] = detected_val
+                except Exception:
+                    pass
+
+        return tokens
+
+    def get_tokens(self) -> List[str]:
+        """
+        Return a list of all active telemetry tokens to be included in HTTP User-Agent.
+
+        Returns
+        -------
+        List[str]: List of formatted token strings, e.g. ['fw/pandas', 'env/gke'].
+        """
+        token_map = self.collect_tokens_map()
+        return list(token_map.values())
+
+    def get_dimension(self, dimension: Dimension) -> Optional[str]:
+        """
+        Resolve a specific dimension token (e.g. Dimension.FRAMEWORK).
+        """
+        token_map = self.collect_tokens_map()
+        return token_map.get(dimension.value)
+
+
+# Default singleton instance pre-configured with standard framework detector
+default_usage_tracker = UsageMetricsTracker(detectors=[
+    FrameworkDetector(),
+])

--- a/gcsfs/telemetry/manager.py
+++ b/gcsfs/telemetry/manager.py
@@ -65,16 +65,19 @@ def mirror_gcs_sync_methods(obj: Any) -> None:
     from gcsfs.core import GCSFileSystem
 
     # Collect coroutine and async generator method names strictly from target class dictionaries
-    target_classes = [AsyncFileSystem, GCSFileSystem, type(obj)]
+    target_classes = {AsyncFileSystem, GCSFileSystem, type(obj)}
     method_names = set(async_methods + ["_call"])
 
     for cls in target_classes:
-        for name in cls.__dict__:
+        for name, attr in cls.__dict__.items():
             # Only pick private methods that are NOT dunders (e.g. '_ls', '_cat_file', '_info')
             if name.startswith("_") and not (
                 name.startswith("__") and name.endswith("__")
             ):
-                method_names.add(name)
+                if inspect.iscoroutinefunction(attr) or inspect.isasyncgenfunction(
+                    attr
+                ):
+                    method_names.add(name)
 
     # Bind the sync wrapper only for valid public methods
     from fsspec.spec import AbstractFileSystem

--- a/gcsfs/telemetry/manager.py
+++ b/gcsfs/telemetry/manager.py
@@ -9,6 +9,7 @@ from typing import Any, Callable, Dict, List, Optional
 from gcsfs.telemetry.context import Dimension, get_telemetry_context
 from gcsfs.telemetry.detectors.base import BaseDetector
 from gcsfs.telemetry.detectors.framework import FrameworkDetector
+from gcsfs.telemetry.sanitizer import sanitize_token
 
 
 def _gcs_sync_wrapper(func: Callable, obj: Any = None) -> Callable:
@@ -158,14 +159,19 @@ class UsageMetricsTracker:
         List[str]: List of formatted token strings, e.g. ['fw/pandas', 'env/gke'].
         """
         token_map = self.collect_tokens_map()
-        return list(token_map.values())
+        sanitized_tokens = []
+        for token in token_map.values():
+            clean = sanitize_token(token)
+            if clean:
+                sanitized_tokens.append(clean)
+        return sanitized_tokens
 
     def get_dimension(self, dimension: Dimension) -> Optional[str]:
         """
         Resolve a specific dimension token (e.g. Dimension.FRAMEWORK).
         """
         token_map = self.collect_tokens_map()
-        return token_map.get(dimension.value)
+        return sanitize_token(token_map.get(dimension.value))
 
 
 # Default singleton instance pre-configured with standard framework detector

--- a/gcsfs/telemetry/manager.py
+++ b/gcsfs/telemetry/manager.py
@@ -41,16 +41,25 @@ def _gcs_async_gen_wrapper(func: Callable, obj: Any = None) -> Callable:
     def wrapper(*args, **kwargs):
         self = obj or args[0]
         gen = func(*args, **kwargs)
-        while True:
-            try:
-                if hasattr(self, "_sync"):
-                    yield self._sync(gen.__anext__)
-                else:
+        try:
+            while True:
+                try:
+                    if hasattr(self, "_sync"):
+                        yield self._sync(gen.__anext__)
+                    else:
+                        import fsspec.asyn
+
+                        yield fsspec.asyn.sync(self.loop, gen.__anext__)
+                except StopAsyncIteration:
+                    break
+        finally:
+            if hasattr(gen, "aclose"):
+                try:
                     import fsspec.asyn
 
-                    yield fsspec.asyn.sync(self.loop, gen.__anext__)
-            except StopAsyncIteration:
-                break
+                    fsspec.asyn.sync(self.loop, gen.aclose)
+                except Exception:
+                    pass
 
     return wrapper
 
@@ -146,8 +155,7 @@ class UsageMetricsTracker:
             if detector.is_enabled() and dim_key not in tokens:
                 try:
                     detected_val = detector.detect()
-                    if detected_val:
-                        tokens[dim_key] = detected_val
+                    tokens[dim_key] = detected_val or ""
                 except Exception:
                     pass
 

--- a/gcsfs/telemetry/manager.py
+++ b/gcsfs/telemetry/manager.py
@@ -57,18 +57,17 @@ def _gcs_async_gen_wrapper(func: Callable, obj: Any = None) -> Callable:
 def mirror_gcs_sync_methods(obj: Any) -> None:
     """
     Binds sync methods on a GCSFileSystem instance using _gcs_sync_wrapper.
-    Uses __dict__ across AsyncFileSystem, GCSFileSystem, and the concrete type
-    to find all async coroutines and async generators, avoiding object inspection.
+    Uses class __mro__ to find all async coroutines and async generators,
+    avoiding eager property evaluation.
     """
-    from fsspec.asyn import AsyncFileSystem, async_methods
+    from fsspec.asyn import async_methods
 
-    from gcsfs.core import GCSFileSystem
+    # Collect coroutine and async generator method names strictly from class dictionaries in MRO
+    method_names = set(async_methods)
 
-    # Collect coroutine and async generator method names strictly from target class dictionaries
-    target_classes = {AsyncFileSystem, GCSFileSystem, type(obj)}
-    method_names = set(async_methods + ["_call"])
-
-    for cls in target_classes:
+    for cls in type(obj).__mro__:
+        if cls is object:
+            continue
         for name, attr in cls.__dict__.items():
             # Only pick private methods that are NOT dunders (e.g. '_ls', '_cat_file', '_info')
             if name.startswith("_") and not (

--- a/gcsfs/telemetry/manager.py
+++ b/gcsfs/telemetry/manager.py
@@ -19,8 +19,8 @@ def _gcs_sync_wrapper(func: Callable, obj: Any = None) -> Callable:
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        self = obj or (args[0] if args else None)
-        if self is not None and hasattr(self, "_sync"):
+        self = obj or args[0]
+        if hasattr(self, "_sync"):
             return self._sync(func, *args, **kwargs)
         # Fallback if unbound
         import fsspec.asyn
@@ -38,11 +38,11 @@ def _gcs_async_gen_wrapper(func: Callable, obj: Any = None) -> Callable:
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        self = obj or (args[0] if args else None)
+        self = obj or args[0]
         gen = func(*args, **kwargs)
         while True:
             try:
-                if self is not None and hasattr(self, "_sync"):
+                if hasattr(self, "_sync"):
                     yield self._sync(gen.__anext__)
                 else:
                     import fsspec.asyn

--- a/gcsfs/telemetry/manager.py
+++ b/gcsfs/telemetry/manager.py
@@ -119,32 +119,80 @@ def _setup_file_telemetry(file_obj) -> Optional[Any]:
     return set_telemetry_context(tokens_map)
 
 
+import contextlib
+
+
+@contextlib.contextmanager
+def _file_telemetry_context(file_obj):
+    """Context manager to safely handle file telemetry token setup and teardown."""
+    token = _setup_file_telemetry(file_obj)
+    try:
+        yield
+    finally:
+        if token is not None:
+            from gcsfs.telemetry.context import reset_telemetry_context
+
+            reset_telemetry_context(token)
+
+
+def _file_async_gen_wrapper(func):
+    @functools.wraps(func)
+    async def wrapper(self, *args, **kwargs):
+        gen = func(self, *args, **kwargs)
+        while True:
+            with _file_telemetry_context(self):
+                try:
+                    item = await gen.__anext__()
+                except StopAsyncIteration:
+                    break
+            yield item
+
+    return wrapper
+
+
+def _file_sync_gen_wrapper(func):
+    @functools.wraps(func)
+    def wrapper(self, *args, **kwargs):
+        gen = func(self, *args, **kwargs)
+        while True:
+            with _file_telemetry_context(self):
+                try:
+                    item = next(gen)
+                except StopIteration:
+                    break
+            yield item
+
+    return wrapper
+
+
+def _file_async_wrapper(func):
+    @functools.wraps(func)
+    async def wrapper(self, *args, **kwargs):
+        with _file_telemetry_context(self):
+            return await func(self, *args, **kwargs)
+
+    return wrapper
+
+
+def _file_sync_wrapper(func):
+    @functools.wraps(func)
+    def wrapper(self, *args, **kwargs):
+        with _file_telemetry_context(self):
+            return func(self, *args, **kwargs)
+
+    return wrapper
+
+
 def _file_telemetry_wrapper(func):
-    is_async = inspect.iscoroutinefunction(func)
-
-    @functools.wraps(func)
-    def sync_wrapper(self, *args, **kwargs):
-        token = _setup_file_telemetry(self)
-        if token is None:
-            return func(self, *args, **kwargs)
-
-        try:
-            return func(self, *args, **kwargs)
-        finally:
-            reset_telemetry_context(token)
-
-    @functools.wraps(func)
-    async def async_wrapper(self, *args, **kwargs):
-        token = _setup_file_telemetry(self)
-        if token is None:
-            return await func(self, *args, **kwargs)
-
-        try:
-            return await func(self, *args, **kwargs)
-        finally:
-            reset_telemetry_context(token)
-
-    return async_wrapper if is_async else sync_wrapper
+    """Routes a GCSFile method to the correct telemetry wrapper based on its type."""
+    if inspect.isasyncgenfunction(func):
+        return _file_async_gen_wrapper(func)
+    elif inspect.isgeneratorfunction(func):
+        return _file_sync_gen_wrapper(func)
+    elif inspect.iscoroutinefunction(func):
+        return _file_async_wrapper(func)
+    else:
+        return _file_sync_wrapper(func)
 
 
 def wrap_file_methods():

--- a/gcsfs/telemetry/manager.py
+++ b/gcsfs/telemetry/manager.py
@@ -103,10 +103,16 @@ def _gcs_async_gen_wrapper(func: Callable, obj: Any = None) -> Callable:
 def _setup_file_telemetry(file_obj) -> Optional[Any]:
     fw = getattr(file_obj, "caller_framework", None)
 
-    from gcsfs.telemetry.context import has_telemetry_context
-
-    if has_telemetry_context() or not fw:
+    if not isinstance(fw, str):
         return None
+
+    from gcsfs.telemetry.context import Dimension, get_dimension_context
+
+    # O(1) zero-allocation fast path check
+    if get_dimension_context(Dimension.FRAMEWORK) == fw:
+        return None
+
+    from gcsfs.telemetry.context import get_telemetry_context, set_telemetry_context
 
     tokens_map = get_telemetry_context()
     tokens_map[Dimension.FRAMEWORK.value] = fw

--- a/gcsfs/telemetry/manager.py
+++ b/gcsfs/telemetry/manager.py
@@ -100,6 +100,58 @@ def _gcs_async_gen_wrapper(func: Callable, obj: Any = None) -> Callable:
     return wrapper
 
 
+def _setup_file_telemetry(file_obj) -> Optional[Any]:
+    fw = getattr(file_obj, "caller_framework", None)
+
+    from gcsfs.telemetry.context import has_telemetry_context
+
+    if has_telemetry_context() or not fw:
+        return None
+
+    tokens_map = get_telemetry_context()
+    tokens_map[Dimension.FRAMEWORK.value] = fw
+    return set_telemetry_context(tokens_map)
+
+
+def _file_telemetry_wrapper(func):
+    is_async = inspect.iscoroutinefunction(func)
+
+    @functools.wraps(func)
+    def sync_wrapper(self, *args, **kwargs):
+        token = _setup_file_telemetry(self)
+        if token is None:
+            return func(self, *args, **kwargs)
+
+        try:
+            return func(self, *args, **kwargs)
+        finally:
+            reset_telemetry_context(token)
+
+    @functools.wraps(func)
+    async def async_wrapper(self, *args, **kwargs):
+        token = _setup_file_telemetry(self)
+        if token is None:
+            return await func(self, *args, **kwargs)
+
+        try:
+            return await func(self, *args, **kwargs)
+        finally:
+            reset_telemetry_context(token)
+
+    return async_wrapper if is_async else sync_wrapper
+
+
+def wrap_file_methods():
+    from gcsfs.core import GCSFile
+
+    for name, attr in list(GCSFile.__dict__.items()):
+        if not name.startswith("__") and callable(attr):
+            if not getattr(attr, "_is_telemetry_wrapped", False):
+                wrapped = _file_telemetry_wrapper(attr)
+                wrapped._is_telemetry_wrapped = True
+                setattr(GCSFile, name, wrapped)
+
+
 def mirror_gcs_methods(obj: Any) -> None:
     """
     Binds sync and native async methods on a GCSFileSystem class or instance using
@@ -160,10 +212,6 @@ def mirror_gcs_methods(obj: Any) -> None:
                     getattr(AbstractFileSystem, smethod, None), "__doc__", ""
                 )
             setattr(obj, smethod, mth)
-
-
-# Alias for backward compatibility
-mirror_gcs_sync_methods = mirror_gcs_methods
 
 
 class UsageMetricsTracker:

--- a/gcsfs/telemetry/manager.py
+++ b/gcsfs/telemetry/manager.py
@@ -200,7 +200,7 @@ class UsageMetricsTracker:
                     detected_val = detector.detect()
                     tokens[dim_key] = detected_val or ""
                 except Exception:
-                    pass
+                    tokens[dim_key] = ""
 
         return tokens
 

--- a/gcsfs/telemetry/sanitizer.py
+++ b/gcsfs/telemetry/sanitizer.py
@@ -1,0 +1,37 @@
+"""RFC 9110 compliant token sanitization helper."""
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+# Allowed characters in RFC 9110 product-version tokens: ASCII alphanumeric, '_', '.', '-'
+# Disallows delimiters including '/', ':', and whitespace.
+_TOKEN_SANITIZE_REGEX = re.compile(r"[^a-zA-Z0-9_.-]")
+
+
+def sanitize_framework(value: Optional[str], max_len: int = 64) -> str:
+    """
+    Sanitize framework string to comply with RFC 9110 token grammar and strip CRLF / control chars.
+
+    Parameters
+    ----------
+    value: Optional[str]
+        Raw framework string to sanitize.
+    max_len: int, default 64
+        Maximum allowed length.
+
+    Returns
+    -------
+    str: Cleaned, ASCII-safe framework string. Returns empty string if input is None or empty.
+    """
+    if not value or not isinstance(value, str):
+        return ""
+
+    # Strip leading/trailing whitespace and control chars (including \r, \n)
+    cleaned = value.strip()
+    if not cleaned:
+        return ""
+
+    # Replace forbidden characters with '_' and truncate
+    sanitized = _TOKEN_SANITIZE_REGEX.sub("_", cleaned)
+    return sanitized[:max_len]

--- a/gcsfs/telemetry/sanitizer.py
+++ b/gcsfs/telemetry/sanitizer.py
@@ -1,4 +1,5 @@
 """RFC 9110 compliant token sanitization helper."""
+
 from __future__ import annotations
 
 import re

--- a/gcsfs/telemetry/sanitizer.py
+++ b/gcsfs/telemetry/sanitizer.py
@@ -36,3 +36,28 @@ def sanitize_framework(value: Optional[str], max_len: int = 64) -> str:
     # Replace forbidden characters with '_' and truncate
     sanitized = _TOKEN_SANITIZE_REGEX.sub("_", cleaned)
     return sanitized[:max_len]
+
+
+def sanitize_token(token: Optional[str], max_len: int = 64) -> Optional[str]:
+    """
+    Sanitize a full dimension token (e.g. 'fw/pandas', 'env/gke') splitting at most once by '/'.
+
+    Parameters
+    ----------
+    token: Optional[str]
+        Raw token string to sanitize.
+    max_len: int, default 64
+        Maximum allowed length per segment.
+
+    Returns
+    -------
+    Optional[str]: Valid sanitized RFC 9110 token string, or None if invalid or empty.
+    """
+    if not token or not isinstance(token, str):
+        return None
+
+    parts = token.split("/", 1)
+    sanitized_parts = [sanitize_framework(p, max_len=max_len) for p in parts]
+    if all(sanitized_parts):
+        return "/".join(sanitized_parts)
+    return None

--- a/gcsfs/tests/conftest.py
+++ b/gcsfs/tests/conftest.py
@@ -678,8 +678,10 @@ def mock_gcs_harness(monkeypatch):
             return {}, sample_csv_data
         return {}, sample_pt_data
 
+    from gcsfs.telemetry.manager import _gcs_sync_wrapper
+
     monkeypatch.setattr(GCSFileSystem, "_call", mock_call)
-    monkeypatch.setattr(GCSFileSystem, "call", asyn.sync_wrapper(mock_call))
+    monkeypatch.setattr(GCSFileSystem, "call", _gcs_sync_wrapper(mock_call))
 
     class Harness:
         def __init__(self):

--- a/gcsfs/tests/conftest.py
+++ b/gcsfs/tests/conftest.py
@@ -633,7 +633,9 @@ def mock_gcs_harness(monkeypatch):
 
         # Mock initiate_upload (resumable upload session)
         if kwargs.get("uploadType") == "resumable":
-            return {"Location": "http://mock-gcs/upload/session-12345678901234567890"}, b""
+            return {
+                "Location": "http://mock-gcs/upload/session-12345678901234567890"
+            }, b""
 
         # Mock upload chunk / upload completion
         if "http://mock-gcs/upload" in str(path):

--- a/gcsfs/tests/conftest.py
+++ b/gcsfs/tests/conftest.py
@@ -607,6 +607,95 @@ async def async_gcs():
         await _close_gcs_async(gcs)
 
 
+@pytest.fixture
+def mock_gcs_harness(monkeypatch):
+    """
+    Harness that mocks GCSFileSystem HTTP transport and records the exact
+    User-Agent header sent on every outgoing GCS request.
+    """
+    captured_user_agents = []
+    sample_pt_data = b"MOCK_PT_BINARY_DATA_FOR_TORCH_LOADER_TESTING_12345"
+    sample_csv_data = b"col1,col2,col3\n1,2,3\n4,5,6\n"
+
+    async def mock_call(self, method, path, *args, **kwargs):
+        if args:
+            path = path.format(*args)
+        # Capture the User-Agent header
+        headers = kwargs.get("headers") or {}
+        ua = headers.get("User-Agent")
+        if not ua:
+            ua = self._get_headers(
+                headers,
+                cache_type=kwargs.get("cache_type"),
+                cache_source=kwargs.get("cache_source"),
+            ).get("User-Agent")
+        captured_user_agents.append(ua or "")
+
+        # Mock initiate_upload (resumable upload session)
+        if kwargs.get("uploadType") == "resumable":
+            return {"Location": "http://mock-gcs/upload/session-12345678901234567890"}, b""
+
+        # Mock upload chunk / upload completion
+        if "http://mock-gcs/upload" in str(path):
+            return {}, b'{"generation": "1"}'
+
+        # Mock object metadata response (json_out=True returns dict directly)
+        if kwargs.get("json_out"):
+            if path in ["b", "b?"] or str(path).startswith("b?"):
+                return {"kind": "storage#buckets", "items": [{"name": "test-bucket"}]}
+            if str(path).startswith("b/") and "/o" not in str(path):
+                return {
+                    "kind": "storage#bucket",
+                    "name": "test-bucket",
+                    "items": [{"name": "test-bucket"}],
+                }
+            if str(path).endswith("/o") or "/o?" in str(path):
+                return {
+                    "items": [
+                        {
+                            "name": "model.pt" if "model" in str(path) else "file.txt",
+                            "bucket": "test-bucket",
+                            "size": str(len(sample_pt_data)),
+                            "generation": "1",
+                        }
+                    ]
+                }
+            obj_name = path.split("/o/")[-1] if "/o/" in path else path.split("/")[-1]
+            size = len(sample_csv_data) if "csv" in obj_name else len(sample_pt_data)
+            return {
+                "name": obj_name,
+                "bucket": "test-bucket",
+                "size": str(size),
+                "generation": "1",
+                "timeCreated": "2026-01-01T00:00:00.000Z",
+                "updated": "2026-01-01T00:00:00.000Z",
+            }
+
+        # Mock object data content
+        if "csv" in str(path):
+            return {}, sample_csv_data
+        return {}, sample_pt_data
+
+    monkeypatch.setattr(GCSFileSystem, "_call", mock_call)
+    monkeypatch.setattr(GCSFileSystem, "call", asyn.sync_wrapper(mock_call))
+
+    class Harness:
+        def __init__(self):
+            self.user_agents = captured_user_agents
+            self.fs = GCSFileSystem(
+                token="anon", project="test-project", consistency="none"
+            )
+
+        def clear(self):
+            self.user_agents.clear()
+
+        def last_user_agent(self) -> str:
+            assert len(self.user_agents) > 0, "No User-Agent was captured!"
+            return self.user_agents[-1]
+
+    return Harness()
+
+
 def pytest_addoption(parser):
     parser.addoption(
         "--run-benchmarks",

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -3731,9 +3731,7 @@ def test_user_agent_telemetry_integration(gcs):
     )
     assert "cache_type/readahead:e" in headers_explicit["User-Agent"]
 
-    headers_default = gcs._get_headers(
-        None, cache_type="none", cache_source="default"
-    )
+    headers_default = gcs._get_headers(None, cache_type="none", cache_source="default")
     assert "cache_type/none:d" in headers_default["User-Agent"]
 
     # 3. ContextVar caller framework

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -3710,3 +3710,65 @@ def test_user_agent_includes_cache_type_and_source_in_read(gcs):
             for call in mock_session_request.call_args_list
         ]
         assert any("cache_type/readahead:d" in ua for ua in user_agents)
+
+
+def test_user_agent_telemetry_integration(gcs):
+    """Verify that gcs._get_headers and User-Agent include telemetry tokens and handle overrides."""
+    from gcsfs.telemetry.context import (
+        Dimension,
+        reset_telemetry_context,
+        set_dimension_context,
+    )
+
+    # 1. Default headers
+    headers = gcs._get_headers(None)
+    assert headers["User-Agent"].startswith("python-gcsfs/")
+    assert "cache_type" not in headers["User-Agent"]
+
+    # 2. Cache type explicit & default
+    headers_explicit = gcs._get_headers(
+        None, cache_type="readahead", cache_source="explicit"
+    )
+    assert "cache_type/readahead:e" in headers_explicit["User-Agent"]
+
+    headers_default = gcs._get_headers(
+        None, cache_type="none", cache_source="default"
+    )
+    assert "cache_type/none:d" in headers_default["User-Agent"]
+
+    # 3. ContextVar caller framework
+    token = set_dimension_context(Dimension.FRAMEWORK, "fw/torch")
+    try:
+        headers_caller = gcs._get_headers(None)
+        assert "fw/torch" in headers_caller["User-Agent"]
+        assert headers_caller["User-Agent"].startswith("python-gcsfs/")
+    finally:
+        reset_telemetry_context(token)
+
+    # 4. Preset User-Agent is preserved
+    token = set_dimension_context(Dimension.FRAMEWORK, "fw/pandas")
+    try:
+        headers_preset = gcs._get_headers({"User-Agent": "my-custom-agent"})
+        assert headers_preset["User-Agent"] == "my-custom-agent"
+    finally:
+        reset_telemetry_context(token)
+
+
+def test_no_eager_property_evaluation_on_init(monkeypatch):
+    """
+    Verify that instantiating GCSFileSystem does NOT eagerly invoke
+    properties like `fs.buckets`, which would trigger network I/O.
+    """
+    from gcsfs.core import GCSFileSystem
+
+    buckets_called = False
+
+    async def mock_list_buckets(self, *args, **kwargs):
+        nonlocal buckets_called
+        buckets_called = True
+        return []
+
+    monkeypatch.setattr(GCSFileSystem, "_list_buckets", mock_list_buckets)
+
+    _ = GCSFileSystem(token="anon", project="test-project")
+    assert not buckets_called, "GCSFileSystem.__init__ eagerly evaluated fs.buckets!"

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -540,6 +540,7 @@ def test_rm_batch(gcs):
 @pytest.mark.asyncio
 async def test_rm_batch_error(gcs):
     path = TEST_BUCKET + "/test_error_file"
+    boundary = "==========7330845974216740156=="
     mock_response_content = (
         f"\n--{boundary}\n"
         "Content-Type: application/http\n"
@@ -572,7 +573,7 @@ async def test_rm_batch_not_found_invalidates_stale_cache(gcs):
         if hasattr(gcs, "_is_bucket_hns_enabled")
         else False
     )
-
+    boundary = "==========7330845974216740156=="
     mock_response_content = (
         f"\n--{boundary}\n"
         "Content-Type: application/http\n"
@@ -3768,6 +3769,8 @@ def test_no_eager_property_evaluation_on_init(monkeypatch):
 
     _ = GCSFileSystem(token="anon", project="test-project")
     assert not buckets_called, "GCSFileSystem.__init__ eagerly evaluated fs.buckets!"
+
+
 def test_process_object_structure(gcs):
     bucket = "my-bucket"
     metadata = {

--- a/gcsfs/tests/test_telemetry.py
+++ b/gcsfs/tests/test_telemetry.py
@@ -459,3 +459,71 @@ def test_post_fork_telemetry_reset():
         assert get_dimension_context(Dimension.FRAMEWORK) == "fw/parent-process"
     finally:
         reset_telemetry_context(token)
+
+
+def test_async_gen_wrapper_aclose_on_early_exit():
+    """Verify that _gcs_async_gen_wrapper properly closes the underlying async generator on early exit."""
+    from gcsfs.core import GCSFileSystem
+    from gcsfs.telemetry.manager import _gcs_async_gen_wrapper
+
+    closed = False
+
+    async def sample_async_gen():
+        nonlocal closed
+        try:
+            yield 1
+            yield 2
+            yield 3
+        finally:
+            closed = True
+
+    fs = GCSFileSystem(token="anon")
+    wrapped_gen = _gcs_async_gen_wrapper(sample_async_gen, obj=fs)
+    gen_instance = wrapped_gen()
+    val = next(gen_instance)
+    assert val == 1
+    assert not closed
+    # Close the sync generator early (simulating break in for loop)
+    gen_instance.close()
+    assert closed
+
+
+def test_collect_tokens_map_records_empty_for_none_detection():
+    """Verify that collect_tokens_map records empty string for None detection and avoids redundant checks."""
+    from gcsfs.telemetry.context import (
+        Dimension,
+        reset_telemetry_context,
+        set_telemetry_context,
+    )
+    from gcsfs.telemetry.detectors.base import BaseDetector
+    from gcsfs.telemetry.manager import UsageMetricsTracker
+
+    call_count = 0
+
+    class DummyNoneDetector(BaseDetector):
+        @property
+        def name(self):
+            return Dimension.FRAMEWORK
+
+        def detect(self):
+            nonlocal call_count
+            call_count += 1
+            return None
+
+    tracker = UsageMetricsTracker(detectors=[DummyNoneDetector()])
+    tokens_map = tracker.collect_tokens_map()
+    assert tokens_map == {"fw": ""}
+    assert call_count == 1
+
+    # In _sync(), the captured tokens_map is bridged into ContextVar:
+    token = set_telemetry_context(tokens_map)
+    try:
+        # All downstream operations on event loop (get_tokens, get_dimension, collect_tokens_map)
+        # must now be O(1) without re-running detect()
+        assert tracker.get_tokens() == []
+        assert tracker.get_dimension(Dimension.FRAMEWORK) is None
+        tokens_map_2 = tracker.collect_tokens_map()
+        assert tokens_map_2 == {"fw": ""}
+        assert call_count == 1  # Still 1, no additional detect() calls!
+    finally:
+        reset_telemetry_context(token)

--- a/gcsfs/tests/test_telemetry.py
+++ b/gcsfs/tests/test_telemetry.py
@@ -1,0 +1,382 @@
+"""Unit tests for the gcsfs telemetry subsystem."""
+from __future__ import annotations
+
+import os
+import sys
+import types
+import pytest
+
+from gcsfs.telemetry.sanitizer import sanitize_framework
+from gcsfs.telemetry.context import (
+    Dimension,
+    get_dimension_context,
+    reset_telemetry_context,
+    set_dimension_context,
+)
+from gcsfs.telemetry.detectors.base import BaseDetector
+from gcsfs.telemetry.detectors.framework import FrameworkDetector
+from gcsfs.telemetry.manager import UsageMetricsTracker
+
+
+# ============================================================================
+# 1. Sanitizer Tests
+# ============================================================================
+
+def test_sanitize_framework_empty_and_none():
+    assert sanitize_framework(None) == ""
+    assert sanitize_framework("") == ""
+    assert sanitize_framework("   ") == ""
+    assert sanitize_framework(123) == ""  # Non-string input
+
+
+def test_sanitize_framework_valid_characters():
+    assert sanitize_framework("pandas") == "pandas"
+    assert sanitize_framework("datasets") == "datasets"
+    assert sanitize_framework("scikit-learn") == "scikit-learn"
+    assert sanitize_framework("version.1.2.3") == "version.1.2.3"
+    assert sanitize_framework("my_custom_framework-v2") == "my_custom_framework-v2"
+
+
+def test_sanitize_framework_forbidden_chars_and_crlf():
+    # CRLF injection attempt (\r\n replaced, delimiters like ':' and '/' sanitized)
+    assert sanitize_framework("pandas\r\nInjected-Header: bad") == "pandas__Injected-Header__bad"
+    # Slashes and colons are sanitized to prevent malformed tokens
+    assert sanitize_framework("fw/torch") == "fw_torch"
+    assert sanitize_framework("host:8080") == "host_8080"
+    # Special characters & Unicode
+    assert sanitize_framework("my@framework#1$2%3^4*5") == "my_framework_1_2_3_4_5"
+    assert sanitize_framework("  spaced framework  ") == "spaced_framework"
+
+
+def test_sanitize_framework_length_truncation():
+    long_str = "a" * 100
+    assert len(sanitize_framework(long_str, max_len=64)) == 64
+    assert len(sanitize_framework(long_str, max_len=10)) == 10
+
+
+# ============================================================================
+# 2. Framework Detector Tests
+# ============================================================================
+
+def _create_mock_frame(module_name: str, back_frame=None):
+    """Helper to create a fake execution frame for testing stack traversal."""
+    frame = types.SimpleNamespace()
+    frame.f_globals = {"__name__": module_name}
+    frame.f_back = back_frame
+    return frame
+
+
+def test_framework_detector_known_frameworks_mapping():
+    detector = FrameworkDetector()
+    assert detector.KNOWN_FRAMEWORKS["pandas"] == "pandas"
+    assert detector.KNOWN_FRAMEWORKS["dask"] == "dask"
+    assert detector.KNOWN_FRAMEWORKS["lightning"] == "lightning"
+    assert detector.KNOWN_FRAMEWORKS["pytorch_lightning"] == "lightning"
+
+
+def test_framework_detector_top_to_bottom_traversal(monkeypatch):
+    detector = FrameworkDetector()
+
+    # Stack: root (__main__) -> dask.dataframe -> pandas.io -> pyarrow.parquet -> gcsfs.core
+    f_root = _create_mock_frame("__main__")
+    f_dask = _create_mock_frame("dask.dataframe.io.parquet", f_root)
+    f_pandas = _create_mock_frame("pandas.io.parquet", f_dask)
+    f_pyarrow = _create_mock_frame("pyarrow.parquet", f_pandas)
+    f_gcsfs = _create_mock_frame("gcsfs.core", f_pyarrow)
+
+    monkeypatch.setattr(sys, "_getframe", lambda: f_gcsfs)
+    assert detector.detect() == "fw/dask"
+
+
+def test_framework_detector_ignores_internal_and_test_prefixes(monkeypatch):
+    detector = FrameworkDetector()
+
+    # Stack: root (__main__) -> pytest -> unittest -> asyncio -> fsspec -> gcsfs
+    f_root = _create_mock_frame("__main__")
+    f_pytest = _create_mock_frame("pytest.runner", f_root)
+    f_asyncio = _create_mock_frame("asyncio.events", f_pytest)
+    f_fsspec = _create_mock_frame("fsspec.asyn", f_asyncio)
+    f_gcsfs = _create_mock_frame("gcsfs.core", f_fsspec)
+
+    monkeypatch.setattr(sys, "_getframe", lambda: f_gcsfs)
+    assert detector.detect() is None
+
+
+def test_framework_detector_handles_empty_and_invalid_frames(monkeypatch):
+    detector = FrameworkDetector()
+
+    monkeypatch.setattr(sys, "_getframe", lambda: None)
+    assert detector.detect() is None
+
+    # Frame with missing or empty __name__
+    empty_frame = types.SimpleNamespace(f_globals={}, f_back=None)
+    monkeypatch.setattr(sys, "_getframe", lambda: empty_frame)
+    assert detector.detect() is None
+
+    # sys._getframe raises exception on unsupported platforms / frames
+    def mock_raises():
+        raise ValueError("call stack is not deep enough")
+
+    monkeypatch.setattr(sys, "_getframe", mock_raises)
+    assert detector.detect() is None
+
+
+def test_framework_detector_opt_out(monkeypatch):
+    detector = FrameworkDetector()
+
+    # Default: active
+    assert detector.is_enabled()
+
+    # With GCSFS_NO_TELEMETRY=1
+    monkeypatch.setenv("GCSFS_NO_TELEMETRY", "1")
+    assert not detector.is_enabled()
+    assert detector.detect() is None
+
+    # With GCSFS_NO_TELEMETRY=true
+    monkeypatch.setenv("GCSFS_NO_TELEMETRY", "true")
+    assert not detector.is_enabled()
+
+
+# ============================================================================
+# 3. Context Management Tests
+# ============================================================================
+
+def test_set_and_get_dimension_context():
+    # Initial state
+    assert get_dimension_context(Dimension.FRAMEWORK) is None
+
+    # Set caller framework
+    token = set_dimension_context(Dimension.FRAMEWORK, "fw/custom-engine")
+    assert get_dimension_context(Dimension.FRAMEWORK) == "fw/custom-engine"
+
+    # Reset
+    reset_telemetry_context(token)
+    assert get_dimension_context(Dimension.FRAMEWORK) is None
+
+
+# ============================================================================
+# 4. Telemetry Manager & Header Building Tests
+# ============================================================================
+
+def test_multidimensional_telemetry_registration():
+    class DummyEnvDetector(BaseDetector):
+        @property
+        def name(self) -> str:
+            return "env"
+
+        def detect(self):
+            return "env/gke"
+
+    tracker = UsageMetricsTracker(detectors=[DummyEnvDetector(), FrameworkDetector()])
+    assert "env/gke" in tracker.get_tokens()
+
+    # When framework is active in context
+    token = set_dimension_context(Dimension.FRAMEWORK, "fw/pandas")
+    try:
+        tokens = tracker.get_tokens()
+        assert "env/gke" in tokens
+        assert "fw/pandas" in tokens
+        assert tracker.get_dimension(Dimension.FRAMEWORK) == "fw/pandas"
+    finally:
+        reset_telemetry_context(token)
+
+
+# ============================================================================
+# 5. GCSFS Telemetry Propagation Tests
+# ============================================================================
+
+def test_nested_method_calls_telemetry():
+    """
+    Verify that deeply nested method calls (e.g. outer sync -> bridged async -> inner async)
+    correctly maintain the outer framework across all levels and cleanly reset context.
+    """
+    import fsspec.asyn
+    from gcsfs.core import GCSFileSystem
+
+    fs = GCSFileSystem(token="anon", project="test-project")
+
+    # Set outer framework context
+    token = set_dimension_context(Dimension.FRAMEWORK, "fw/custom-pipeline")
+    try:
+        # Outermost level
+        assert get_dimension_context(Dimension.FRAMEWORK) == "fw/custom-pipeline"
+
+        # Simulate nested async execution across bridged sync
+        async def inner_coro():
+            assert get_dimension_context(Dimension.FRAMEWORK) == "fw/custom-pipeline"
+
+            # Simulate innermost async method (Level 2)
+            async def innermost_coro():
+                return get_dimension_context(Dimension.FRAMEWORK)
+
+            return await innermost_coro()
+
+        res = fsspec.asyn.sync(fs.loop, inner_coro)
+        assert res == "fw/custom-pipeline"
+
+        # Context at outer level is still intact
+        assert get_dimension_context(Dimension.FRAMEWORK) == "fw/custom-pipeline"
+    finally:
+        reset_telemetry_context(token)
+
+    # After outer method completes, context is completely clean
+    assert get_dimension_context(Dimension.FRAMEWORK) is None
+
+
+def test_multithreaded_context_isolation():
+    """
+    Verify that concurrent threads executing with distinct framework contexts
+    remain completely isolated without cross-thread ContextVar leakage or overlap.
+    """
+    import concurrent.futures
+    import threading
+    import time
+
+    barrier = threading.Barrier(4)
+    errors = []
+
+    def worker(framework_name: str):
+        try:
+            # 1. Verify clean initial state in this thread
+            if get_dimension_context(Dimension.FRAMEWORK) is not None:
+                errors.append(f"{framework_name}: initial context not None")
+
+            # 2. Set thread-local context
+            token = set_dimension_context(Dimension.FRAMEWORK, f"fw/{framework_name}")
+            try:
+                # 3. Synchronize all threads so all 4 contexts are simultaneously active
+                barrier.wait(timeout=5)
+
+                # 4. Repeatedly verify context during concurrent overlap
+                for _ in range(5):
+                    current = get_dimension_context(Dimension.FRAMEWORK)
+                    if current != f"fw/{framework_name}":
+                        errors.append(f"{framework_name}: expected fw/{framework_name}, got {current}")
+                    time.sleep(0.005)
+            finally:
+                reset_telemetry_context(token)
+
+            # 5. Verify thread context is cleanly reset
+            if get_dimension_context(Dimension.FRAMEWORK) is not None:
+                errors.append(f"{framework_name}: post-reset context not None")
+        except Exception as e:
+            errors.append(f"{framework_name} exception: {e}")
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
+        futures = [
+            executor.submit(worker, name)
+            for name in ["pandas", "torch", "dask", "ray"]
+        ]
+        concurrent.futures.wait(futures)
+
+    assert errors == [], f"Thread isolation errors: {errors}"
+
+
+def test_deep_stack_traversal(monkeypatch):
+    """Verify stack frame detector traverses deep stacks up to depth 64."""
+    detector = FrameworkDetector(max_depth=64)
+
+    # Build a 50-frame stack where the top frame (frame 50) is 'lightning'
+    current_frame = _create_mock_frame("lightning.pytorch.trainer")
+    for i in range(49):
+        current_frame = _create_mock_frame(f"internal_module_{i}", back_frame=current_frame)
+
+    monkeypatch.setattr(sys, "_getframe", lambda: current_frame)
+    detected = detector.detect()
+    assert detected == "fw/lightning"
+
+
+def test_all_parent_methods_telemetry_coverage(mock_gcs_harness):
+    """
+    Concise verification that ALL inherited and overridden FileSystem and File
+    methods correctly propagate the caller framework in outgoing User-Agent headers.
+    """
+    fs = mock_gcs_harness.fs
+    captured = mock_gcs_harness.user_agents
+
+    # 1. Test all inherited & overridden FileSystem methods
+    fs_operations = [
+        ("ls", lambda: fs.ls("test-bucket")),
+        ("info", lambda: fs.info("test-bucket/file.txt")),
+        ("exists", lambda: fs.exists("test-bucket/file.txt")),
+        ("cat", lambda: fs.cat("test-bucket/file.txt")),
+        ("head", lambda: fs.head("test-bucket/file.txt", size=5)),
+        ("tail", lambda: fs.tail("test-bucket/file.txt", size=5)),
+        ("find", lambda: fs.find("test-bucket")),
+        ("walk", lambda: list(fs.walk("test-bucket"))),
+        ("glob", lambda: fs.glob("test-bucket/*")),
+        ("du", lambda: fs.du("test-bucket")),
+        ("size", lambda: fs.size("test-bucket/file.txt")),
+        ("read_bytes", lambda: fs.read_bytes("test-bucket/file.txt")),
+        ("read_text", lambda: fs.read_text("test-bucket/file.txt")),
+        ("write_bytes", lambda: fs.write_bytes("test-bucket/file.txt", b"data")),
+        ("write_text", lambda: fs.write_text("test-bucket/file.txt", "data")),
+        ("buckets", lambda: fs.buckets),
+        ("open_read", lambda: fs.open("test-bucket/file.txt", "rb").read(5)),
+        (
+            "open_write",
+            lambda: _write_file_helper(fs),
+        ),
+    ]
+
+    def _write_file_helper(filesystem):
+        with filesystem.open("test-bucket/file.txt", "wb") as f:
+            f.write(b"data\n")
+            f.writelines([b"data2\n"])
+            f.flush()
+
+    for name, op in fs_operations:
+        fs.dircache.clear()
+        captured.clear()
+        expected_token = f"fw/test-{name}"
+        token = set_dimension_context(Dimension.FRAMEWORK, expected_token)
+        try:
+            op()
+            assert len(captured) > 0, f"operation {name} did not execute any network calls"
+            assert all(
+                expected_token in ua for ua in captured
+            ), f"operation {name} had requests missing {expected_token}: {captured}"
+        finally:
+            reset_telemetry_context(token)
+
+
+# ============================================================================
+# 8. Fork Reset Tests
+# ============================================================================
+
+def test_post_fork_telemetry_reset():
+    """Verify os.register_at_fork automatically clears telemetry in a real forked child process."""
+    if not hasattr(os, "fork"):
+        pytest.skip("os.fork is only supported on Unix platforms")
+
+    import multiprocessing
+    from gcsfs.telemetry.context import (
+        get_dimension_context,
+        get_telemetry_context,
+        reset_telemetry_context,
+        set_dimension_context,
+    )
+
+    token = set_dimension_context(Dimension.FRAMEWORK, "fw/parent-process")
+    try:
+        assert get_telemetry_context() == {"fw": "fw/parent-process"}
+
+        ctx = multiprocessing.get_context("fork")
+        result_queue = ctx.Queue()
+
+        def child_worker(q):
+            # In the forked child, os.register_at_fork(after_in_child=...) automatically runs
+            q.put(get_telemetry_context())
+
+        p = ctx.Process(target=child_worker, args=(result_queue,))
+        p.start()
+        p.join(timeout=5)
+
+        child_result = result_queue.get(timeout=5)
+        # Child process must have an empty telemetry context
+        assert child_result == {}, f"Child telemetry was not reset! Got: {child_result}"
+
+        # Parent process still retains its original telemetry context
+        assert get_dimension_context(Dimension.FRAMEWORK) == "fw/parent-process"
+    finally:
+        reset_telemetry_context(token)

--- a/gcsfs/tests/test_telemetry.py
+++ b/gcsfs/tests/test_telemetry.py
@@ -1,12 +1,13 @@
 """Unit tests for the gcsfs telemetry subsystem."""
+
 from __future__ import annotations
 
 import os
 import sys
 import types
+
 import pytest
 
-from gcsfs.telemetry.sanitizer import sanitize_framework
 from gcsfs.telemetry.context import (
     Dimension,
     get_dimension_context,
@@ -16,11 +17,12 @@ from gcsfs.telemetry.context import (
 from gcsfs.telemetry.detectors.base import BaseDetector
 from gcsfs.telemetry.detectors.framework import FrameworkDetector
 from gcsfs.telemetry.manager import UsageMetricsTracker
-
+from gcsfs.telemetry.sanitizer import sanitize_framework
 
 # ============================================================================
 # 1. Sanitizer Tests
 # ============================================================================
+
 
 def test_sanitize_framework_empty_and_none():
     assert sanitize_framework(None) == ""
@@ -39,7 +41,10 @@ def test_sanitize_framework_valid_characters():
 
 def test_sanitize_framework_forbidden_chars_and_crlf():
     # CRLF injection attempt (\r\n replaced, delimiters like ':' and '/' sanitized)
-    assert sanitize_framework("pandas\r\nInjected-Header: bad") == "pandas__Injected-Header__bad"
+    assert (
+        sanitize_framework("pandas\r\nInjected-Header: bad")
+        == "pandas__Injected-Header__bad"
+    )
     # Slashes and colons are sanitized to prevent malformed tokens
     assert sanitize_framework("fw/torch") == "fw_torch"
     assert sanitize_framework("host:8080") == "host_8080"
@@ -57,6 +62,7 @@ def test_sanitize_framework_length_truncation():
 # ============================================================================
 # 2. Framework Detector Tests
 # ============================================================================
+
 
 def _create_mock_frame(module_name: str, back_frame=None):
     """Helper to create a fake execution frame for testing stack traversal."""
@@ -141,6 +147,7 @@ def test_framework_detector_opt_out(monkeypatch):
 # 3. Context Management Tests
 # ============================================================================
 
+
 def test_set_and_get_dimension_context():
     # Initial state
     assert get_dimension_context(Dimension.FRAMEWORK) is None
@@ -157,6 +164,7 @@ def test_set_and_get_dimension_context():
 # ============================================================================
 # 4. Telemetry Manager & Header Building Tests
 # ============================================================================
+
 
 def test_multidimensional_telemetry_registration():
     class DummyEnvDetector(BaseDetector):
@@ -185,12 +193,14 @@ def test_multidimensional_telemetry_registration():
 # 5. GCSFS Telemetry Propagation Tests
 # ============================================================================
 
+
 def test_nested_method_calls_telemetry():
     """
     Verify that deeply nested method calls (e.g. outer sync -> bridged async -> inner async)
     correctly maintain the outer framework across all levels and cleanly reset context.
     """
     import fsspec.asyn
+
     from gcsfs.core import GCSFileSystem
 
     fs = GCSFileSystem(token="anon", project="test-project")
@@ -251,7 +261,9 @@ def test_multithreaded_context_isolation():
                 for _ in range(5):
                     current = get_dimension_context(Dimension.FRAMEWORK)
                     if current != f"fw/{framework_name}":
-                        errors.append(f"{framework_name}: expected fw/{framework_name}, got {current}")
+                        errors.append(
+                            f"{framework_name}: expected fw/{framework_name}, got {current}"
+                        )
                     time.sleep(0.005)
             finally:
                 reset_telemetry_context(token)
@@ -264,8 +276,7 @@ def test_multithreaded_context_isolation():
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
         futures = [
-            executor.submit(worker, name)
-            for name in ["pandas", "torch", "dask", "ray"]
+            executor.submit(worker, name) for name in ["pandas", "torch", "dask", "ray"]
         ]
         concurrent.futures.wait(futures)
 
@@ -279,7 +290,9 @@ def test_deep_stack_traversal(monkeypatch):
     # Build a 50-frame stack where the top frame (frame 50) is 'lightning'
     current_frame = _create_mock_frame("lightning.pytorch.trainer")
     for i in range(49):
-        current_frame = _create_mock_frame(f"internal_module_{i}", back_frame=current_frame)
+        current_frame = _create_mock_frame(
+            f"internal_module_{i}", back_frame=current_frame
+        )
 
     monkeypatch.setattr(sys, "_getframe", lambda: current_frame)
     detected = detector.detect()
@@ -332,7 +345,9 @@ def test_all_parent_methods_telemetry_coverage(mock_gcs_harness):
         token = set_dimension_context(Dimension.FRAMEWORK, expected_token)
         try:
             op()
-            assert len(captured) > 0, f"operation {name} did not execute any network calls"
+            assert (
+                len(captured) > 0
+            ), f"operation {name} did not execute any network calls"
             assert all(
                 expected_token in ua for ua in captured
             ), f"operation {name} had requests missing {expected_token}: {captured}"
@@ -344,12 +359,14 @@ def test_all_parent_methods_telemetry_coverage(mock_gcs_harness):
 # 8. Fork Reset Tests
 # ============================================================================
 
+
 def test_post_fork_telemetry_reset():
     """Verify os.register_at_fork automatically clears telemetry in a real forked child process."""
     if not hasattr(os, "fork"):
         pytest.skip("os.fork is only supported on Unix platforms")
 
     import multiprocessing
+
     from gcsfs.telemetry.context import (
         get_dimension_context,
         get_telemetry_context,

--- a/gcsfs/tests/test_telemetry.py
+++ b/gcsfs/tests/test_telemetry.py
@@ -17,7 +17,7 @@ from gcsfs.telemetry.context import (
 from gcsfs.telemetry.detectors.base import BaseDetector
 from gcsfs.telemetry.detectors.framework import FrameworkDetector
 from gcsfs.telemetry.manager import UsageMetricsTracker
-from gcsfs.telemetry.sanitizer import sanitize_framework
+from gcsfs.telemetry.sanitizer import sanitize_framework, sanitize_token
 
 # ============================================================================
 # 1. Sanitizer Tests
@@ -57,6 +57,31 @@ def test_sanitize_framework_length_truncation():
     long_str = "a" * 100
     assert len(sanitize_framework(long_str, max_len=64)) == 64
     assert len(sanitize_framework(long_str, max_len=10)) == 10
+
+
+def test_sanitize_token_valid_and_edge_cases():
+    # Valid tokens
+    assert sanitize_token("fw/pandas") == "fw/pandas"
+    assert sanitize_token("env/gke") == "env/gke"
+    assert sanitize_token("pandas") == "pandas"
+
+    # Multi-slash values sanitized to single slash
+    assert sanitize_token("fw/my/custom/lib") == "fw/my_custom_lib"
+
+    # CRLF and forbidden characters sanitized
+    assert (
+        sanitize_token("fw/custom\r\nInjected-Header: injected_val")
+        == "fw/custom__Injected-Header__injected_val"
+    )
+
+    # Empty, none, non-string, or malformed tokens
+    assert sanitize_token(None) is None
+    assert sanitize_token("") is None
+    assert sanitize_token(123) is None
+    assert sanitize_token("   ") is None
+    assert sanitize_token("fw/") is None
+    assert sanitize_token("/pandas") is None
+    assert sanitize_token("///") is None
 
 
 # ============================================================================
@@ -187,6 +212,43 @@ def test_multidimensional_telemetry_registration():
         assert tracker.get_dimension(Dimension.FRAMEWORK) == "fw/pandas"
     finally:
         reset_telemetry_context(token)
+
+
+def test_get_tokens_sanitization_user_controlled_context():
+    """Verify that get_tokens and get_dimension sanitize forbidden chars and CRLF from user context."""
+    tracker = UsageMetricsTracker()
+
+    # User sets context with CRLF and custom headers
+    token = set_dimension_context(
+        Dimension.FRAMEWORK, "fw/custom\r\nInjected-Header: injected_val"
+    )
+    try:
+        tokens = tracker.get_tokens()
+        assert tokens == ["fw/custom__Injected-Header__injected_val"]
+        assert (
+            tracker.get_dimension(Dimension.FRAMEWORK)
+            == "fw/custom__Injected-Header__injected_val"
+        )
+    finally:
+        reset_telemetry_context(token)
+
+    # Extra slashes in value (e.g. fw/my/custom/lib -> fw/my_custom_lib)
+    token = set_dimension_context(Dimension.FRAMEWORK, "fw/my/custom/lib")
+    try:
+        tokens = tracker.get_tokens()
+        assert tokens == ["fw/my_custom_lib"]
+        assert tracker.get_dimension(Dimension.FRAMEWORK) == "fw/my_custom_lib"
+    finally:
+        reset_telemetry_context(token)
+
+    # Dangling / leading slash or empty should not produce invalid tokens like 'fw/'
+    for malformed in ["fw/", "/pandas", "   ", ""]:
+        token = set_dimension_context(Dimension.FRAMEWORK, malformed)
+        try:
+            assert tracker.get_tokens() == []
+            assert tracker.get_dimension(Dimension.FRAMEWORK) is None
+        finally:
+            reset_telemetry_context(token)
 
 
 # ============================================================================

--- a/gcsfs/tests/test_telemetry.py
+++ b/gcsfs/tests/test_telemetry.py
@@ -532,10 +532,10 @@ def test_collect_tokens_map_records_empty_for_none_detection():
 @pytest.mark.asyncio
 async def test_gcs_async_wrapper_scopes_context(monkeypatch):
     """Verify that _gcs_async_wrapper scopes context so inner HTTP requests skip stack detection."""
+    import gcsfs.telemetry.manager as manager_mod
     from gcsfs.telemetry.context import Dimension, get_telemetry_context
     from gcsfs.telemetry.detectors.base import BaseDetector
     from gcsfs.telemetry.manager import UsageMetricsTracker, _gcs_async_wrapper
-    import gcsfs.telemetry.manager as manager_mod
 
     # 1. Count how many times detect() actually executes
     detect_count = 0
@@ -577,9 +577,9 @@ async def test_gcs_async_wrapper_scopes_context(monkeypatch):
 @pytest.mark.asyncio
 async def test_consecutive_native_async_calls_isolated(monkeypatch):
     """Verify that consecutive native async calls under different frameworks are 100% isolated."""
+    import gcsfs.telemetry.manager as manager_mod
     from gcsfs.telemetry.context import get_telemetry_context
     from gcsfs.telemetry.manager import _gcs_async_wrapper
-    import gcsfs.telemetry.manager as manager_mod
 
     current_fw = "pandas"
     monkeypatch.setattr(
@@ -604,4 +604,3 @@ async def test_consecutive_native_async_calls_isolated(monkeypatch):
     await wrapped()
     assert captured[-1] == "fw/torch"
     assert get_telemetry_context() == {}
-

--- a/gcsfs/tests/test_telemetry.py
+++ b/gcsfs/tests/test_telemetry.py
@@ -604,3 +604,39 @@ async def test_consecutive_native_async_calls_isolated(monkeypatch):
     await wrapped()
     assert captured[-1] == "fw/torch"
     assert get_telemetry_context() == {}
+
+
+def test_gcsfile_caller_framework_caches_empty_and_avoids_repeated_detect(monkeypatch):
+    """Verify that GCSFile.caller_framework caches empty string when None and avoids repeated detect calls."""
+    from gcsfs.core import GCSFile, GCSFileSystem
+    from gcsfs.telemetry.context import Dimension
+    from gcsfs.telemetry.detectors.base import BaseDetector
+    from gcsfs.telemetry.manager import UsageMetricsTracker
+
+    detect_count = 0
+
+    class DummyNoneDetector(BaseDetector):
+        @property
+        def name(self):
+            return Dimension.FRAMEWORK
+
+        def detect(self):
+            nonlocal detect_count
+            detect_count += 1
+            return None
+
+    tracker = UsageMetricsTracker(detectors=[DummyNoneDetector()])
+    monkeypatch.setattr("gcsfs.core.default_usage_tracker", tracker)
+    monkeypatch.setattr("gcsfs.telemetry.manager.default_usage_tracker", tracker)
+
+    fs = GCSFileSystem(token="anon")
+    f = GCSFile(fs, "bucket/test.txt", mode="wb")
+
+    # Initialized once during GCSFile.__init__
+    assert detect_count == 1
+    assert f.caller_framework == ""
+
+    # Subsequent reads of property must be O(1) without re-running detect()
+    for _ in range(10):
+        assert f.caller_framework == ""
+    assert detect_count == 1

--- a/gcsfs/tests/test_telemetry.py
+++ b/gcsfs/tests/test_telemetry.py
@@ -527,3 +527,81 @@ def test_collect_tokens_map_records_empty_for_none_detection():
         assert call_count == 1  # Still 1, no additional detect() calls!
     finally:
         reset_telemetry_context(token)
+
+
+@pytest.mark.asyncio
+async def test_gcs_async_wrapper_scopes_context(monkeypatch):
+    """Verify that _gcs_async_wrapper scopes context so inner HTTP requests skip stack detection."""
+    from gcsfs.telemetry.context import Dimension, get_telemetry_context
+    from gcsfs.telemetry.detectors.base import BaseDetector
+    from gcsfs.telemetry.manager import UsageMetricsTracker, _gcs_async_wrapper
+    import gcsfs.telemetry.manager as manager_mod
+
+    # 1. Count how many times detect() actually executes
+    detect_count = 0
+
+    class MockDetector(BaseDetector):
+        @property
+        def name(self):
+            return Dimension.FRAMEWORK
+
+        def detect(self):
+            nonlocal detect_count
+            detect_count += 1
+            return "fw/pandas"
+
+    tracker = UsageMetricsTracker(detectors=[MockDetector()])
+    monkeypatch.setattr(manager_mod, "default_usage_tracker", tracker)
+
+    # 2. Simulate an async file operation (like _cat_file) making 5 inner HTTP requests
+    async def simulated_cat_file():
+        for _ in range(5):
+            # Each HTTP request calls tracker.get_tokens() for the User-Agent header
+            tokens = tracker.get_tokens()
+            assert tokens == ["fw/pandas"]
+        return "done"
+
+    # 3. Wrap with _gcs_async_wrapper
+    wrapped_cat_file = _gcs_async_wrapper(simulated_cat_file)
+
+    # 4. Run the operation
+    assert await wrapped_cat_file() == "done"
+
+    # 5. Check: detect() ran ONCE at entry (instead of 5 times for 5 HTTP requests)
+    assert detect_count == 1
+
+    # 6. Check: ContextVar is cleanly reset after the operation finishes
+    assert get_telemetry_context() == {}
+
+
+@pytest.mark.asyncio
+async def test_consecutive_native_async_calls_isolated(monkeypatch):
+    """Verify that consecutive native async calls under different frameworks are 100% isolated."""
+    from gcsfs.telemetry.context import get_telemetry_context
+    from gcsfs.telemetry.manager import _gcs_async_wrapper
+    import gcsfs.telemetry.manager as manager_mod
+
+    current_fw = "pandas"
+    monkeypatch.setattr(
+        manager_mod.default_usage_tracker,
+        "collect_tokens_map",
+        lambda: {"fw": f"fw/{current_fw}"},
+    )
+
+    captured = []
+
+    async def file_operation():
+        captured.append(get_telemetry_context().get("fw"))
+
+    wrapped = _gcs_async_wrapper(file_operation)
+
+    current_fw = "pandas"
+    await wrapped()
+    assert captured[-1] == "fw/pandas"
+    assert get_telemetry_context() == {}
+
+    current_fw = "torch"
+    await wrapped()
+    assert captured[-1] == "fw/torch"
+    assert get_telemetry_context() == {}
+

--- a/gcsfs/tests/test_telemetry.py
+++ b/gcsfs/tests/test_telemetry.py
@@ -272,8 +272,14 @@ def test_collect_tokens_map_caches_detector_exception():
     assert tokens1 == {Dimension.FRAMEWORK.value: ""}
     assert call_count == 1
 
-    # Second call with the same token dictionary should not re-invoke detect()
-    tokens2 = tracker.collect_tokens_map(tokens=tokens1)
+    # Second call
+    from gcsfs.telemetry.context import reset_telemetry_context, set_telemetry_context
+
+    t = set_telemetry_context(tokens1)
+    try:
+        tokens2 = tracker.collect_tokens_map()
+    finally:
+        reset_telemetry_context(t)
     assert tokens2 == {Dimension.FRAMEWORK.value: ""}
     assert call_count == 1
 
@@ -667,3 +673,75 @@ def test_gcsfile_caller_framework_caches_empty_and_avoids_repeated_detect(monkey
     for _ in range(10):
         assert f.caller_framework == ""
     assert detect_count == 1
+
+
+@pytest.mark.asyncio
+async def test_async_fetch_range_propagates_caller_framework():
+    """Verify that background prefetch coroutines inherit the framework context."""
+    from gcsfs.telemetry.context import Dimension, get_telemetry_context
+
+    captured_context = {}
+
+    async def mock_cat_file_concurrent(*args, **kwargs):
+        captured_context.update(get_telemetry_context())
+        return b"data"
+
+    import unittest.mock as mock
+
+    import gcsfs
+
+    fs = mock.MagicMock()
+    fs._cat_file_concurrent = mock.AsyncMock(side_effect=mock_cat_file_concurrent)
+    fs.split_path.return_value = ("bucket", "test.parquet", None)
+
+    # Bypass info call during init
+    with mock.patch.object(gcsfs.core.GCSFile, "info", return_value={"size": 100}):
+        f = gcsfs.core.GCSFile(fs, "gs://bucket/test.parquet", "rb", cache_type="none")
+
+    f.caller_framework = "fw/pandas"
+    # Ensure it is wrapped since it is manually instantiated without module load hooks
+    from gcsfs.telemetry.manager import _file_telemetry_wrapper
+
+    f._async_fetch_range = _file_telemetry_wrapper(
+        gcsfs.core.GCSFile._async_fetch_range
+    ).__get__(f)
+
+    await f._async_fetch_range(0, 10)
+    assert captured_context.get(Dimension.FRAMEWORK.value) == "fw/pandas"
+
+
+def test_defer_close_propagates_caller_framework():
+    """Verify that background deferred close inherits the framework context."""
+    import threading
+
+    from gcsfs.telemetry.context import Dimension, get_telemetry_context
+
+    captured_context = {}
+
+    import unittest.mock as mock
+
+    import gcsfs
+
+    fs = mock.MagicMock()
+    fs.split_path.return_value = ("bucket", "test.parquet", None)
+    with mock.patch.object(gcsfs.core.GCSFile, "info", return_value={"size": 100}):
+        f = gcsfs.core.GCSFile(fs, "gs://bucket/test.parquet", "wb")
+
+    f.caller_framework = "fw/ray"
+
+    def mock_upload_chunk(self, final=False):
+        captured_context.update(get_telemetry_context())
+
+    from gcsfs.telemetry.manager import _file_telemetry_wrapper
+
+    f._upload_chunk = _file_telemetry_wrapper(mock_upload_chunk).__get__(f)
+
+    def background_job():
+        f._upload_chunk(final=True)
+
+    t = threading.Thread(target=background_job)
+    t.start()
+    t.join()
+
+    assert captured_context.get(Dimension.FRAMEWORK.value) == "fw/ray"
+    f.closed = True

--- a/gcsfs/tests/test_telemetry.py
+++ b/gcsfs/tests/test_telemetry.py
@@ -100,6 +100,7 @@ def _create_mock_frame(module_name: str, back_frame=None):
 def test_framework_detector_known_frameworks_mapping():
     detector = FrameworkDetector()
     assert detector.KNOWN_FRAMEWORKS["pandas"] == "pandas"
+    assert detector.KNOWN_FRAMEWORKS["polars"] == "polars"
     assert detector.KNOWN_FRAMEWORKS["dask"] == "dask"
     assert detector.KNOWN_FRAMEWORKS["lightning"] == "lightning"
     assert detector.KNOWN_FRAMEWORKS["pytorch_lightning"] == "lightning"
@@ -249,6 +250,32 @@ def test_get_tokens_sanitization_user_controlled_context():
             assert tracker.get_dimension(Dimension.FRAMEWORK) is None
         finally:
             reset_telemetry_context(token)
+
+
+def test_collect_tokens_map_caches_detector_exception():
+    """Verify that if a detector raises an exception, it caches empty string to prevent repeated calls."""
+    call_count = 0
+
+    class FailingDetector(BaseDetector):
+        @property
+        def name(self):
+            return Dimension.FRAMEWORK
+
+        def detect(self):
+            nonlocal call_count
+            call_count += 1
+            raise RuntimeError("Frame traversal failed unexpectedly")
+
+    tracker = UsageMetricsTracker(detectors=[FailingDetector()])
+
+    tokens1 = tracker.collect_tokens_map()
+    assert tokens1 == {Dimension.FRAMEWORK.value: ""}
+    assert call_count == 1
+
+    # Second call with the same token dictionary should not re-invoke detect()
+    tokens2 = tracker.collect_tokens_map(tokens=tokens1)
+    assert tokens2 == {Dimension.FRAMEWORK.value: ""}
+    assert call_count == 1
 
 
 # ============================================================================

--- a/gcsfs/tests/test_upstream_frameworks_real.py
+++ b/gcsfs/tests/test_upstream_frameworks_real.py
@@ -1,0 +1,169 @@
+"""Real integration tests verifying framework detection when upstream packages use gcsfs."""
+from __future__ import annotations
+
+import pytest
+
+
+# ============================================================================
+# 1. PyTorch Lightning Integration Test
+# ============================================================================
+
+def test_pytorch_lightning_real_invocation(mock_gcs_harness):
+    """
+    Verify that when PyTorch Lightning triggers dataset/file loading,
+    'fw/lightning' is accurately detected as the top-most orchestrator.
+    """
+    lightning = pytest.importorskip("lightning")
+    import torch
+    from torch.utils.data import Dataset, DataLoader
+
+    # Create a custom PyTorch dataset that reads from GCS using fsspec/gcsfs
+    class GCSStreamDataset(Dataset):
+        def __init__(self, fs):
+            self.fs = fs
+
+        def __len__(self):
+            return 2
+
+        def __getitem__(self, idx):
+            # Lightning initiates the data read through DataLoader
+            with self.fs.open(f"gcs://test-bucket/data_{idx}.pt", "rb") as f:
+                data = f.read(32)
+            return torch.tensor([idx, len(data)], dtype=torch.float32)
+
+    # Wrap inside a PyTorch Lightning DataModule
+    class SampleLightningDataModule(lightning.LightningDataModule):
+        def __init__(self, fs):
+            super().__init__()
+            self.fs = fs
+
+        def train_dataloader(self):
+            return DataLoader(GCSStreamDataset(self.fs), batch_size=1)
+
+    # Minimal LightningModule
+    class DummyModule(lightning.LightningModule):
+        def __init__(self):
+            super().__init__()
+            self.layer = torch.nn.Linear(2, 1)
+
+        def training_step(self, batch, batch_idx):
+            loss = self.layer(batch).sum()
+            return loss
+
+        def configure_optimizers(self):
+            return torch.optim.SGD(self.parameters(), lr=0.01)
+
+    dm = SampleLightningDataModule(mock_gcs_harness.fs)
+    model = DummyModule()
+
+    # Run Lightning Trainer in fast_dev_run mode (1 batch)
+    trainer = lightning.Trainer(
+        max_epochs=1,
+        fast_dev_run=True,
+        enable_checkpointing=False,
+        logger=False,
+        enable_progress_bar=False,
+        accelerator="cpu",
+    )
+
+    mock_gcs_harness.clear()
+    trainer.fit(model, datamodule=dm)
+
+    # Verify that User-Agent contains fw/lightning
+    assert len(mock_gcs_harness.user_agents) > 0
+    for ua in mock_gcs_harness.user_agents:
+        assert "fw/lightning" in ua, f"Expected 'fw/lightning' in User-Agent, got: '{ua}'"
+
+
+def test_pytorch_lightning_native_checkpoint_save(mock_gcs_harness):
+    """
+    Verify 100% framework-internal I/O where PyTorch Lightning itself
+    invokes fsspec and gcsfs to save checkpoints via trainer.save_checkpoint().
+    """
+    lightning = pytest.importorskip("lightning")
+    import torch
+
+    class SimpleModule(lightning.LightningModule):
+        def __init__(self):
+            super().__init__()
+            self.layer = torch.nn.Linear(2, 1)
+
+    model = SimpleModule()
+    trainer = lightning.Trainer(accelerator="cpu")
+    trainer.strategy.connect(model)
+
+    mock_gcs_harness.clear()
+    # Lightning's internal TorchCheckpointIO executes fs.makedirs, fs.pipe, fs.open
+    trainer.save_checkpoint("gcs://test-bucket/model.ckpt")
+
+    assert len(mock_gcs_harness.user_agents) > 0
+    for ua in mock_gcs_harness.user_agents:
+        assert "fw/lightning" in ua, f"Expected 'fw/lightning' in User-Agent, got: '{ua}'"
+
+
+# ============================================================================
+# 2. PyTorch Native DataLoader Integration Test
+# ============================================================================
+
+def test_pytorch_native_dataloader_real_invocation(mock_gcs_harness):
+    """
+    Verify that native PyTorch DataLoader reads detect 'fw/torch'.
+    """
+    torch = pytest.importorskip("torch")
+    from torch.utils.data import Dataset, DataLoader
+
+    class TorchGCSDataset(Dataset):
+        def __init__(self, fs):
+            self.fs = fs
+
+        def __len__(self):
+            return 3
+
+        def __getitem__(self, idx):
+            with self.fs.open(f"gcs://test-bucket/data_{idx}.pt", "rb") as f:
+                content = f.read(32)
+            return torch.tensor([idx, len(content)], dtype=torch.int64)
+
+    loader = DataLoader(TorchGCSDataset(mock_gcs_harness.fs), batch_size=1)
+
+    mock_gcs_harness.clear()
+    for batch in loader:
+        pass
+
+    assert len(mock_gcs_harness.user_agents) > 0
+    for ua in mock_gcs_harness.user_agents:
+        assert "fw/torch" in ua, f"Expected 'fw/torch' in User-Agent, got: '{ua}'"
+
+
+# ============================================================================
+# 3. Pandas Native Integration Tests
+# ============================================================================
+
+def test_pandas_read_csv_native(mock_gcs_harness):
+    """
+    Verify that pd.read_csv("gcs://...") automatically tags User-Agent with 'fw/pandas'.
+    """
+    pandas = pytest.importorskip("pandas")
+
+    mock_gcs_harness.clear()
+    df = pandas.read_csv("gcs://test-bucket/data.csv", storage_options={"token": "anon"})
+
+    assert not df.empty
+    assert len(mock_gcs_harness.user_agents) > 0
+    for ua in mock_gcs_harness.user_agents:
+        assert "fw/pandas" in ua, f"Expected 'fw/pandas' in User-Agent, got: '{ua}'"
+
+
+def test_pandas_to_csv_native(mock_gcs_harness):
+    """
+    Verify that df.to_csv("gcs://...") automatically tags User-Agent with 'fw/pandas'.
+    """
+    pandas = pytest.importorskip("pandas")
+
+    df = pandas.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    mock_gcs_harness.clear()
+    df.to_csv("gcs://test-bucket/out.csv", storage_options={"token": "anon"})
+
+    assert len(mock_gcs_harness.user_agents) > 0
+    for ua in mock_gcs_harness.user_agents:
+        assert "fw/pandas" in ua, f"Expected 'fw/pandas' in User-Agent, got: '{ua}'"

--- a/gcsfs/tests/test_upstream_frameworks_real.py
+++ b/gcsfs/tests/test_upstream_frameworks_real.py
@@ -1,12 +1,13 @@
 """Real integration tests verifying framework detection when upstream packages use gcsfs."""
+
 from __future__ import annotations
 
 import pytest
 
-
 # ============================================================================
 # 1. PyTorch Lightning Integration Test
 # ============================================================================
+
 
 def test_pytorch_lightning_real_invocation(mock_gcs_harness):
     """
@@ -15,7 +16,7 @@ def test_pytorch_lightning_real_invocation(mock_gcs_harness):
     """
     lightning = pytest.importorskip("lightning")
     import torch
-    from torch.utils.data import Dataset, DataLoader
+    from torch.utils.data import DataLoader, Dataset
 
     # Create a custom PyTorch dataset that reads from GCS using fsspec/gcsfs
     class GCSStreamDataset(Dataset):
@@ -72,7 +73,9 @@ def test_pytorch_lightning_real_invocation(mock_gcs_harness):
     # Verify that User-Agent contains fw/lightning
     assert len(mock_gcs_harness.user_agents) > 0
     for ua in mock_gcs_harness.user_agents:
-        assert "fw/lightning" in ua, f"Expected 'fw/lightning' in User-Agent, got: '{ua}'"
+        assert (
+            "fw/lightning" in ua
+        ), f"Expected 'fw/lightning' in User-Agent, got: '{ua}'"
 
 
 def test_pytorch_lightning_native_checkpoint_save(mock_gcs_harness):
@@ -98,19 +101,22 @@ def test_pytorch_lightning_native_checkpoint_save(mock_gcs_harness):
 
     assert len(mock_gcs_harness.user_agents) > 0
     for ua in mock_gcs_harness.user_agents:
-        assert "fw/lightning" in ua, f"Expected 'fw/lightning' in User-Agent, got: '{ua}'"
+        assert (
+            "fw/lightning" in ua
+        ), f"Expected 'fw/lightning' in User-Agent, got: '{ua}'"
 
 
 # ============================================================================
 # 2. PyTorch Native DataLoader Integration Test
 # ============================================================================
 
+
 def test_pytorch_native_dataloader_real_invocation(mock_gcs_harness):
     """
     Verify that native PyTorch DataLoader reads detect 'fw/torch'.
     """
     torch = pytest.importorskip("torch")
-    from torch.utils.data import Dataset, DataLoader
+    from torch.utils.data import DataLoader, Dataset
 
     class TorchGCSDataset(Dataset):
         def __init__(self, fs):
@@ -139,6 +145,7 @@ def test_pytorch_native_dataloader_real_invocation(mock_gcs_harness):
 # 3. Pandas Native Integration Tests
 # ============================================================================
 
+
 def test_pandas_read_csv_native(mock_gcs_harness):
     """
     Verify that pd.read_csv("gcs://...") automatically tags User-Agent with 'fw/pandas'.
@@ -146,7 +153,9 @@ def test_pandas_read_csv_native(mock_gcs_harness):
     pandas = pytest.importorskip("pandas")
 
     mock_gcs_harness.clear()
-    df = pandas.read_csv("gcs://test-bucket/data.csv", storage_options={"token": "anon"})
+    df = pandas.read_csv(
+        "gcs://test-bucket/data.csv", storage_options={"token": "anon"}
+    )
 
     assert not df.empty
     assert len(mock_gcs_harness.user_agents) > 0


### PR DESCRIPTION
### Summary

Adds automatic upstream framework detection and telemetry tagging in `gcsfs` outgoing `User-Agent` HTTP request headers (e.g., `fw/pandas`, `fw/torch`, `fw/lightning`, `fw/ray`, `fw/dask`, `fw/polars`, `fw/duckdb`, `fw/huggingface`, etc.).

### Key Design & Architecture

1. **Zero Upstream Changes**:
   Automatically detects top-level calling frameworks at runtime without requiring upstream libraries or end users to pass custom arguments or wrap filesystems.

2. **Top-Down Call Stack Inspection (`FrameworkDetector`)**:
   Inspects the Python call stack from the root/outermost frame down to the innermost frame using `sys._getframe()`, correctly attributing nested framework hierarchies (e.g., PyTorch Lightning -> PyTorch DataLoader -> gcsfs is tagged as `fw/lightning`).

3. **GCS-Scoped Sync Method Mirroring (`mirror_gcs_sync_methods`)**:
   Attaches `_gcs_sync_wrapper` directly to `GCSFileSystem` instances to capture caller thread telemetry and bridge it into the background asyncio loop thread via `self._sync`.
   Keeps `AbstractFileSystem` and other multi-cloud filesystems (`s3fs`, `adlfs`, `LocalFileSystem`) 100% untouched and isolated.

4. **Multi-Thread, Async, and Process Safety**:
   - `ContextVar` ensures complete thread and task isolation with zero cross-thread context leakage.
   - `os.register_at_fork` cleanly resets telemetry state in child worker processes.
   - Preserves caller framework context across background prefetchers and deferred file close routines.

5. **RFC 9110 Token Sanitization**:
   Sanitizes and truncates framework tokens (`fw/<name>`) to comply strictly with RFC 9110 / HTTP User-Agent grammar and prevent header injection.

6. **Opt-Out Control**:
   Respects `GCSFS_NO_TELEMETRY=1` or `GCSFS_NO_TELEMETRY=true` to completely disable framework detection if desired.

### Tests Added
- Comprehensive unit test suite in `gcsfs/tests/test_telemetry.py` (sanitization, top-to-bottom frame traversal, opt-out, ContextVar isolation, multi-threaded concurrency barriers, fork resets, full method coverage).
- Real upstream framework integration tests in `gcsfs/tests/test_upstream_frameworks_real.py` (PyTorch Lightning trainer, PyTorch Lightning checkpoint save, PyTorch native DataLoader, Pandas `read_csv` and `to_csv`).