### PR TITLE
Always show the e2e test summary (counts and failure logs) in github UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,9 @@ jobs:
       - name: Run Release Automation Tests
         run: |
           pytest -vv .github/release/
+      - name: Run Cloud Build Test Report Unit Tests
+        run: |
+          pytest -vv cloudbuild/test_summarize_test_results.py
       - name: Run all tests (Standard, Zonal & HNS Enabled) with default ON extended feature support
         run: |
           export GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/gcsfs/tests/fake-service-account-credentials.json

--- a/cloudbuild/e2e-tests-cloudbuild.yaml
+++ b/cloudbuild/e2e-tests-cloudbuild.yaml
@@ -186,6 +186,45 @@ steps:
     waitFor: ["setup-vm", "create-buckets"]
     allowFailure: true
 
+  # Test Report
+  # GitHub shows only the first ~65k chars of the build log, so the test steps write their full output to
+  # files on the VM. This step prints a size-capped summary (counts + failure tracebacks) first, then the
+  # full logs. It always exits 0 so that cleanup still runs.
+  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
+    id: "test-report"
+    entrypoint: "bash"
+    args:
+      - "-c"
+      - |
+        mkdir -p /workspace/test-results
+        if gcloud compute instances describe gcsfs-test-vm-${_SHORT_BUILD_ID} --zone=${_ZONE} &>/dev/null; then
+          gcloud compute scp --recurse gcsfs-test-vm-${_SHORT_BUILD_ID}:~/test-results /workspace/ \
+            --zone=${_ZONE} \
+            --internal-ip \
+            --ssh-key-file=/workspace/.ssh/google_compute_engine > /dev/null || echo "⚠️ Could not copy test results from the VM"
+        fi
+
+        python3 cloudbuild/summarize_test_results.py /workspace/test-results \
+          --suites standard zonal zonal-core hns \
+          --failed-steps /workspace/FAILED \
+          --max-chars 30000 || echo "⚠️ Could not summarize test results"
+
+        for suite in standard zonal zonal-core hns; do
+          if [[ -f /workspace/test-results/$${suite}.log ]]; then
+            echo "===== FULL LOG: $${suite} ====="
+            cat /workspace/test-results/$${suite}.log
+          fi
+        done
+        exit 0
+    waitFor:
+      [
+        "run-standard-tests",
+        "run-zonal-tests",
+        "run-hns-tests",
+        "run-zonal-core-tests",
+      ]
+    allowFailure: true
+
   # Cleanup
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
     id: "cleanup"
@@ -202,13 +241,7 @@ steps:
       - "WORKERS_HNS=${_WORKERS_HNS}"
       - "WORKERS_ZONAL=${_WORKERS_ZONAL}"
       - "WORKERS_ZONAL_CORE=${_WORKERS_ZONAL_CORE}"
-    waitFor:
-      [
-        "run-standard-tests",
-        "run-zonal-tests",
-        "run-hns-tests",
-        "run-zonal-core-tests",
-      ]
+    waitFor: ["test-report"]
 
   # Fail the build if any previous step failed
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"

--- a/cloudbuild/run_tests.sh
+++ b/cloudbuild/run_tests.sh
@@ -31,8 +31,42 @@ RESULTS_LOG="${RESULTS_DIR}/${TEST_SUITE}.log"
 mkdir -p "${RESULTS_DIR}"
 ARGS+=("--junitxml=${RESULTS_DIR}/${TEST_SUITE}.xml")
 
+# While pytest runs, print the tests still in progress every HEARTBEAT_SECS. A hung test is failed by
+# pytest-timeout and a killed pytest leaves its log tail for test-report, but if the whole build times out
+# (or the VM is lost) test-report never runs, so these lines keep a stuck test visible in the step log.
+HEARTBEAT_SECS="${HEARTBEAT_SECS:-300}"
+if ! [[ "${HEARTBEAT_SECS}" =~ ^[0-9]+$ ]] || (( HEARTBEAT_SECS <= 0 )); then
+  HEARTBEAT_SECS=300
+fi
+
+in_progress_tests() {
+  # With -vv, xdist logs "<nodeid>" when a test starts and "[gwN] <OUTCOME> <nodeid>" when it finishes.
+  awk '
+    { sub(/ <- .*/, ""); sub(/[ \t]+$/, "") }
+    /^\[gw[0-9]+\] [A-Z]+ / { sub(/^\[gw[0-9]+\] [A-Z]+ /, ""); delete running[$0]; next }
+    /^[^ ]+\.py::/ { running[$0] = 1 }
+    END { for (t in running) printf "%s%s", (n++ ? ", " : ""), t; if (!n) printf "none" }
+  ' "${RESULTS_LOG}" 2>/dev/null | cut -c1-500
+}
+
+heartbeat() {
+  local elapsed=0
+  # Sleep in 1s steps so stopping the heartbeat never leaves a long sleep holding the ssh session open.
+  while sleep 1; do
+    elapsed=$((elapsed + 1))
+    if (( elapsed % HEARTBEAT_SECS == 0 )); then
+      echo "--- ${TEST_SUITE}: still running after $((elapsed / 60))m; in progress: $(in_progress_tests) ---"
+    fi
+  done
+}
+
 run_pytest() {
-  pytest "$@" > "${RESULTS_LOG}" 2>&1
+  local status=0
+  heartbeat &
+  local heartbeat_pid=$!
+  pytest "$@" > "${RESULTS_LOG}" 2>&1 || status=$?
+  { kill "${heartbeat_pid}" && wait "${heartbeat_pid}"; } 2>/dev/null
+  return "${status}"
 }
 STATUS=0
 

--- a/cloudbuild/run_tests.sh
+++ b/cloudbuild/run_tests.sh
@@ -24,6 +24,18 @@ if ! [[ "${PYTEST_XDIST_WORKERS}" =~ ^[0-9]+$ ]] || (( PYTEST_XDIST_WORKERS <= 0
 fi
 ARGS+=(-n "${PYTEST_XDIST_WORKERS}")
 
+# Full pytest output goes to files instead of the build log. GitHub shows only the first ~65k chars
+# of the Cloud Build log, so the test-report step prints a summary from the JUnit XML before these logs.
+RESULTS_DIR="${HOME}/test-results"
+RESULTS_LOG="${RESULTS_DIR}/${TEST_SUITE}.log"
+mkdir -p "${RESULTS_DIR}"
+ARGS+=("--junitxml=${RESULTS_DIR}/${TEST_SUITE}.xml")
+
+run_pytest() {
+  pytest "$@" > "${RESULTS_LOG}" 2>&1
+}
+STATUS=0
+
 echo "--- Running Test Suite: ${TEST_SUITE} ---"
 
 case "$TEST_SUITE" in
@@ -31,7 +43,7 @@ case "$TEST_SUITE" in
     export GCSFS_TEST_BUCKET="gcsfs-test-standard-${SHORT_BUILD_ID}"
     export GCSFS_TEST_VERSIONED_BUCKET="gcsfs-test-versioned-${SHORT_BUILD_ID}"
     export GCSFS_TEST_REQ_PAYS_BUCKET="gcsfs-test-standard-req-pay-${SHORT_BUILD_ID}"
-    pytest "${ARGS[@]}" gcsfs/ --deselect gcsfs/tests/test_core.py::test_sign
+    run_pytest "${ARGS[@]}" gcsfs/ --deselect gcsfs/tests/test_core.py::test_sign || STATUS=$?
     ;;
 
   "zonal")
@@ -44,13 +56,13 @@ case "$TEST_SUITE" in
     export GCSFS_RUN_RAPID_TESTS="true"
     export GCSFS_EXPERIMENTAL_ZB_HNS_SUPPORT='true'
     # Excludes tests related to requster pays as Zonal buckets do not support requester pays feature
-    pytest "${ARGS[@]}" \
+    run_pytest "${ARGS[@]}" \
       gcsfs/tests/test_extended_gcsfs.py \
       gcsfs/tests/test_zonal_file.py \
       gcsfs/tests/integration/test_async_gcsfs.py \
       gcsfs/tests/integration/test_extended_hns.py \
       --deselect gcsfs/tests/integration/test_extended_hns.py::TestExtendedGcsFileSystemHnsRequesterPays::test_hns_mkdir_fails_without_quota_project \
-      --deselect gcsfs/tests/integration/test_extended_hns.py::TestExtendedGcsFileSystemHnsRequesterPays::test_hns_bucket_type_detection_with_req_pays
+      --deselect gcsfs/tests/integration/test_extended_hns.py::TestExtendedGcsFileSystemHnsRequesterPays::test_hns_bucket_type_detection_with_req_pays || STATUS=$?
     ;;
 
   "hns")
@@ -68,14 +80,14 @@ case "$TEST_SUITE" in
     # - test_core.py::test_sign: Current Cloud Build auth setup does not support this.
     # - test_core.py::test_mv_file_cache: Integration test only applicable for regional buckets.
     # - test_core.py::test_rm_wildcards_non_recursive: HNS buckets have different behavior for non-recursive wildcard deletion.
-    pytest "${ARGS[@]}" gcsfs/ \
+    run_pytest "${ARGS[@]}" gcsfs/ \
       --deselect gcsfs/tests/test_extended_gcsfs.py \
       --deselect gcsfs/tests/test_zonal_file.py \
       --deselect gcsfs/tests/test_extended_gcsfs_unit.py \
       --deselect gcsfs/tests/test_core_versioned.py \
       --deselect gcsfs/tests/test_core.py::test_sign \
       --deselect gcsfs/tests/test_core.py::test_mv_file_cache \
-      --deselect gcsfs/tests/test_core.py::test_rm_wildcards_non_recursive
+      --deselect gcsfs/tests/test_core.py::test_rm_wildcards_non_recursive || STATUS=$?
     ;;
 
   "zonal-core")
@@ -158,6 +170,11 @@ case "$TEST_SUITE" in
       "--deselect=gcsfs/tests/test_core.py::test_requester_pays_fails_without_user_project"
     )
 
-    pytest "${ARGS[@]}" "${ZONAL_DESELECTS[@]}" gcsfs/tests/test_core.py
+    run_pytest "${ARGS[@]}" "${ZONAL_DESELECTS[@]}" gcsfs/tests/test_core.py || STATUS=$?
     ;;
 esac
+
+# Pytest's final "=== N passed, M skipped in Xs ===" line, so the step log still shows the counts.
+RESULT_LINE=$(grep -E '^=+ .* in [0-9.]+s' "${RESULTS_LOG}" 2>/dev/null | tail -n 1 | sed -E 's/^=+ | =+$//g')
+echo "--- ${TEST_SUITE}: pytest exit ${STATUS} ${RESULT_LINE} ---"
+exit "${STATUS}"

--- a/cloudbuild/summarize_test_results.py
+++ b/cloudbuild/summarize_test_results.py
@@ -9,6 +9,7 @@ failure list) and the output never exceeds --max-chars.
 import argparse
 import os
 import xml.etree.ElementTree as ET
+from collections import deque
 
 TRACEBACK_LINES = 40
 LOG_TAIL_LINES = 60
@@ -85,9 +86,11 @@ def build_summary(results_dir, suites, failed_steps=None, max_chars=30000):
             )
             head.append(f"{suite:<12}  {reason}")
             if os.path.isfile(log_path):
+                # Keep only the last lines in memory; a crashed suite's log can be large.
                 with open(log_path, errors="replace") as f:
-                    body = f"Last {LOG_TAIL_LINES} lines of {suite}.log:\n"
-                    body += _tail(f.read(), LOG_TAIL_LINES)
+                    log_tail = "".join(deque(f, maxlen=LOG_TAIL_LINES))
+                body = f"Last {LOG_TAIL_LINES} lines of {suite}.log:\n"
+                body += _tail(log_tail, LOG_TAIL_LINES)
             else:
                 body = "The suite did not run; see its step log above."
             problems.append(

--- a/cloudbuild/summarize_test_results.py
+++ b/cloudbuild/summarize_test_results.py
@@ -1,0 +1,152 @@
+"""Print a size-capped summary of the e2e test suites' JUnit XML results.
+
+GitHub shows only the first ~65k chars of a Cloud Build log, so the test-report step in
+e2e-tests-cloudbuild.yaml prints this summary before the full pytest logs. Sections are
+added in priority order (failed steps, per-suite counts, failure details, one-line
+failure list) and the output never exceeds --max-chars.
+"""
+
+import argparse
+import os
+import xml.etree.ElementTree as ET
+
+TRACEBACK_LINES = 40
+LOG_TAIL_LINES = 60
+MESSAGE_CHARS = 500
+DETAIL_CHARS = 4000
+ONE_LINE_CHARS = 300
+# Room for the "not shown in detail" header and the "... and N more" note.
+NOTE_RESERVE = 150
+FOOTER = "===== END OF E2E TEST SUMMARY (full logs follow) ====="
+
+
+def _tail(text, lines, chars=DETAIL_CHARS):
+    tail = "\n".join((text or "").rstrip().splitlines()[-lines:])
+    return tail[-chars:]
+
+
+def parse_junit(path):
+    """Return ({outcome: count}, seconds, [(outcome, nodeid, message, traceback)])."""
+    root = ET.parse(path).getroot()
+    suites = [root] if root.tag == "testsuite" else root.findall("testsuite")
+    counts = {"passed": 0, "failed": 0, "error": 0, "skipped": 0}
+    seconds = 0.0
+    problems = []
+    for suite in suites:
+        seconds += float(suite.get("time") or 0)
+        for case in suite.iter("testcase"):
+            nodeid = "::".join(
+                part for part in (case.get("classname"), case.get("name")) if part
+            )
+            tags = {child.tag for child in case}
+            # pytest reports xfailed tests as <skipped>, so they are counted as skipped.
+            if "failure" in tags:
+                counts["failed"] += 1
+            elif "error" in tags:
+                counts["error"] += 1
+            elif "skipped" in tags:
+                counts["skipped"] += 1
+            else:
+                counts["passed"] += 1
+            for child in case:
+                if child.tag not in ("failure", "error"):
+                    continue
+                outcome = "FAILED" if child.tag == "failure" else "ERROR"
+                message = (child.get("message") or "").strip().split("\n")[0]
+                traceback = _tail(child.text, TRACEBACK_LINES)
+                problems.append((outcome, nodeid, message[:MESSAGE_CHARS], traceback))
+    return counts, seconds, problems
+
+
+def build_summary(results_dir, suites, failed_steps=None, max_chars=30000):
+    head = ["===== E2E TEST SUMMARY ====="]
+    if failed_steps and os.path.isfile(failed_steps):
+        with open(failed_steps) as f:
+            steps = [line.strip() for line in f if line.strip()]
+        if steps:
+            head.append("Failed build steps: " + ", ".join(steps))
+    head.append("")
+    head.append(
+        f"{'suite':<12}{'passed':>8}{'failed':>8}{'error':>8}{'skipped':>9}{'time':>10}"
+    )
+
+    # (full detail, one-line fallback) for each problem, in suite order.
+    problems = []
+    for suite in suites:
+        xml_path = os.path.join(results_dir, f"{suite}.xml")
+        log_path = os.path.join(results_dir, f"{suite}.log")
+        try:
+            counts, seconds, suite_problems = parse_junit(xml_path)
+        except (OSError, ET.ParseError) as e:
+            reason = (
+                "no JUnit results"
+                if isinstance(e, OSError)
+                else "unreadable JUnit results"
+            )
+            head.append(f"{suite:<12}  {reason}")
+            if os.path.isfile(log_path):
+                with open(log_path, errors="replace") as f:
+                    body = f"Last {LOG_TAIL_LINES} lines of {suite}.log:\n"
+                    body += _tail(f.read(), LOG_TAIL_LINES)
+            else:
+                body = "The suite did not run; see its step log above."
+            problems.append(
+                (f"--- {suite}: {reason} ---\n{body}", f"{suite}: {reason}")
+            )
+            continue
+
+        head.append(
+            f"{suite:<12}{counts['passed']:>8}{counts['failed']:>8}"
+            f"{counts['error']:>8}{counts['skipped']:>9}{seconds:>9.0f}s"
+        )
+        for outcome, nodeid, message, traceback in suite_problems:
+            detail = f"--- {suite}: {outcome} {nodeid} ---\n{message}\n{traceback}"
+            problems.append((detail, f"{suite}: {outcome} {nodeid}"[:ONE_LINE_CHARS]))
+
+    if not problems:
+        head.append("")
+        head.append("No failures or errors.")
+
+    parts = ["\n".join(head)]
+    used = len(parts[0]) + len(FOOTER) + NOTE_RESERVE
+    listed_only = []
+    for detail, one_line in problems:
+        if not listed_only and used + len(detail) + 2 <= max_chars:
+            parts.append(detail)
+            used += len(detail) + 2
+        else:
+            listed_only.append(one_line)
+
+    if listed_only:
+        lines = ["Not shown in detail (see the full logs below):"]
+        omitted = 0
+        for one_line in listed_only:
+            if used + len(one_line) + 1 <= max_chars:
+                lines.append(one_line)
+                used += len(one_line) + 1
+            else:
+                omitted += 1
+        if omitted:
+            lines.append(f"... and {omitted} more")
+        parts.append("\n".join(lines))
+
+    parts.append(FOOTER)
+    return "\n\n".join(parts)[:max_chars]
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "results_dir", help="Directory with <suite>.xml and <suite>.log"
+    )
+    parser.add_argument("--suites", nargs="+", required=True)
+    parser.add_argument("--failed-steps", help="File listing failed build steps")
+    parser.add_argument("--max-chars", type=int, default=30000)
+    args = parser.parse_args(argv)
+    print(
+        build_summary(args.results_dir, args.suites, args.failed_steps, args.max_chars)
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/cloudbuild/summarize_test_results.py
+++ b/cloudbuild/summarize_test_results.py
@@ -71,7 +71,7 @@ def build_summary(results_dir, suites, failed_steps=None, max_chars=30000):
         f"{'suite':<12}{'passed':>8}{'failed':>8}{'error':>8}{'skipped':>9}{'time':>10}"
     )
 
-    # (full detail, one-line fallback) for each problem, in suite order.
+    # (suite, full detail, one-line fallback) for each problem, in suite order.
     problems = []
     for suite in suites:
         xml_path = os.path.join(results_dir, f"{suite}.xml")
@@ -94,7 +94,7 @@ def build_summary(results_dir, suites, failed_steps=None, max_chars=30000):
             else:
                 body = "The suite did not run; see its step log above."
             problems.append(
-                (f"--- {suite}: {reason} ---\n{body}", f"{suite}: {reason}")
+                (suite, f"--- {suite}: {reason} ---\n{body}", f"{suite}: {reason}")
             )
             continue
 
@@ -104,31 +104,51 @@ def build_summary(results_dir, suites, failed_steps=None, max_chars=30000):
         )
         for outcome, nodeid, message, traceback in suite_problems:
             detail = f"--- {suite}: {outcome} {nodeid} ---\n{message}\n{traceback}"
-            problems.append((detail, f"{suite}: {outcome} {nodeid}"[:ONE_LINE_CHARS]))
+            one_line = f"{suite}: {outcome} {nodeid}"[:ONE_LINE_CHARS]
+            problems.append((suite, detail, one_line))
 
     if not problems:
         head.append("")
         head.append("No failures or errors.")
 
+    # Fill the budget round-robin across suites (each suite's 1st problem, then each 2nd, ...) so a
+    # suite with hundreds of failures cannot crowd out the other suites' failures.
+    next_rank = {}
+    ranked = []
+    for i, (suite, _, _) in enumerate(problems):
+        ranked.append((next_rank.get(suite, 0), i))
+        next_rank[suite] = next_rank.get(suite, 0) + 1
+    order = [i for _, i in sorted(ranked)]
+
     parts = ["\n".join(head)]
     used = len(parts[0]) + len(FOOTER) + NOTE_RESERVE
-    listed_only = []
-    for detail, one_line in problems:
-        if not listed_only and used + len(detail) + 2 <= max_chars:
-            parts.append(detail)
+    detailed = set()
+    suites_out_of_room = set()
+    for i in order:
+        suite, detail, _ = problems[i]
+        if suite not in suites_out_of_room and used + len(detail) + 2 <= max_chars:
+            detailed.add(i)
             used += len(detail) + 2
         else:
-            listed_only.append(one_line)
+            suites_out_of_room.add(suite)
 
-    if listed_only:
+    listed = set()
+    omitted = 0
+    for i in order:
+        if i in detailed:
+            continue
+        one_line = problems[i][2]
+        if used + len(one_line) + 1 <= max_chars:
+            listed.add(i)
+            used += len(one_line) + 1
+        else:
+            omitted += 1
+
+    # Render in suite order.
+    parts.extend(problems[i][1] for i in sorted(detailed))
+    if listed or omitted:
         lines = ["Not shown in detail (see the full logs below):"]
-        omitted = 0
-        for one_line in listed_only:
-            if used + len(one_line) + 1 <= max_chars:
-                lines.append(one_line)
-                used += len(one_line) + 1
-            else:
-                omitted += 1
+        lines.extend(problems[i][2] for i in sorted(listed))
         if omitted:
             lines.append(f"... and {omitted} more")
         parts.append("\n".join(lines))

--- a/cloudbuild/test_summarize_test_results.py
+++ b/cloudbuild/test_summarize_test_results.py
@@ -148,7 +148,7 @@ def test_missing_xml_prints_log_tail(tmp_path):
     assert re.search(r"^zonal\s+no JUnit results$", out, re.M)
     assert "--- zonal: no JUnit results ---" in out
     assert "line-099" in out
-    assert "line-040" in out
+    assert "Last 60 lines of zonal.log:\nline-040\n" in out
     assert "line-039" not in out
 
 

--- a/cloudbuild/test_summarize_test_results.py
+++ b/cloudbuild/test_summarize_test_results.py
@@ -198,9 +198,54 @@ def test_output_never_exceeds_budget_and_keeps_counts(tmp_path):
     assert row(out, "standard") == (0, 300, 0, 0)
     assert row(out, "hns") == (0, 300, 0, 0)
     assert "--- standard: FAILED gcsfs.tests.test_standard::test_0 ---" in out
+    assert "--- hns: FAILED gcsfs.tests.test_hns::test_0 ---" in out
     assert "Not shown in detail (see the full logs below):" in out
+    assert "\nstandard: FAILED gcsfs.tests.test_standard::test_299\n" not in out
+    assert "\nhns: FAILED gcsfs.tests.test_hns::test_5\n" in out
     assert re.search(r"^\.\.\. and \d+ more$", out, re.M)
     assert out.endswith(summarize_test_results.FOOTER)
+
+
+def test_every_suite_shows_a_detail_when_an_earlier_suite_has_many_failures(tmp_path):
+    traceback = "\n".join("E   " + "x" * 200 for _ in range(60))
+    write_junit(
+        tmp_path / "standard.xml",
+        [
+            ("gcsfs.tests.test_core", f"test_{i}", "failed", "boom", traceback)
+            for i in range(300)
+        ],
+    )
+    write_junit(
+        tmp_path / "zonal.xml",
+        [
+            (
+                "gcsfs.tests.test_zonal_file",
+                "test_z",
+                "failed",
+                "zonal boom",
+                "E   zonal boom",
+            )
+        ],
+    )
+    (tmp_path / "hns.log").write_text("collection crashed\n")
+
+    out = summarize_test_results.build_summary(
+        str(tmp_path), ["standard", "zonal", "zonal-core", "hns"]
+    )
+
+    assert len(out) <= 30000
+    standard = out.index("--- standard: FAILED gcsfs.tests.test_core::test_0 ---")
+    zonal = out.index(
+        "--- zonal: FAILED gcsfs.tests.test_zonal_file::test_z ---\nzonal boom\nE   zonal boom"
+    )
+    zonal_core = out.index(
+        "--- zonal-core: no JUnit results ---\nThe suite did not run"
+    )
+    hns = out.index(
+        "--- hns: no JUnit results ---\nLast 60 lines of hns.log:\ncollection crashed"
+    )
+    # Details are still rendered in suite order.
+    assert standard < zonal < zonal_core < hns
 
 
 def test_tiny_budget_is_still_capped(tmp_path):

--- a/cloudbuild/test_summarize_test_results.py
+++ b/cloudbuild/test_summarize_test_results.py
@@ -1,0 +1,229 @@
+import os
+import re
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+
+# Add the directory containing summarize_test_results.py to the path
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
+import summarize_test_results
+
+TAGS = {"failed": "failure", "error": "error", "skipped": "skipped"}
+
+
+def write_junit(path, cases, time=12.0):
+    """Write a pytest-style JUnit XML file from (classname, name, outcome, message, text)."""
+    root = ET.Element("testsuites", name="pytest tests")
+    suite = ET.SubElement(root, "testsuite", name="pytest", time=str(time))
+    for classname, name, outcome, message, text in cases:
+        case = ET.SubElement(suite, "testcase", classname=classname, name=name)
+        if outcome != "passed":
+            child = ET.SubElement(case, TAGS[outcome], message=message)
+            child.text = text
+    ET.ElementTree(root).write(path)
+
+
+def row(out, suite):
+    match = re.search(
+        rf"^{re.escape(suite)}\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s", out, re.M
+    )
+    assert match, out
+    return tuple(int(n) for n in match.groups())
+
+
+def test_all_pass_counts(tmp_path):
+    write_junit(
+        tmp_path / "standard.xml",
+        [
+            ("gcsfs.tests.test_core", "test_a", "passed", "", ""),
+            ("gcsfs.tests.test_core", "test_b", "passed", "", ""),
+            ("gcsfs.tests.test_core", "test_c", "passed", "", ""),
+            ("gcsfs.tests.test_core", "test_d", "skipped", "not on zonal", ""),
+        ],
+    )
+
+    out = summarize_test_results.build_summary(str(tmp_path), ["standard"])
+
+    assert row(out, "standard") == (3, 0, 0, 1)
+    assert "No failures or errors." in out
+
+
+def test_failures_and_errors_show_message_and_traceback_tail(tmp_path):
+    traceback = (
+        "\n".join(f"tb-{i:03d}" for i in range(100)) + "\nE   AssertionError: boom"
+    )
+    write_junit(
+        tmp_path / "zonal-core.xml",
+        [
+            ("gcsfs.tests.test_core", "test_ok", "passed", "", ""),
+            (
+                "gcsfs.tests.test_core",
+                "test_bad",
+                "failed",
+                "AssertionError: boom\nmore",
+                traceback,
+            ),
+            (
+                "gcsfs.tests.test_core",
+                "test_setup",
+                "error",
+                "failed on setup",
+                "RuntimeError: x",
+            ),
+        ],
+    )
+
+    out = summarize_test_results.build_summary(str(tmp_path), ["zonal-core"])
+
+    assert row(out, "zonal-core") == (1, 1, 1, 0)
+    assert (
+        "--- zonal-core: FAILED gcsfs.tests.test_core::test_bad ---\nAssertionError: boom\n"
+        in out
+    )
+    assert "E   AssertionError: boom" in out
+    assert "tb-099" in out
+    assert "tb-060" not in out
+    assert "--- zonal-core: ERROR gcsfs.tests.test_core::test_setup ---" in out
+    assert "RuntimeError: x" in out
+    assert "No failures or errors." not in out
+
+
+def test_real_pytest_junit_output(tmp_path):
+    (tmp_path / "pytest.ini").write_text("[pytest]\n")
+    (tmp_path / "test_sample.py").write_text(
+        "import pytest\n"
+        "\n"
+        "@pytest.fixture\n"
+        "def broken():\n"
+        "    raise RuntimeError('fixture exploded')\n"
+        "\n"
+        "def test_pass():\n"
+        "    pass\n"
+        "\n"
+        "def test_fail():\n"
+        "    assert 1 == 2, 'numbers differ'\n"
+        "\n"
+        "def test_error(broken):\n"
+        "    pass\n"
+        "\n"
+        "@pytest.mark.skip(reason='unsupported')\n"
+        "def test_skip():\n"
+        "    pass\n"
+    )
+    results = tmp_path / "results"
+    results.mkdir()
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-p",
+            "no:cacheprovider",
+            "-c",
+            str(tmp_path / "pytest.ini"),
+            "--rootdir",
+            str(tmp_path),
+            f"--junitxml={results / 'hns.xml'}",
+            str(tmp_path / "test_sample.py"),
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+    )
+
+    out = summarize_test_results.build_summary(str(results), ["hns"])
+
+    assert row(out, "hns") == (1, 1, 1, 1)
+    assert "--- hns: FAILED test_sample::test_fail ---" in out
+    assert "AssertionError: numbers differ" in out
+    assert "--- hns: ERROR test_sample::test_error ---" in out
+    assert "RuntimeError: fixture exploded" in out
+
+
+def test_missing_xml_prints_log_tail(tmp_path):
+    log = "\n".join(f"line-{i:03d}" for i in range(100))
+    (tmp_path / "zonal.log").write_text(log)
+
+    out = summarize_test_results.build_summary(str(tmp_path), ["zonal"])
+
+    assert re.search(r"^zonal\s+no JUnit results$", out, re.M)
+    assert "--- zonal: no JUnit results ---" in out
+    assert "line-099" in out
+    assert "line-040" in out
+    assert "line-039" not in out
+
+
+def test_missing_suite_without_log(tmp_path):
+    out = summarize_test_results.build_summary(str(tmp_path / "absent"), ["hns"])
+
+    assert (
+        "--- hns: no JUnit results ---\nThe suite did not run; see its step log above."
+        in out
+    )
+
+
+def test_unparseable_xml(tmp_path):
+    (tmp_path / "standard.xml").write_text("<testsuites><testsuite")
+
+    out = summarize_test_results.build_summary(str(tmp_path), ["standard"])
+
+    assert "--- standard: unreadable JUnit results ---" in out
+
+
+def test_failed_steps_listed(tmp_path):
+    write_junit(tmp_path / "standard.xml", [("m", "test_a", "passed", "", "")])
+    failed = tmp_path / "FAILED"
+    failed.write_text("run-zonal-core-tests\nrun-hns-tests\n")
+
+    out = summarize_test_results.build_summary(str(tmp_path), ["standard"], str(failed))
+
+    assert "Failed build steps: run-zonal-core-tests, run-hns-tests" in out
+
+
+def test_output_never_exceeds_budget_and_keeps_counts(tmp_path):
+    traceback = "\n".join("E   " + "x" * 200 for _ in range(60))
+    for suite in ("standard", "hns"):
+        write_junit(
+            tmp_path / f"{suite}.xml",
+            [
+                (f"gcsfs.tests.test_{suite}", f"test_{i}", "failed", "boom", traceback)
+                for i in range(300)
+            ],
+        )
+
+    out = summarize_test_results.build_summary(
+        str(tmp_path), ["standard", "hns"], max_chars=20000
+    )
+
+    assert len(out) <= 20000
+    assert row(out, "standard") == (0, 300, 0, 0)
+    assert row(out, "hns") == (0, 300, 0, 0)
+    assert "--- standard: FAILED gcsfs.tests.test_standard::test_0 ---" in out
+    assert "Not shown in detail (see the full logs below):" in out
+    assert re.search(r"^\.\.\. and \d+ more$", out, re.M)
+    assert out.endswith(summarize_test_results.FOOTER)
+
+
+def test_tiny_budget_is_still_capped(tmp_path):
+    write_junit(
+        tmp_path / "standard.xml", [("m", "test_a", "failed", "boom", "E   boom")]
+    )
+
+    out = summarize_test_results.build_summary(
+        str(tmp_path), ["standard"], max_chars=40
+    )
+
+    assert len(out) == 40
+    assert out.startswith("===== E2E TEST SUMMARY =====")
+
+
+def test_main_cli(tmp_path, capsys):
+    write_junit(tmp_path / "zonal.xml", [("m", "test_a", "failed", "boom", "E   boom")])
+
+    summarize_test_results.main(
+        [str(tmp_path), "--suites", "zonal", "standard", "--max-chars", "5000"]
+    )
+
+    out = capsys.readouterr().out
+    assert row(out, "zonal") == (0, 1, 0, 0)
+    assert "--- zonal: FAILED m::test_a ---" in out
+    assert "--- standard: no JUnit results ---" in out

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -3852,22 +3852,3 @@ def test_get_dirs_and_update_cache_with_directories_and_prefix(gcs):
     assert f"{bucket}/a/b/c" in dirs
     # Cache should remain empty because update_cache=False and prefix is used
     assert len(gcs.dircache) == 0
-
-
-# TEMPORARY (PR #1056): intentionally fail/error on the Cloud Build e2e run to validate the
-# test-report failure summary. Remove before merging.
-@requires_real_gcs
-def test_tmp_validate_e2e_report_failure(gcs):
-    assert not gcs.exists(
-        TEST_BUCKET
-    ), "intentional failure to validate the e2e test report"
-
-
-@pytest.fixture
-def tmp_broken_fixture():
-    raise RuntimeError("intentional fixture error to validate the e2e test report")
-
-
-@requires_real_gcs
-def test_tmp_validate_e2e_report_error(tmp_broken_fixture):
-    pass

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -3852,3 +3852,22 @@ def test_get_dirs_and_update_cache_with_directories_and_prefix(gcs):
     assert f"{bucket}/a/b/c" in dirs
     # Cache should remain empty because update_cache=False and prefix is used
     assert len(gcs.dircache) == 0
+
+
+# TEMPORARY (PR #1056): intentionally fail/error on the Cloud Build e2e run to validate the
+# test-report failure summary. Remove before merging.
+@requires_real_gcs
+def test_tmp_validate_e2e_report_failure(gcs):
+    assert not gcs.exists(
+        TEST_BUCKET
+    ), "intentional failure to validate the e2e test report"
+
+
+@pytest.fixture
+def tmp_broken_fixture():
+    raise RuntimeError("intentional fixture error to validate the e2e test report")
+
+
+@requires_real_gcs
+def test_tmp_validate_e2e_report_error(tmp_broken_fixture):
+    pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,5 +78,5 @@ markers = [
 
 [tool.isort]
 profile = "black"
-known_first_party = ["prepare_release"]
+known_first_party = ["prepare_release", "summarize_test_results"]
 known_third_party = ["aiohttp", "click", "datasets", "decorator", "fsspec", "fuse", "google", "google_auth_oauthlib", "lightning", "metric_logging", "metrics", "numpy", "prettytable", "psutil", "pyarrow", "pytest", "pytest_asyncio", "ray", "requests", "torch", "torchdata", "transformers", "yaml"]


### PR DESCRIPTION
**Problem**
The e2e Cloud Build check shows only the **first ~65k characters** of the build log on GitHub. With four test suites streaming `pytest -vv -s` output in parallel, the log reaches that limit partway through the test run. The failure tracebacks, pytest's passed/failed/skipped counts and the `check-failure` step never show up.

External PR #1049's [cat file failure](https://github.com/fsspec/gcsfs/pull/1049/checks?check_run_id=102369502178) is an example. The check text was cut off , while the tests were still printing `PASSED` lines. The steps table shows *which* step failed but not *why*. The "Build Log" link needs GCP project access, so external PR authors can't use it.

**Solution**
Keep the test steps nearly silent, and print a size-capped summary as soon as the tests finish, before any verbose output.  The summary is capped at 30,000 characters. Failures beyond that are listed by test id only. The full logs are printed **after** the summary, so they're still in Cloud Logging. The step always exits 0, so `cleanup` still runs.