### PR TITLE
fix(macrobenchmarks): force reinstall requirement overrides with --no-deps in Ray workload

### DIFF
--- a/gcsfs/tests/perf/macrobenchmarks/workloads/ray-data-ray-train-pytorch/helm_chart/launcher.sh
+++ b/gcsfs/tests/perf/macrobenchmarks/workloads/ray-data-ray-train-pytorch/helm_chart/launcher.sh
@@ -216,7 +216,11 @@ if [[ -n "${REQUIREMENTS:-}" ]]; then
   # the one thing that must never be served from a previous pod's download, so a
   # re-pushed artifact at an unchanged URL can never go stale here.
   # shellcheck disable=SC2086
-  pip3 install --no-cache-dir --force-reinstall $REQUIREMENTS
+  pip3 install --no-cache-dir $REQUIREMENTS
+  # Reinstall only the requested packages so their dependency graph is not
+  # unnecessarily reinstalled after the normal resolution pass above.
+  # shellcheck disable=SC2086
+  pip3 install --no-cache-dir --no-deps --force-reinstall $REQUIREMENTS
 fi
 
 python3 - <<'PY'


### PR DESCRIPTION
### Description
In `gcsfs/tests/perf/macrobenchmarks/workloads/ray-data-ray-train-pytorch/helm_chart/launcher.sh`, requirement overrides were installed with `pip3 install --no-cache-dir --force-reinstall $REQUIREMENTS`.

Because `--no-deps` was omitted, pip attempted to force-reinstall all transitive dependencies of the overrides (e.g., `PyYAML` from `pytorch-lightning`). In the base container image `nvcr.io/nvidia/pytorch:26.05-py3`, `PyYAML 6.0.1` is pre-installed as a Debian-managed package in `/usr/lib/python3/dist-packages` without a `RECORD` file, causing pip to fail with `error: uninstall-no-record-file` (`Cannot uninstall PyYAML 6.0.1`).

### Solution
Follow the same two-stage installation pattern used in `hf-pytorch-lightning-cpu/helm_chart/launcher.sh`:
1. `pip3 install --no-cache-dir $REQUIREMENTS` (resolve dependencies normally).
2. `pip3 install --no-cache-dir --no-deps --force-reinstall $REQUIREMENTS` (reinstall only the target override packages).

### Testing
- `pytest gcsfs/tests/perf/macrobenchmarks/workloads/ray-data-ray-train-pytorch/tests/test_metric_logging.py` passed.
- `helm lint gcsfs/tests/perf/macrobenchmarks/workloads/ray-data-ray-train-pytorch/helm_chart -f gcsfs/tests/perf/macrobenchmarks/workloads/ray-data-ray-train-pytorch/helm_chart/values_base.yaml` passed.