### PR TITLE
perf(subsystembenchmarks): update Hugging Face read benchmark baseline file_count to 256

### DIFF
--- a/gcsfs/tests/perf/subsystembenchmarks/dataloading/huggingface_datasets/configs.yaml
+++ b/gcsfs/tests/perf/subsystembenchmarks/dataloading/huggingface_datasets/configs.yaml
@@ -4,7 +4,7 @@ common:
   batch_size: 8
   baseline:
     fmt: "text_parquet"
-    file_count: 64
+    file_count: 256
     rows_per_file: 10920
     # Keeps uncompressed pretokenized Parquet row groups below about 30 MB.
     row_group_size: 1800
@@ -32,6 +32,6 @@ scenarios:
 
       - {axis: "climbmix", fmt: "pretok_jsonl", file_count: 100, rows_per_file: 6988}
 
-      - {axis: "scale", file_count: 512, rows_per_file: 1365}
+      - {axis: "scale", file_count: 2048, rows_per_file: 1365}
 
       - {axis: "prefetch", prefetch_factor: 4}

--- a/gcsfs/tests/perf/subsystembenchmarks/dataloading/huggingface_datasets/tests/test_configs.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/dataloading/huggingface_datasets/tests/test_configs.py
@@ -55,10 +55,10 @@ def test_case_ids_unique_and_named():
 def test_macrobenchmark_baseline_present():
     baseline = next(c for c in _cases() if c.sweep_axis == "baseline")
     assert baseline.name == (
-        "read-hf-txpq-shuf-nw4-rg1800-fc64x10920-" "splitws8div-mbis10-reg"
+        "read-hf-txpq-shuf-nw4-rg1800-fc256x10920-" "splitws8div-mbis10-reg"
     )
     assert baseline.fmt == "text_parquet"
-    assert baseline.file_count == 64
+    assert baseline.file_count == 256
     assert baseline.rows_per_file == 10920
     assert baseline.row_group_size == 1800
     assert baseline.access == "shuffled"
@@ -101,7 +101,7 @@ def test_scale_axis_present():
     """Verify scale axis sweeps shard count holding total rows fixed."""
     cases = _cases()
     scale = [c for c in cases if c.sweep_axis == "scale"]
-    assert {c.file_count for c in scale} == {512}
+    assert {c.file_count for c in scale} == {2048}
     base = next(c for c in cases if c.sweep_axis == "baseline")
     base_rows = base.file_count * base.rows_per_file
     for c in scale:


### PR DESCRIPTION
### Description
Updates the Hugging Face streaming read subsystem benchmark configurations:
* Increases default baseline `file_count` from 64 to 256 files (256 x 10,920 rows, ~5.8 GiB total across pretokenized Parquet shards).
* Updates the `scale` sweep variant to 2048 files (2048 x 1365 rows), preserving total rows at 2,795,520 while evaluating high shard count behavior.

### Motivation
When using 64 files, the number of DataLoader workers is reduced to 1 by the framework due to its internal sharding and shuffling logic. Bumping baseline `file_count` to 256 ensures there are sufficient shards across distributed nodes and workers, preventing worker concurrency from collapsing to 1. Setting the `scale` axis to 2048 files provides an 8x shard scaling sweep while holding total row volume constant.

### Key Changes
* `gcsfs/tests/perf/subsystembenchmarks/dataloading/huggingface_datasets/configs.yaml`:
  * Updated `common.baseline.file_count` from 64 to 256.
  * Updated `scenarios[0].variants[scale].file_count` from 512 to 2048.
* `gcsfs/tests/perf/subsystembenchmarks/dataloading/huggingface_datasets/tests/test_configs.py`:
  * Updated `test_macrobenchmark_baseline_present` to assert `file_count == 256` and baseline case name `...-fc256x10920-...`.
  * Updated `test_scale_axis_present` to assert `file_count == 2048` while holding total rows fixed.

### Validation
* Unit tests passed: `pytest gcsfs/tests/perf/subsystembenchmarks/dataloading/huggingface_datasets/tests/test_configs.py`
* Pre-commit hooks passed: `black`, `flake8`, `isort`, `trailing-whitespace`, `end-of-file-fixer`